### PR TITLE
계산기 [STEP 1] Jiss, Ehd, Joey

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		D3F4E2562682C5F100CC58C8 /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F4E2552682C5F100CC58C8 /* Calculator.swift */; };
 		D4FE3E932682C43A00040B43 /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FE3E922682C43A00040B43 /* Stack.swift */; };
 /* End PBXBuildFile section */
 
@@ -25,6 +26,7 @@
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D3F4E2552682C5F100CC58C8 /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		D4FE3E922682C43A00040B43 /* Stack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -62,6 +64,7 @@
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
 				C713D9452570E5EB001C3AFC /* ViewController.swift */,
 				D4FE3E922682C43A00040B43 /* Stack.swift */,
+				D3F4E2552682C5F100CC58C8 /* Calculator.swift */,
 				C713D9472570E5EB001C3AFC /* Main.storyboard */,
 				C713D94A2570E5ED001C3AFC /* Assets.xcassets */,
 				C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */,
@@ -143,6 +146,7 @@
 				D4FE3E932682C43A00040B43 /* Stack.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				D3F4E2562682C5F100CC58C8 /* Calculator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		D4FE3E932682C43A00040B43 /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FE3E922682C43A00040B43 /* Stack.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +25,7 @@
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D4FE3E922682C43A00040B43 /* Stack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
 				C713D9452570E5EB001C3AFC /* ViewController.swift */,
+				D4FE3E922682C43A00040B43 /* Stack.swift */,
 				C713D9472570E5EB001C3AFC /* Main.storyboard */,
 				C713D94A2570E5ED001C3AFC /* Assets.xcassets */,
 				C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */,
