### PR TITLE
계산기 [STEP1] 애플사이다

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		368952922738EAE0003B8C71 /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368952912738EAE0003B8C71 /* CalculatorTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -15,7 +16,20 @@
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		368952942738EAE0003B8C71 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		3689528F2738EAE0003B8C71 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		368952912738EAE0003B8C71 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
+		368952932738EAE0003B8C71 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -27,6 +41,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3689528C2738EAE0003B8C71 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93B2570E5EB001C3AFC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -37,10 +58,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		368952902738EAE0003B8C71 /* CalculatorTests */ = {
+			isa = PBXGroup;
+			children = (
+				368952912738EAE0003B8C71 /* CalculatorTests.swift */,
+				368952932738EAE0003B8C71 /* Info.plist */,
+			);
+			path = CalculatorTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
+				368952902738EAE0003B8C71 /* CalculatorTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -49,6 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
+				3689528F2738EAE0003B8C71 /* CalculatorTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -70,6 +102,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		3689528E2738EAE0003B8C71 /* CalculatorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 368952982738EAE0003B8C71 /* Build configuration list for PBXNativeTarget "CalculatorTests" */;
+			buildPhases = (
+				3689528B2738EAE0003B8C71 /* Sources */,
+				3689528C2738EAE0003B8C71 /* Frameworks */,
+				3689528D2738EAE0003B8C71 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				368952952738EAE0003B8C71 /* PBXTargetDependency */,
+			);
+			name = CalculatorTests;
+			productName = CalculatorTests;
+			productReference = 3689528F2738EAE0003B8C71 /* CalculatorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -93,9 +143,13 @@
 		C713D9362570E5EB001C3AFC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					3689528E2738EAE0003B8C71 = {
+						CreatedOnToolsVersion = 12.5.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -115,11 +169,19 @@
 			projectRoot = "";
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
+				3689528E2738EAE0003B8C71 /* CalculatorTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3689528D2738EAE0003B8C71 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93C2570E5EB001C3AFC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -133,6 +195,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3689528B2738EAE0003B8C71 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				368952922738EAE0003B8C71 /* CalculatorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -144,6 +214,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		368952952738EAE0003B8C71 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 368952942738EAE0003B8C71 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C713D9472570E5EB001C3AFC /* Main.storyboard */ = {
@@ -165,6 +243,47 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		368952962738EAE0003B8C71 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = CalculatorTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kevin.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		368952972738EAE0003B8C71 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = CalculatorTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.kevin.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
 		C713D9502570E5ED001C3AFC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -327,6 +446,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		368952982738EAE0003B8C71 /* Build configuration list for PBXNativeTarget "CalculatorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				368952962738EAE0003B8C71 /* Debug */,
+				368952972738EAE0003B8C71 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C713D9392570E5EB001C3AFC /* Build configuration list for PBXProject "Calculator" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		368952922738EAE0003B8C71 /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368952912738EAE0003B8C71 /* CalculatorTests.swift */; };
+		368952C327395BC1003B8C71 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368952C227395BC1003B8C71 /* CalculatorItemQueue.swift */; };
+		368952C427395BC4003B8C71 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368952C227395BC1003B8C71 /* CalculatorItemQueue.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -30,6 +32,7 @@
 		3689528F2738EAE0003B8C71 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		368952912738EAE0003B8C71 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		368952932738EAE0003B8C71 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		368952C227395BC1003B8C71 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -95,6 +98,7 @@
 				C713D94A2570E5ED001C3AFC /* Assets.xcassets */,
 				C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */,
 				C713D94F2570E5ED001C3AFC /* Info.plist */,
+				368952C227395BC1003B8C71 /* CalculatorItemQueue.swift */,
 			);
 			path = Calculator;
 			sourceTree = "<group>";