@@ -137,6 +140,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D4FE3E932682C43A00040B43 /* Stack.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -84,6 +84,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="random:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7bz-35-FdO"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -84,9 +84,6 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
-                                                <connections>
-                                                    <action selector="random:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7bz-35-FdO"/>
-                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -37,9 +37,8 @@ enum Operator {
 
 struct Calculator {
     func calculate(infix: [String]) throws -> String {
-        let postfix: [String] = try changeToPostfix(infix: infix)
+        let postfix: [String] = try changeToPostfixNotation(infix: infix)
         let operationResult = try calculatePostfix(postfix: postfix)
-        print(operationResult)
         let finalResult: String = ""
         return finalResult
     }
@@ -47,12 +46,10 @@ struct Calculator {
     private func calculatePostfix(postfix: [String]) throws -> String {
         var temporaryNumberStack = Stack<String>()
         for element in postfix {
-            if let _ = Double(element) {
+            if Double(element) != nil {
                 temporaryNumberStack.push(element)
             } else {
-                try calculateToValue(operator: element,
-                                     tempNumberStack: &temporaryNumberStack
-                )
+                try calculateToValue(operator: element, tempNumberStack: &temporaryNumberStack)
             }
         }
         guard let result = temporaryNumberStack.pop() else {
@@ -61,9 +58,7 @@ struct Calculator {
         return result
     }
     
-    private func calculateToValue(operator: String,
-                          tempNumberStack: inout Stack<String>
-    ) throws {
+    private func calculateToValue(operator: String, tempNumberStack: inout Stack<String>) throws {
         guard let firstOperand = tempNumberStack.pop(),
               let secondOperand = tempNumberStack.pop()
         else {
@@ -106,11 +101,11 @@ struct Calculator {
         }
     }
 
-    private func changeToPostfix(infix: [String]) throws -> [String] {
+    private func changeToPostfixNotation(infix: [String]) throws -> [String] {
         var temporarySignStack = Stack<String>()
         var postfix: [String] = []
         for element in infix {
-            if let _ = Double(element) {
+            if Double(element) != nil {
                 postfix.append(element)
             } else {
                 try popAndAppend(sign: element, from: &temporarySignStack, to: &postfix)
@@ -127,23 +122,20 @@ struct Calculator {
         return currentOperator > thanOperator
     }
     
-    private func popAndAppend(
-        sign: String, from temporarySignStack: inout Stack<String>,
-        to postfix: inout [String]
-    ) throws {
+    private func popAndAppend(sign: String,
+                              from temporarySignStack: inout Stack<String>,
+                              to postfix: inout [String]) throws {
         while let topOfTemporarySignStack = temporarySignStack.top,
-              try !hasHigherPriority(this: sign, than: topOfTemporarySignStack) {
+              try hasHigherPriority(this: sign, than: topOfTemporarySignStack) == false {
             if let poppedSign = temporarySignStack.pop() {
                 postfix.append(poppedSign)
             }
         }
     }
 
-    private func popAndAppendLeftovers(
-        from temporarySignStack: inout Stack<String>,
-        to postfix: inout [String]
-    ) throws{
-        while let _ = temporarySignStack.top {
+    private func popAndAppendLeftovers(from temporarySignStack: inout Stack<String>,
+                                       to postfix: inout [String]) throws{
+        while temporarySignStack.isEmpty == false {
             if let poppedSign = temporarySignStack.pop() {
                 postfix.append(poppedSign)
             }

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -1,0 +1,43 @@
+//
+//  Calculator.swift
+//  Calculator
+//
+//  Created by 신동훈 on 2021/06/23.
+//
+
+import Foundation
+
+class Calculator {
+    func calculate(infix: [String]) -> String {
+        var result: String = ""
+        let postfix: [String] = changeToPostfix(infix: infix)
+        return result
+    }
+    func changeToPostfix(infix: [String]) -> [String] {
+        var temporarySignStack = Stack<String>()
+        var postfix: [String] = []
+        for element in infix {
+            if let _ = Int(element) {
+                postfix.append(element)
+                continue
+            }
+            while !temporarySignStack.isEmpty
+                    && !hasHigherPriority(this: element, than: temporarySignStack.top!) {
+                let poppedSign = temporarySignStack.pop()
+                
+                postfix.append(poppedSign!)
+
+            }
+            temporarySignStack.push(element)
+
+        }
+        while !temporarySignStack.isEmpty {
+            let poppedSign = temporarySignStack.pop()
+            postfix.append(poppedSign!)
+        }
+        return postfix
+    }
+    func hasHigherPriority(this: String, than: String) -> Bool {
+        return (this == "/" || this == "x") && (than == "+" || than == "-")
+    }
+}

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -13,31 +13,36 @@ class Calculator {
         let postfix: [String] = changeToPostfix(infix: infix)
         return result
     }
+    
     func changeToPostfix(infix: [String]) -> [String] {
         var temporarySignStack = Stack<String>()
         var postfix: [String] = []
         for element in infix {
-            if let _ = Int(element) {
+            if let _ = Double(element) {
                 postfix.append(element)
-                continue
+            } else {
+                popAndAppend(sign: element, from: &temporarySignStack, to: &postfix)
+                temporarySignStack.push(element)
             }
-            while !temporarySignStack.isEmpty
-                    && !hasHigherPriority(this: element, than: temporarySignStack.top!) {
-                let poppedSign = temporarySignStack.pop()
-                
-                postfix.append(poppedSign!)
-
-            }
-            temporarySignStack.push(element)
-
         }
+        
         while !temporarySignStack.isEmpty {
             let poppedSign = temporarySignStack.pop()
             postfix.append(poppedSign!)
         }
         return postfix
     }
+    
     func hasHigherPriority(this: String, than: String) -> Bool {
         return (this == "/" || this == "x") && (than == "+" || than == "-")
+    }
+    
+    func popAndAppend( sign: String, from temporarySignStack: inout Stack<String>, to postfix: inout [String]) {
+        while let topOfTemporarySignStcak = temporarySignStack.top,
+              !hasHigherPriority(this: sign, than: topOfTemporarySignStcak) {
+            if let poppedSign = temporarySignStack.pop() {
+                postfix.append(poppedSign)
+            }
+        }
     }
 }

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -35,8 +35,29 @@ enum Operator {
 class Calculator {
     func calculate(infix: [String]) throws -> String {
         var result: String = ""
-        let postfix: [String] = try changeToPostfix(infix: infix)
+        var postfix: [String] = try changeToPostfix(infix: infix)
+        calculatePostfix(postfix: &postfix)
         return result
+    }
+    
+    func calculatePostfix(postfix: inout [String]) {
+        var tempNumberStack = Stack<String>()
+        for element in postfix {
+            if let _ = Double(element) {
+                tempNumberStack.push(element)
+            } else {
+                if let firstNumber = tempNumberStack.pop(),
+                   let secondNumber = tempNumberStack.pop() {
+                    let operation = firstNumber + element + secondNumber
+                    let convertToEquation = NSExpression(format: operation)
+                    if let result: Double = convertToEquation.expressionValue(with: nil, context: nil) as? Double {
+                        let strResult = String(result)
+                        tempNumberStack.push(strResult)
+                    }
+                }
+            }
+        }
+        print(tempNumberStack.pop()!)
     }
 
     func convertToOperator(string: String) throws -> Operator {
@@ -45,9 +66,9 @@ class Calculator {
             return .plus
         case "-":
             return .minus
-        case "×":
+        case "*":
             return .multiply
-        case "÷":
+        case "/":
             return .divide
         default:
             throw OperatorError.unknownOperator

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -7,39 +7,81 @@
 
 import Foundation
 
+enum OperatorError: Error {
+    case unknownOperator
+}
+
+enum Operator {
+    static let lowPriority = 1
+    static let highPriority = 2
+    
+    case plus, minus
+    case multiply, divide
+
+    var priority: Int {
+        switch self {
+        case .plus, .minus:
+            return Operator.lowPriority
+        case .multiply, .divide:
+            return Operator.highPriority
+        }
+    }
+
+    static func >(lhs: Operator, rhs: Operator) -> Bool {
+        return lhs.priority > rhs.priority
+    }
+}
+
 class Calculator {
-    func calculate(infix: [String]) -> String {
+    func calculate(infix: [String]) throws -> String {
         var result: String = ""
-        let postfix: [String] = changeToPostfix(infix: infix)
+        let postfix: [String] = try changeToPostfix(infix: infix)
         return result
     }
+
+    func convertToOperator(string: String) throws -> Operator {
+        switch string {
+        case "+":
+            return .plus
+        case "-":
+            return .minus
+        case "×":
+            return .multiply
+        case "÷":
+            return .divide
+        default:
+            throw OperatorError.unknownOperator
+        }
+    }
     
-    func changeToPostfix(infix: [String]) -> [String] {
+    func changeToPostfix(infix: [String]) throws -> [String] {
         var temporarySignStack = Stack<String>()
         var postfix: [String] = []
         for element in infix {
             if let _ = Double(element) {
                 postfix.append(element)
             } else {
-                popAndAppend(sign: element, from: &temporarySignStack, to: &postfix)
+                try popAndAppend(sign: element, from: &temporarySignStack, to: &postfix)
                 temporarySignStack.push(element)
             }
         }
-        
+
         while !temporarySignStack.isEmpty {
             let poppedSign = temporarySignStack.pop()
             postfix.append(poppedSign!)
         }
         return postfix
     }
-    
-    func hasHigherPriority(this: String, than: String) -> Bool {
-        return (this == "/" || this == "x") && (than == "+" || than == "-")
+
+    func hasHigherPriority(this: String, than: String) throws -> Bool {
+        let currentOperator: Operator = try convertToOperator(string: this)
+        let thanOperator: Operator = try convertToOperator(string: than)
+        return currentOperator > thanOperator
     }
     
-    func popAndAppend( sign: String, from temporarySignStack: inout Stack<String>, to postfix: inout [String]) {
+    func popAndAppend( sign: String, from temporarySignStack: inout Stack<String>, to postfix: inout [String]) throws {
         while let topOfTemporarySignStcak = temporarySignStack.top,
-              !hasHigherPriority(this: sign, than: topOfTemporarySignStcak) {
+              try !hasHigherPriority(this: sign, than: topOfTemporarySignStcak) {
             if let poppedSign = temporarySignStack.pop() {
                 postfix.append(poppedSign)
             }

--- a/Calculator/Calculator/Stack.swift
+++ b/Calculator/Calculator/Stack.swift
@@ -1,0 +1,28 @@
+//
+//  Stack.swift
+//  Calculator
+//
+//  Created by 홍정아 on 2021/06/23.
+//
+
+import Foundation
+
+struct Stack<T> {
+    var stack: Array<T> = []
+    
+    var isEmpty: Bool {
+        return stack.isEmpty
+    }
+    
+    mutating func push(_ element: T) {
+        stack.append(element)
+    }
+    
+    mutating func pop() -> T? {
+        return stack.popLast()
+    }
+    
+    var top: T? {
+        return stack.last
+    }
+}

--- a/Calculator/Calculator/Stack.swift
+++ b/Calculator/Calculator/Stack.swift
@@ -26,3 +26,4 @@ struct Stack<T> {
         return stack.last
     }
 }
+

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -11,14 +11,8 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
-        
     }
 
-    @IBAction func random(_ sender: Any) {
-        let calculator = Calculator()
-        let postfix = calculator.calculate(infix: ["7", "+", "3", "x", "3", "+", "4"])
-        print(postfix)
-    }
     
 }
 

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -11,8 +11,14 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+        
     }
 
-
+    @IBAction func random(_ sender: Any) {
+        let calculator = Calculator()
+        let postfix = calculator.calculate(infix: ["7", "+", "3", "x", "3", "+", "4"])
+        print(postfix)
+    }
+    
 }
 

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -11,14 +11,6 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
-        let cal = Calculator()
-        do {
-            try cal.calculate(infix: ["7", "+", "3", "*", "3", "+", "4"])
-           
-        } catch {
-            print(error.localizedDescription)
-        }
-      
     }
 
     

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -11,6 +11,14 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+        let cal = Calculator()
+        do {
+            try cal.calculate(infix: ["7", "+", "3", "*", "3", "+", "4"])
+           
+        } catch {
+            print(error.localizedDescription)
+        }
+      
     }
 
     


### PR DESCRIPTION
@hyunable 

## 작동 방법

- ViewController에서 Calculator 기능을 확인해보실 수 있는 코드입니다. 
  - viewDidLoad()에 복붙하시면 작동합니다

```swift
private static let lowPriority = 1
let cal = Calculator()
do {
    try cal.calculate(infix: ["1", "+", "2"])
    try cal.calculate(infix: ["7", "+", "3", "*", "3", "+", "4"])
} catch {
    print("error")
}
```



## 고민/궁금증

### Comparable 프로토콜 채택 여부

- 연산자의 우선순위를 비교하기 위해 Operator 열거형을 만들었습니다
  - `*`와 `/`는 `+` 나 `-` 보다 높은 우선순위를 갖기 때문에 각각의 우선순위에 `lowPriority` 와 `highPriority` 라는 숫자를 매칭하고 `>` 를 새로 정의해주었습니다.
- Q. 여기서 Operator 열거형이 Comparable 프로토콜을 채택하지 않아도 잘 작동됨을 확인했는데 채택이 필요한 것인지 안 해도 되는 것인지 궁금합니다. 🧐

### 우선순위 구현 방식

- Q:  연산자들의 우선순위를 비교하는 더 방법이 없을까 고민하다가 일단 현재 연산자들의 우선순위를 비교하는 방식을 아래 방식으로도 구현보긴했는데 더 좋은 방법은 없을지 계속 고민입니다. 혹시 어떤 문법을 활용해보면 좋을지 조언 부탁드려도 될까요? 🤩

  ```swift
  enum Priority {
      static let low = ["+", "-"]
      static let high = ["*", "/"]
  }
  
  extension String {
      static func >(left: String, right: String) -> Bool {
          return Priority.high.contains(left) && Priority.low.contains(right)
      }
  }
  
  func hasHigherPriority(this: String, than: String) throws -> Bool {
      return this > than
  }
  ```

### 에러 처리

- `popAndAppend()` 와 `popAndAppendLeftovers()`  의 while문에서 `temporarySignStack` 이 비어있지 않음을 확인한 뒤에 while문 내에서 `temporarySignStack` 의 마지막 항목을 `poppedSign` 으로 `pop()` 하는 코드가 있습니다.

  ```swift
  while let _ = temporarySignStack.top {
    if let poppedSign = temporarySignStack.pop() {
      postfix.append(poppedSign)
    }
  }
  ```

- 상위 while 문에서 이미 동일한 처리를 하기 때문에 `pop()` 을 사용하는 경우 옵셔널 바인딩에 실패할 리 없다고 생각해서 실패시 처리를 하지 않았습니다. 비어있지 않은데도 `pop()` 에 실패했다면 그것은 다음번 while 문을 다시 돌며 처리하면 될 것이라 생각했습니다.

- Q. 이 경우 별도의 에러 처리를 해주는 것이 좋을지 궁금합니다. 이렇게 조금씩 애매한 경우에 대한 에러 처리는 어떻게 하면 좋을지 궁금합니다.



### __NSCFNumber as? String

- 저희는 문자열로 된 식을 바로 계산할 수 있도록 `NSExpression()`과 `expressionValue()` 를 활용했습니다. 여기서 `expressionValue()` 의 반환값을 Double 로 다운캐스팅? 한 뒤 나중에 String으로 변환하는 과정을 거쳤습니다.

```swift
let expression = NSExpression(format: equation)
guard let operationResult = expression.expressionValue(with: nil, context: nil) as? Double else {
  throw CalculatorError.invalidEquation
}
return String(operationResult)
```

- 이 과정이 번거롭다고 생각해서 바로 String으로의 다운캐스팅을 시도했는데 에러가 발생했습니다. [공식문서](https://developer.apple.com/documentation/foundation/nsexpression/1410363-expressionvalue)에는 `expressionValue()` 의 반환값이 Any?로 되어있는데 결과의 타입을 확인해보니 `__NSCFNumber` 으로 나왔습니다. `__NSCFNumber` 를 String으로 다운캐스팅할 수 없어서 안되는 것 같은데 왜 아래와 같은 코드로 작성할 수 없는 것인지 잘 이해가 되지 않습니다. 😭

```swift
let expression = NSExpression(format: equation)
guard let operationResult = expression.expressionValue(with: nil, context: nil) as? String else {
  throw CalculatorError.invalidEquation
}
return operationResult
```



### Protocol 활용

Q. 프로토콜을 사용 하려 했으나, 막상 어디에서 사용을 해야 될 지 감이 안와 적용을 못했습니다....ㅜㅜ 사용법에 대한 팁(?) 같은게 있으시면 조인 부탁드리겠습니다 😢





# 감사합니다!