@@ -199,6 +203,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				368952C427395BC4003B8C71 /* CalculatorItemQueue.swift in Sources */,
 				368952922738EAE0003B8C71 /* CalculatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -209,6 +214,7 @@
 			files = (
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				368952C327395BC1003B8C71 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+               BuildableName = "Calculator.app"
+               BlueprintName = "Calculator"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3689528E2738EAE0003B8C71"
+               BuildableName = "CalculatorTests.xctest"
+               BlueprintName = "CalculatorTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Calculator/Calculator/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/CalculatorItemQueue.swift
@@ -18,6 +18,16 @@ class Node<T> {
 
 class LinkedList<T> {
     var head: Node<T>?
+    var tail: Node<T>? {
+        if isEmpty {
+            return nil
+        }
+        
+        while head?.next != nil {
+            head = head?.next
+        }
+        return head
+    }
     var isEmpty: Bool {
         return head == nil
     }

--- a/Calculator/Calculator/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/CalculatorItemQueue.swift
@@ -3,7 +3,7 @@ import Foundation
 protocol CalculateItem {
 }
 
-class CalculatorItemQueue: CalculateItem {
+class CalculatorItemQueue<T>: LinkedList<T>, CalculateItem {
 }
 
 class Node<T> {

--- a/Calculator/Calculator/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/CalculatorItemQueue.swift
@@ -5,3 +5,13 @@ protocol CalculateItem {
 
 class CalculatorItemQueue: CalculateItem {
 }
+
+class Node<T> {
+    var value: T
+    var next: Node<T>?
+    
+    init(value: T, next: Node<T>? = nil) {
+        self.value = value
+        self.next = next
+    }
+}

--- a/Calculator/Calculator/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/CalculatorItemQueue.swift
@@ -60,4 +60,8 @@ class LinkedList<T> {
         }
         return scanResult
     }
+    
+    func removeAll() {
+        head = nil
+    }
 }

--- a/Calculator/Calculator/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/CalculatorItemQueue.swift
@@ -38,4 +38,18 @@ class LinkedList<T> {
         }
         finderToTail?.next = Node(value: value)
     }
+    
+    func scanAllValue() -> [T] {
+        var scanResult: [T] = []
+
+        guard var finderToTail: Node<T> = head else { return scanResult }
+        scanResult.append(finderToTail.value)
+        
+        guard let nextNode = finderToTail.next else { return scanResult }
+        while finderToTail.next != nil {
+            finderToTail = nextNode
+            scanResult.append(finderToTail.value)
+        }
+        return scanResult
+    }
 }

--- a/Calculator/Calculator/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/CalculatorItemQueue.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+protocol CalculateItem {
+}
+
+class CalculatorItemQueue: CalculateItem {
+}

--- a/Calculator/Calculator/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/CalculatorItemQueue.swift
@@ -15,3 +15,27 @@ class Node<T> {
         self.next = next
     }
 }
+
+class LinkedList<T> {
+    var head: Node<T>?
+    var isEmpty: Bool {
+        return head == nil
+    }
+
+    init(head: Node<T>?) {
+        self.head = head
+    }
+    
+    func append(value: T) {
+        if isEmpty {
+            head = Node(value: value)
+            return
+        }
+        
+        var finderToTail: Node<T>? = head
+        while finderToTail?.next != nil {
+            finderToTail = finderToTail?.next
+        }
+        finderToTail?.next = Node(value: value)
+    }
+}

--- a/Calculator/Calculator/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/CalculatorItemQueue.swift
@@ -39,6 +39,14 @@ class LinkedList<T> {
         finderToTail?.next = Node(value: value)
     }
     
+    func removeFirst() -> T? {
+        if isEmpty { return nil }
+        
+        let removedValue: T? = head?.value
+        head = head?.next
+        return removedValue
+    }
+    
     func scanAllValue() -> [T] {
         var scanResult: [T] = []
 

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -12,4 +12,25 @@ class CalculatorTests: XCTestCase {
         queue.append(value: 2)
         XCTAssertEqual(queue.scanAllValue(), [1, 2])
     }
+    
+    func test_1이_있는_큐를_removeFirst하면_빈_큐가되고_제거한값을_반환한다() {
+        let queue = CalculatorItemQueue<Int>(head: Node(value: 1))
+        let removedValue = queue.removeFirst()
+        XCTAssertTrue(queue.scanAllValue().isEmpty)
+        XCTAssertEqual(removedValue, 1)
+    }
+
+    func test_1과2가_있는_큐를_removeFirst하면_2가_남고_제거한값1을_반환한다() {
+        let queue = CalculatorItemQueue<Int>(head: Node(value: 1, next: Node(value: 2)))
+        let removedValue = queue.removeFirst()
+        XCTAssertEqual(queue.scanAllValue(), [2])
+        XCTAssertEqual(removedValue, 1)
+    }
+    
+    func test_1과2와3이_있는_큐를_removeFirst하면_2와3이_남고_제거한값1을_반환한다() {
+        let queue = CalculatorItemQueue<Int>(head: Node(value: 1, next: Node(value: 2, next: Node(value: 3))))
+        let removedValue = queue.removeFirst()
+        XCTAssertEqual(queue.scanAllValue(), [2, 3])
+        XCTAssertEqual(removedValue, 1)
+    }
 }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+
+class CalculatorTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+}

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -1,6 +1,16 @@
 import XCTest
 
 class CalculatorTests: XCTestCase {
+    func test_1과2와3이_있는_큐의_head의_value는_1이다() {
+        let queue = CalculatorItemQueue<Int>(head: Node(value: 1, next: Node(value: 2, next: Node(value: 3))))
+        XCTAssertEqual(queue.head?.value, 1)
+    }
+    
+    func test_1과2와3이_있는_큐의_tail의_value는_3이다() {
+        let queue = CalculatorItemQueue<Int>(head: Node(value: 1, next: Node(value: 2, next: Node(value: 3))))
+        XCTAssertEqual(queue.tail?.value, 3)
+    }
+    
     func test_빈_큐에_1을_append하면_1이_남는다() {
         let queue = CalculatorItemQueue<Int>(head: nil)
         queue.append(value: 1)

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -33,4 +33,10 @@ class CalculatorTests: XCTestCase {
         XCTAssertEqual(queue.scanAllValue(), [2, 3])
         XCTAssertEqual(removedValue, 1)
     }
+    
+    func test_1과2가_있는_큐를_removeAll하면_빈_큐가된다() {
+        let queue = CalculatorItemQueue<Int>(head: Node(value: 1, next: Node(value: 2)))
+        queue.removeAll()
+        XCTAssertNil(queue.head)
+    }
 }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -1,12 +1,15 @@
 import XCTest
 
 class CalculatorTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func test_빈_큐에_1을_append하면_1이_남는다() {
+        let queue = CalculatorItemQueue<Int>(head: nil)
+        queue.append(value: 1)
+        XCTAssertEqual(queue.scanAllValue(), [1])
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    
+    func test_1이_있는_큐에_2를_append하면_1과2가_남는다() {
+        let queue = CalculatorItemQueue<Int>(head: Node(value: 1))
+        queue.append(value: 2)
+        XCTAssertEqual(queue.scanAllValue(), [1, 2])
     }
 }

--- a/Calculator/CalculatorTests/Info.plist
+++ b/Calculator/CalculatorTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@
    - Queue를 사용하는 이유 : 계산기 프로그램에는 맨 앞과 맨 뒤를 삭제/추가하는 기능이 필요하며, 임의의 값을 탐색하지 않으므로 Queue가 적절하다.
    - Queue를 구현할 때 Array보다 Linked List가 적합한 이유 : Array의 removeFirst 메서드는 메모리 상에서 삭제한 요소 뒤에 위치한 요소들의 index를 모두 변경해야 하므로 성능이 낮다. (시간복잡도 O(n)) 반면 Linked List는 다음 요소를 가리키고 있는 포인터만 변경해주면 되므로 메모리 관리에 유리하다. (시간복잡도 O(1))
 
+* 주요 프로퍼티
+   - head : Linked List의 첫 번째 노드를 가리킨다.
+   - tail : Linked List의 마지막 노드를 가리킨다. (메서드 로직에서 마지막 노드를 찾는 경우가 빈번하므로 코드 중복을 방지하고자 생성했다.)
+   - isEmpty : head가 있는지, 없는지 여부를 나타낸다.
+
 * 주요 메서드
    - append : Linked List의 마지막에 새로운 노드를 추가한다.
    - removeFirst : Linked List의 첫 번째 노드 (head)를 제거 및 반환한다. (Queue에서 꺼낸 숫자 및 연산자를 사용하기 위해 반환타입을 지정했다.)
    - scanAllValue : 계산기 프로그램 작동에 직접 사용되지는 않지만, 테스트 코드에서 사용하기 위해 추가했다. 
+   - removeAll : Linked List의 전체 노드를 삭제한다. 계산기의 AC 버튼 기능을 구현하기 위해 생성했다.
 
 ### 키워드
 - TDD (Unit Test, XCTest), Data Structure (Queue/Linked List), Time Complexity, Generic, Inheritance, UML

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - TDD 방식으로 프로그래밍을 진행했다. XCTest를 통해 Test Case를 작성하여 테스트를 실행했다.
 
 ### UML
+![Calculator_STEP1_211109 drawio](https://user-images.githubusercontent.com/70856586/140907304-a4874c4e-8925-4ccb-9110-16b0c0974c94.png)
 
 ### 고려사항
 * 기능

--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
-## iOS 커리어 스타터 캠프
+# 계산기 프로젝트
 
-### 계산기 프로젝트 저장소
+## 프로젝트 소개
+1. (STEP2/3 확인 후 작성 예정)
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+### 프로젝트 참여자
+   - 팀원 : 애플사이다 @just1103
+   - 리뷰어 : 찌루루 @jae57
 
+### 프로젝트 일정
+* 1주차 - STEP1
+   - 11/08 (월) 스크럼, 프로젝트 확인, Linked List/Queue 구현
+   - 11/09 (화) 스크럼, UML 작성, PR 요청
+
+## STEP1
+### 구현 내용
+- 사용자가 계산기에 입력한 숫자 및 연산자를 Queue (CalculatorItemQueue 클래스)에 차례로 저장한다.
+- Queue를 구현하기 위해 Linked List를 활용했다.
+- TDD 방식으로 프로그래밍을 진행했다. XCTest를 통해 Test Case를 작성하여 테스트를 실행했다.
+
+### UML
+
+### 고려사항
+* 기능
+   - Queue를 사용하는 이유 : 계산기 프로그램에는 맨 앞과 맨 뒤를 삭제/추가하는 기능이 필요하며, 임의의 값을 탐색하지 않으므로 Queue가 적절하다.
+   - Queue를 구현할 때 Array보다 Linked List가 적합한 이유 : Array의 removeFirst 메서드는 메모리 상에서 삭제한 요소 뒤에 위치한 요소들의 index를 모두 변경해야 하므로 성능이 낮다. (시간복잡도 O(n)) 반면 Linked List는 다음 요소를 가리키고 있는 포인터만 변경해주면 되므로 메모리 관리에 유리하다. (시간복잡도 O(1))
+
+* 주요 메서드
+   - append : Linked List의 마지막에 새로운 노드를 추가한다.
+   - removeFirst : Linked List의 첫 번째 노드 (head)를 제거 및 반환한다. (Queue에서 꺼낸 숫자 및 연산자를 사용하기 위해 반환타입을 지정했다.)
+   - scanAllValue : 계산기 프로그램 작동에 직접 사용되지는 않지만, 테스트 코드에서 사용하기 위해 추가했다. 
+
+### 키워드
+- TDD (Unit Test, XCTest), Data Structure (Queue/Linked List), Time Complexity, Generic, Inheritance, UML


### PR DESCRIPTION
안녕하세요. 찌루루 @jae57
애플사이다 입니다. @just1103   
모르는 게 많아서 어떤 부분이든 코멘트 주시면 많이 도움될 것 같아요. STEP1 리뷰 잘 부탁드립니다 :)

## 궁금한 점
- 테스트 파일 
   이번 STEP의 4개 테스트 케이스에서 CalculatorItemQueue 인스턴스의 초기값이 모두 달라서 XCTest의 setUpWithError, tearDownWithError 메서드를 사용하지 않았습니다. 
   보통 sut (System Under Test) 프로퍼티를 생성하여 아래와 같이 사용하는 것으로 알고 있는데, 이번 STEP1 처럼 각 테스트 케이스 전후로 set up/tear down할 요소가 많이 없는 경우에는 사용하지 않아도 무방할까요?
    ```swift
    class StrangeCalculatorTests: XCTestCase {
        var sut: CalculatorItemQueue<Int>!
    
        override func setUpWithError() throws { 
            try super.setUpWithError()
            sut = CalculatorItemQueue<Int>(head: nil)
        }
    
        override func tearDownWithError() throws { 
            try super.tearDownWithError()
            sut = nil
        }
    //...
    ```

- 메모리 관리
검색을 통해 컴파일러가 메모리를 자동으로 관리해준다는 것을 알았습니다. ("더 이상 사용하지 않는 인스턴스 (아무도 참조하지 않는 인스턴스)의 메모리 해제는 신경 쓰지 않아도 된다. Swift의 ARC 특성 때문이다."라는 내용) 
그래서 removeFirst 메서드를 간단히 구현할 수 있었는데, 이렇게 해도 괜찮을까요?
    ```swift
    func removeFirst() -> T? { 
        if isEmpty { return nil } 
        
        let removedValue: T? = head?.value
        head = head?.next 
        return removedValue
    }
    ```

- scanAllValue 메서드 리팩토링
   프로젝트 제약사항에 따라 ! (강제 언래핑)사용을 지양하려고 방법-1로 제출했습니다. 하지만 방법-2를 보면 강제 언래핑을 사용했지만, while문의 조건을 통해 언래핑 전에 nil이 아닌지 미리 확인을 하도록 했습니다. 이 경우 nil에 접근할 가능성이 없으므로 강제 언래핑을 사용해도 괜찮을지 궁금합니다. (현업에서 때에 따라 강제 언래핑을 사용하는 경우도 있다고 들었습니다.) 🤔🤔
만약 강제 언래핑을 사용하지 않는 게 좋을 경우, 리팩토링을 위한 다른 방법이 있을지 찌루루의 의견이 궁금합니다!

    ```swift
    // 방법-1. 제출한 코드
    func scanAllValue() -> [T] {
        var scanResult: [T] = []
    
        guard var finderToTail: Node<T> = head else { return scanResult }  // head가 있는지 확인
        scanResult.append(finderToTail.value)
        
        guard let nextNode = finderToTail.next else { return scanResult }  // head 다음이 있는지 확인하고, 반복문 실행
        while finderToTail.next != nil {
            finderToTail = nextNode
            scanResult.append(finderToTail.value)
        }
        return scanResult
    }
    
    // 방법-2. 강제 언래핑 사용
    func scanAllValue() -> [T] {
	      var scanResult: [T] = []
	      var scanner: Node<T>? = head
	      
	      while scanner != nil {
	          scanResult.append(scanner!.value)  // 강제 언래핑
	          scanner = scanner?.next
	      }
	      return scanResult
    }
    ```

## 조언을 듣고 싶은 점
- API 네이밍이 적절한지 궁금합니다. 특히 메서드명과 관련해서 보통 enQueue/deQueue 또는 put/get을 많이 사용한다고 알고 있습니다. 이번 PR에서는 Array의 메서드명이 익숙한 개발자가 많다고 판단했고, put/get은 너무 단어의 의미가 광범위하다고 판단해서 append/removeFirst로 명명했는데 괜찮을까요?
- LinkedList 클래스의 모든 프로퍼티/메서드를 Queue 클래스가 사용할 수 있어야 하고, STEP2/3에서 Queue에 추가기능을 구현할 것이라고 예상해서 상속으로 구현했습니다. 이렇게 Queue와 Linked List를 상속으로 연결하는 것이 적절할까요?
- 이외 다시 생각해볼 점이 있다면 어느 것이든 공유 부탁드립니다 😊😊

## 기타 사항
- STEP2/3에서 Queue를 어떻게 사용할지 아직 파악하지 못해서 접근제어자를 설정하지 않았습니다. 
- CalculateItem 프로토콜 및 CalculatorItemQueue 클래스는 비어있는 상태입니다. 프로젝트 요구사항에서 비어있는 CalculateItem 프로토콜을 CalculatorItemQueue가 준수하도록 하라는 내용이 있어서 일단 추가했습니다.