### PR TITLE
계산기 [STEP 1] PR 알라딘

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		ED00CF3B27397DA40081B9F3 /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF3A27397DA40081B9F3 /* LinkedListTests.swift */; };
 		ED00CF42273982370081B9F3 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF41273982370081B9F3 /* LinkedList.swift */; };
 		ED00CF4A273BA1E80081B9F3 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF49273BA1E80081B9F3 /* CalculatorItemQueueTests.swift */; };
+		ED00CF4C273BA29A0081B9F3 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF4B273BA29A0081B9F3 /* CalculatorItemQueue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,6 +43,7 @@
 		ED00CF3C27397DA40081B9F3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		ED00CF41273982370081B9F3 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		ED00CF49273BA1E80081B9F3 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
+		ED00CF4B273BA29A0081B9F3 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 			isa = PBXGroup;
 			children = (
 				ED00CF41273982370081B9F3 /* LinkedList.swift */,
+				ED00CF4B273BA29A0081B9F3 /* CalculatorItemQueue.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -214,6 +217,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				ED00CF4C273BA29A0081B9F3 /* CalculatorItemQueue.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				ED00CF42273982370081B9F3 /* LinkedList.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -17,6 +17,16 @@
 		ED00CF42273982370081B9F3 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF41273982370081B9F3 /* LinkedList.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		ED00CF44273994220081B9F3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -54,7 +64,6 @@
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
-				ED00CF40273982130081B9F3 /* Model */,
 				ED00CF3927397DA40081B9F3 /* CalculatorTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
@@ -79,6 +88,7 @@
 				C713D94A2570E5ED001C3AFC /* Assets.xcassets */,
 				C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */,
 				C713D94F2570E5ED001C3AFC /* Info.plist */,
+				ED00CF40273982130081B9F3 /* Model */,
 			);
 			path = Calculator;
 			sourceTree = "<group>";
@@ -131,6 +141,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				ED00CF45273994220081B9F3 /* PBXTargetDependency */,
 			);
 			name = CalculatorTests;
 			productName = CalculatorTests;
@@ -151,6 +162,7 @@
 					};
 					ED00CF3727397DA40081B9F3 = {
 						CreatedOnToolsVersion = 12.5;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
 				};
 			};
@@ -214,6 +226,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		ED00CF45273994220081B9F3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = ED00CF44273994220081B9F3 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C713D9472570E5EB001C3AFC /* Main.storyboard */ = {
@@ -397,6 +417,7 @@
 		ED00CF3D27397DA40081B9F3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 7QHGBDS383;
@@ -412,12 +433,14 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
 			};
 			name = Debug;
 		};
 		ED00CF3E27397DA40081B9F3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 7QHGBDS383;
@@ -432,6 +455,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
 			};
 			name = Release;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		ED00CF42273982370081B9F3 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF41273982370081B9F3 /* LinkedList.swift */; };
 		ED00CF4A273BA1E80081B9F3 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF49273BA1E80081B9F3 /* CalculatorItemQueueTests.swift */; };
 		ED00CF4C273BA29A0081B9F3 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF4B273BA29A0081B9F3 /* CalculatorItemQueue.swift */; };
+		ED00CF4E273BC4A50081B9F3 /* DummyItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF4D273BC4A50081B9F3 /* DummyItem.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +45,7 @@
 		ED00CF41273982370081B9F3 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		ED00CF49273BA1E80081B9F3 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
 		ED00CF4B273BA29A0081B9F3 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
+		ED00CF4D273BC4A50081B9F3 /* DummyItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyItem.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +102,7 @@
 		ED00CF3927397DA40081B9F3 /* CalculatorTests */ = {
 			isa = PBXGroup;
 			children = (
+				ED00CF4D273BC4A50081B9F3 /* DummyItem.swift */,
 				ED00CF3A27397DA40081B9F3 /* LinkedListTests.swift */,
 				ED00CF49273BA1E80081B9F3 /* CalculatorItemQueueTests.swift */,
 				ED00CF3C27397DA40081B9F3 /* Info.plist */,
@@ -228,6 +231,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED00CF4E273BC4A50081B9F3 /* DummyItem.swift in Sources */,
 				ED00CF4A273BA1E80081B9F3 /* CalculatorItemQueueTests.swift in Sources */,
 				ED00CF3B27397DA40081B9F3 /* LinkedListTests.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 		ED00CF3B27397DA40081B9F3 /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF3A27397DA40081B9F3 /* LinkedListTests.swift */; };
 		ED00CF42273982370081B9F3 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF41273982370081B9F3 /* LinkedList.swift */; };
+		ED00CF4A273BA1E80081B9F3 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED00CF49273BA1E80081B9F3 /* CalculatorItemQueueTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,6 +41,7 @@
 		ED00CF3A27397DA40081B9F3 /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
 		ED00CF3C27397DA40081B9F3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		ED00CF41273982370081B9F3 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		ED00CF49273BA1E80081B9F3 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				ED00CF3A27397DA40081B9F3 /* LinkedListTests.swift */,
+				ED00CF49273BA1E80081B9F3 /* CalculatorItemQueueTests.swift */,
 				ED00CF3C27397DA40081B9F3 /* Info.plist */,
 			);
 			path = CalculatorTests;
@@ -221,6 +224,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED00CF4A273BA1E80081B9F3 /* CalculatorItemQueueTests.swift in Sources */,
 				ED00CF3B27397DA40081B9F3 /* LinkedListTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+               BuildableName = "Calculator.app"
+               BlueprintName = "Calculator"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/CalculatorTests.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/CalculatorTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ED00CF3727397DA40081B9F3"
+               BuildableName = "CalculatorTests.xctest"
+               BlueprintName = "CalculatorTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -26,6 +26,7 @@ struct CalculatorItemQueue<T> {
         list.append(item)
     }
     
+    @discardableResult
     mutating func dequeue() -> T? {
         return list.retrieveHeadValue()
     }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -21,4 +21,11 @@ struct CalculatorItemQueue<T> {
     mutating func enqueue(_ item: T) {
         list.append(item)
     }
+    
+    mutating func dequeue() -> T? {
+        guard list.isNotEmpty else {
+            return nil
+        }
+        return list.getHead()
+    }
 }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -1,0 +1,20 @@
+//
+//  CalculatorItemQueue.swift
+//  Calculator
+//
+//  Created by Jun Bang on 2021/11/10.
+//
+
+import Foundation
+
+struct CalculatorItemQueue<T> {
+    var list = LinkedList<T>()
+    
+    var isNotEmpty: Bool {
+        return list.isNotEmpty
+    }
+    
+    mutating func enqueue(_ item: T) {
+        list.append(item)
+    }
+}

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -27,9 +27,6 @@ struct CalculatorItemQueue<T> {
     }
     
     mutating func dequeue() -> T? {
-        guard list.isNotEmpty else {
-            return nil
-        }
         return list.retrieveHeadValue()
     }
     

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -7,8 +7,19 @@
 
 import Foundation
 
-struct CalculatorItemQueue<T> {
+protocol CalculateItem {
+    
+}
+
+struct CalculatorItemQueue<T: CalculateItem> {
     var list = LinkedList<T>()
+    
+    var first: T? {
+        guard let firstItem = list.first else {
+            return nil
+        }
+        return firstItem
+    }
     
     var isNotEmpty: Bool {
         return list.isNotEmpty

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -11,15 +11,15 @@ protocol CalculateItem {
     
 }
 
-struct CalculatorItemQueue<T: CalculateItem> {
+struct CalculatorItemQueue<T> {
     var list = LinkedList<T>()
     
-    var first: T? {
-        guard let firstItem = list.first else {
-            return nil
-        }
-        return firstItem
-    }
+//    var first: CalculateItem? {
+//        guard let firstItem = list.first else {
+//            return nil
+//        }
+//        return firstItem
+//    }
     
     var isNotEmpty: Bool {
         return list.isNotEmpty

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -14,6 +14,10 @@ protocol CalculateItem {
 struct CalculatorItemQueue<T> {
     var list = LinkedList<T>()
     
+    var isEmpty: Bool {
+        return list.isEmpty
+    }
+    
     var isNotEmpty: Bool {
         return list.isNotEmpty
     }
@@ -27,5 +31,9 @@ struct CalculatorItemQueue<T> {
             return nil
         }
         return list.getHead()
+    }
+    
+    mutating func removeAll() {
+        list.removeAll()
     }
 }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -30,7 +30,7 @@ struct CalculatorItemQueue<T> {
         guard list.isNotEmpty else {
             return nil
         }
-        return list.getHead()
+        return list.retrieveHeadValue()
     }
     
     mutating func removeAll() {

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -14,13 +14,6 @@ protocol CalculateItem {
 struct CalculatorItemQueue<T> {
     var list = LinkedList<T>()
     
-//    var first: CalculateItem? {
-//        guard let firstItem = list.first else {
-//            return nil
-//        }
-//        return firstItem
-//    }
-    
     var isNotEmpty: Bool {
         return list.isNotEmpty
     }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -12,7 +12,7 @@ protocol CalculateItem {
 }
 
 struct CalculatorItemQueue<T> {
-    var list = LinkedList<T>()
+    private var list = LinkedList<T>()
     
     var isEmpty: Bool {
         return list.isEmpty

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -47,7 +47,7 @@ struct LinkedList<T> {
     }
     
     mutating func removeHead() -> Node<T>? {
-        guard isNotEmpty, let nodeToBeRemoved = retrieveNode(at: 0) else {
+        guard let nodeToBeRemoved = retrieveNode(at: 0) else {
             return nil
         }
         return remove(node: nodeToBeRemoved)

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -13,6 +13,7 @@ protocol CalculateItem {
 class Node {
     var item: CalculateItem
     var next: Node?
+    var previous: Node?
     
     init(item: CalculateItem) {
         self.item = item
@@ -21,6 +22,7 @@ class Node {
 
 struct LinkedList {
     private var head: Node?
+    private var tail: Node?
     
     var isNotEmpty: Bool {
         return head != nil
@@ -28,8 +30,10 @@ struct LinkedList {
 
     mutating func append(_ item: CalculateItem) {
         let newNode = Node(item: item)
-        if let head = head {
-            head.next = newNode
+        if let tailNode = tail {
+            newNode.previous = tailNode
+            tailNode.next = newNode
+            tail = newNode
         } else {
             head = newNode
         }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -54,15 +54,10 @@ struct LinkedList<T> {
     }
     
     mutating func removeHead() -> Node<T>? {
-        guard isNotEmpty, let oldHead = head else {
+        guard isNotEmpty, let nodeToBeRemoved = getNode(at:0) else {
             return nil
         }
-        guard let newHead = oldHead.next else {
-            head = nil
-            return oldHead
-        }
-        head = newHead
-        return oldHead
+        return remove(node: nodeToBeRemoved)
     }
     
     mutating func removeAll() {

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 protocol CalculateItem {
-    var zero: Int { get }
+    
 }
 
 class Node {
@@ -37,7 +37,5 @@ struct LinkedList {
 }
 
 extension Int: CalculateItem {
-    var zero: Int {
-        return 0
-    }
+    
 }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -83,6 +83,7 @@ struct LinkedList<T> {
         guard isNotEmpty else {
             return nil
         }
+        
         var currentNode = head
         for _ in 0..<index {
             if let node = currentNode {

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -40,14 +40,14 @@ struct LinkedList<T> {
     }
     
     mutating func retrieveHeadValue() -> T? {
-        if let removedHead = removeHead(){
+        if let removedHead = removeHead() {
             return removedHead.item
         }
         return nil
     }
     
     mutating func removeHead() -> Node<T>? {
-        guard isNotEmpty, let nodeToBeRemoved = retrieveNode(at:0) else {
+        guard isNotEmpty, let nodeToBeRemoved = retrieveNode(at: 0) else {
             return nil
         }
         return remove(node: nodeToBeRemoved)
@@ -75,7 +75,7 @@ struct LinkedList<T> {
         }
         node.previous = nil
         node.next = nil
-
+        
         return node
     }
     

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -55,7 +55,7 @@ struct LinkedList<T> {
     }
     
     @discardableResult
-    mutating func removeHead() -> Node<T>? {
+    private mutating func removeHead() -> Node<T>? {
         guard let oldHead = head else {
             return nil
         }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -46,7 +46,7 @@ struct LinkedList<T> {
         tail = newNode
     }
     
-    mutating func getHead() -> T? {
+    mutating func retrieveHeadValue() -> T? {
         if let removedHead = removeHead(){
             return removedHead.item
         }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -20,6 +20,10 @@ struct LinkedList<T> {
     var head: Node<T>?
     var tail: Node<T>?
     
+    var isEmpty: Bool {
+        return head == nil
+    }
+    
     var isNotEmpty: Bool {
         return head != nil
     }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -6,40 +6,36 @@
 //
 import Foundation
 
-protocol CalculateItem {
-    
-}
-
-class Node {
-    var item: CalculateItem
+class Node<T> {
+    var item: T
     var next: Node?
     var previous: Node?
     
-    init(item: CalculateItem) {
+    init(item: T) {
         self.item = item
     }
 }
 
-struct LinkedList {
-    private var head: Node?
-    private var tail: Node?
+struct LinkedList<T> {
+    private var head: Node<T>?
+    private var tail: Node<T>?
+    
+    var first: Node<T>? {
+        return head
+    }
     
     var isNotEmpty: Bool {
         return head != nil
     }
-
-    mutating func append(_ item: CalculateItem) {
+    
+    mutating func append(_ item: T) {
         let newNode = Node(item: item)
         if let tailNode = tail {
             newNode.previous = tailNode
             tailNode.next = newNode
-            tail = newNode
         } else {
             head = newNode
         }
+        tail = newNode
     }
-}
-
-extension Int: CalculateItem {
-    
 }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -20,6 +20,13 @@ struct LinkedList<T> {
     var head: Node<T>?
     var tail: Node<T>?
     
+    var first: T? {
+        guard let head = head else {
+            return nil
+        }
+        return head.item
+    }
+    
     var isEmpty: Bool {
         return head == nil
     }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -34,4 +34,19 @@ struct LinkedList<T> {
         }
         tail = newNode
     }
+    
+    mutating func removeFront() -> Node<T>? {
+        guard isNotEmpty else {
+            return nil
+        }
+        guard let oldHead = head else {
+            return nil
+        }
+        guard let newHead = oldHead.next else {
+            head = nil
+            return oldHead
+        }
+        head = newHead
+        return oldHead
+    }
 }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -46,6 +46,7 @@ struct LinkedList<T> {
         return nil
     }
     
+    @discardableResult
     mutating func removeHead() -> Node<T>? {
         guard let nodeToBeRemoved = retrieveNode(at: 0) else {
             return nil

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -50,4 +50,9 @@ struct LinkedList<T> {
         head = newHead
         return oldHead
     }
+    
+    mutating func removeAll() {
+        head = nil
+        tail = nil
+    }
 }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -20,13 +20,6 @@ struct LinkedList<T> {
     var head: Node<T>?
     var tail: Node<T>?
     
-    var first: T? {
-        guard let head = head else {
-            return nil
-        }
-        return head.item
-    }
-    
     var isEmpty: Bool {
         return head == nil
     }
@@ -54,7 +47,7 @@ struct LinkedList<T> {
     }
     
     mutating func removeHead() -> Node<T>? {
-        guard isNotEmpty, let nodeToBeRemoved = getNode(at:0) else {
+        guard isNotEmpty, let nodeToBeRemoved = retrieveNode(at:0) else {
             return nil
         }
         return remove(node: nodeToBeRemoved)
@@ -86,7 +79,7 @@ struct LinkedList<T> {
         return node
     }
     
-    func getNode(at index: Int) -> Node<T>? {
+    func retrieveNode(at index: Int) -> Node<T>? {
         guard isNotEmpty else {
             return nil
         }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -24,6 +24,10 @@ struct LinkedList<T> {
         return head
     }
     
+    var last: Node<T>? {
+        return tail
+    }
+    
     var isNotEmpty: Bool {
         return head != nil
     }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -35,11 +35,8 @@ struct LinkedList<T> {
         tail = newNode
     }
     
-    mutating func removeFront() -> Node<T>? {
-        guard isNotEmpty else {
-            return nil
-        }
-        guard let oldHead = head else {
+    mutating func removeHead() -> Node<T>? {
+        guard isNotEmpty, let oldHead = head else {
             return nil
         }
         guard let newHead = oldHead.next else {

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -4,11 +4,10 @@
 //
 //  Created by Jun Bang on 2021/11/09.
 //
-
 import Foundation
 
 protocol CalculateItem {
-    
+    var zero: Int { get }
 }
 
 class Node {
@@ -34,5 +33,11 @@ struct LinkedList {
         } else {
             head = newNode
         }
+    }
+}
+
+extension Int: CalculateItem {
+    var zero: Int {
+        return 0
     }
 }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -48,49 +48,15 @@ struct LinkedList<T> {
     
     @discardableResult
     mutating func removeHead() -> Node<T>? {
-        guard let nodeToBeRemoved = retrieveNode(at: 0) else {
+        guard let oldHead = head else {
             return nil
         }
-        return remove(node: nodeToBeRemoved)
+        head = oldHead.next
+        return oldHead
     }
     
     mutating func removeAll() {
         head = nil
         tail = nil
-    }
-    
-    mutating func remove(node: Node<T>) -> Node<T> {
-        let previousNode = node.previous
-        let nextNode = node.next
-        
-        if let previousNode = previousNode {
-            previousNode.next = nextNode
-        } else {
-            head = nextNode
-        }
-        
-        if let nextNode = nextNode {
-            nextNode.previous = previousNode
-        } else {
-            tail = previousNode
-        }
-        node.previous = nil
-        node.next = nil
-        
-        return node
-    }
-    
-    func retrieveNode(at index: Int) -> Node<T>? {
-        guard isNotEmpty else {
-            return nil
-        }
-        
-        var currentNode = head
-        for _ in 0..<index {
-            if let node = currentNode {
-                currentNode = node.next
-            }
-        }
-        return currentNode
     }
 }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -54,7 +54,6 @@ struct LinkedList<T> {
         return nil
     }
     
-    @discardableResult
     private mutating func removeHead() -> Node<T>? {
         guard let oldHead = head else {
             return nil

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -17,16 +17,8 @@ class Node<T> {
 }
 
 struct LinkedList<T> {
-    private var head: Node<T>?
-    private var tail: Node<T>?
-    
-    var first: Node<T>? {
-        return head
-    }
-    
-    var last: Node<T>? {
-        return tail
-    }
+    var head: Node<T>?
+    var tail: Node<T>?
     
     var isNotEmpty: Bool {
         return head != nil

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -55,4 +55,38 @@ struct LinkedList<T> {
         head = nil
         tail = nil
     }
+    
+    mutating func remove(node: Node<T>) -> Node<T> {
+        let previousNode = node.previous
+        let nextNode = node.next
+        
+        if let previousNode = previousNode {
+            previousNode.next = nextNode
+        } else {
+            head = nextNode
+        }
+        
+        if let nextNode = nextNode {
+            nextNode.previous = previousNode
+        } else {
+            tail = previousNode
+        }
+        node.previous = nil
+        node.next = nil
+
+        return node
+    }
+    
+    func getNode(at index: Int) -> Node<T>? {
+        guard isNotEmpty else {
+            return nil
+        }
+        var currentNode = head
+        for _ in 0..<index {
+            if let node = currentNode {
+                currentNode = node.next
+            }
+        }
+        return currentNode
+    }
 }

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -17,8 +17,16 @@ class Node<T> {
 }
 
 struct LinkedList<T> {
-    var head: Node<T>?
-    var tail: Node<T>?
+    private var head: Node<T>?
+    private var tail: Node<T>?
+    
+    var first: Node<T>? {
+        return head
+    }
+    
+    var last: Node<T>? {
+        return tail
+    }
     
     var isEmpty: Bool {
         return head == nil

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -46,6 +46,13 @@ struct LinkedList<T> {
         tail = newNode
     }
     
+    mutating func getHead() -> T? {
+        if let removedHead = removeHead(){
+            return removedHead.item
+        }
+        return nil
+    }
+    
     mutating func removeHead() -> Node<T>? {
         guard isNotEmpty, let oldHead = head else {
             return nil

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -8,7 +8,6 @@ import UIKit
 
 class ViewController: UIViewController {
     
-    var linkedList = LinkedList<Any>()
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -7,7 +7,8 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
+    var linkedList = LinkedList<Any>()
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -30,8 +30,7 @@ class CalculatorItemQueueTests: XCTestCase {
     func testCalculatorItemQueueDequeue_givenNewInteger_expectFirstItemEqualToInsertedItem() {
         let newData = 10
         sut.enqueue(newData)
-        let removedItem = sut.dequeue()
-        guard let removedItem = removedItem as? Int else { return }
+        guard let removedItem = sut.dequeue() as? Int else { return }
         XCTAssertEqual(removedItem, newData)
     }
     

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -46,4 +46,10 @@ class CalculatorItemQueueTests: XCTestCase {
         }
         XCTAssertEqual(removedItem, newData)
     }
+    
+    func testCalculatorItemQueueDequeue_givenMultipleMixedItems_expectCorrectSequence() {
+        let newItems: [Any] = [20, "+", 30, "-", 2]
+        appendContents(of: newItems, to: sut)
+        XCTAssertTrue(isSameSequence(sut.convertToArray, newItems))
+    }
 }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -97,7 +97,7 @@ class CalculatorItemQueueTests: XCTestCase {
     
     private func removeAll(of queue: inout CalculatorItemQueue<Any>) {
         while queue.isNotEmpty {
-            let _ = queue.dequeue()
+            queue.dequeue()
         }
     }
 }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -1,0 +1,25 @@
+//
+//  CalculatorItemQueueTests.swift
+//  CalculatorTests
+//
+//  Created by Jun Bang on 2021/11/10.
+//
+
+import XCTest
+
+class CalculatorItemQueueTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testCalculatorItemQueueEnqueue_givenNewInteger_expectNotEmpty() {
+        let newData = 10
+        sut.enqueue(newData)
+        XCTAssertTrue(sut.isNotEmpty)
+    }
+}

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -42,12 +42,6 @@ class CalculatorItemQueueTests: XCTestCase {
         XCTAssertEqual(removedItem, newData)
     }
     
-    func testCalculatorItemQueueEnqueue_givenMultipleMixedItems_expectCorrectSequence() {
-        let newItems: [Any] = [20, "+", 30, "-", 2]
-        appendContents(of: newItems, to: &sut)
-        XCTAssertTrue(isEqualSequence(sequence: sut.convertToArray, otherSequence: newItems))
-    }
-    
     func testCalculatorQueueDequeue_givenRemoveAllOfMultipleMixedItems_expectIsEmpty() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
@@ -114,21 +108,5 @@ fileprivate extension LinkedList {
             }
         }
         return count
-    }
-}
-
-fileprivate extension CalculatorItemQueue {
-    var length: Int {
-        return list.length
-    }
-    
-    var convertToArray: [Any] {
-        var convertedArray: [Any] = []
-        for i in 0..<length {
-            if let node = list.retrieveNode(at: i) {
-                convertedArray.append(node.item)
-            }
-        }
-        return convertedArray
     }
 }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -35,7 +35,3 @@ class CalculatorItemQueueTests: XCTestCase {
         XCTAssertEqual(sut.first, testableItem)
     }
 }
-
-extension Int: CalculateItem {
-    
-}

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import Calculator
 
 class CalculatorItemQueueTests: XCTestCase {
-    var sut: CalculatorItemQueue<Any>!
+    var sut: CalculatorItemQueue<LinkedListItem>!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -23,13 +23,19 @@ class CalculatorItemQueueTests: XCTestCase {
     
     func testCalculatorItemQueueEnqueue_givenNewInteger_expectNotEmpty() {
         let newData = 10
-        sut.enqueue(newData)
+        let testableItem = LinkedListItem.number(value: newData)
+        sut.enqueue(testableItem)
         XCTAssertTrue(sut.isNotEmpty)
     }
     
     func testCalculatorItemQueueEnqueue_givenNewInteger_expectFirstItemEqualToInsertedItem() {
         let newData = 10
-        sut.enqueue(newData)
-        XCTAssertEqual(sut.first, newData)
+        let testableItem = LinkedListItem.number(value: newData)
+        sut.enqueue(testableItem)
+        XCTAssertEqual(sut.first, testableItem)
     }
+}
+
+extension Int: CalculateItem {
+    
 }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -63,23 +63,23 @@ class CalculatorItemQueueTests: XCTestCase {
     }
     
     private func isEqualSequence(sequence: [Any], otherSequence: [Any]) -> Bool {
-        let firstConvertedSequence = convertToTestableType(sequence: sequence)
-        let secondConvertedSequence = convertToTestableType(sequence: otherSequence)
+        let firstConvertedSequence = convertToDummyItemArray(sequence: sequence)
+        let secondConvertedSequence = convertToDummyItemArray(sequence: otherSequence)
         
         return firstConvertedSequence == secondConvertedSequence
     }
     
-    private func convertToTestableType(sequence: [Any]) -> [DummyItem] {
+    private func convertToDummyItemArray(sequence: [Any]) -> [DummyItem] {
         var testableList: [DummyItem] = []
         for item in sequence {
-            if let convertedItem = convertToLinkedListItem(value: item) {
+            if let convertedItem = convertToDummyItem(value: item) {
                 testableList.append(convertedItem)
             }
         }
         return testableList
     }
     
-    private func convertToLinkedListItem(value: Any) -> DummyItem? {
+    private func convertToDummyItem(value: Any) -> DummyItem? {
         if let value = value as? Int {
             return DummyItem.number(value: value)
         }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -31,9 +31,7 @@ class CalculatorItemQueueTests: XCTestCase {
         let newData = 10
         sut.enqueue(newData)
         let removedItem = sut.dequeue()
-        guard let removedItem = removedItem as? Int else {
-            return
-        }
+        guard let removedItem = removedItem as? Int else { return }
         XCTAssertEqual(removedItem, newData)
     }
     
@@ -41,9 +39,7 @@ class CalculatorItemQueueTests: XCTestCase {
         let newData = "+"
         sut.enqueue(newData)
         let removedItem = sut.dequeue()
-        guard let removedItem = removedItem as? String else {
-            return
-        }
+        guard let removedItem = removedItem as? String else { return }
         XCTAssertEqual(removedItem, newData)
     }
     
@@ -76,6 +72,7 @@ class CalculatorItemQueueTests: XCTestCase {
     private func isEqualSequence(sequence: [Any], otherSequence: [Any]) -> Bool {
         let firstConvertedSequence = convertToTestableType(sequence: sequence)
         let secondConvertedSequence = convertToTestableType(sequence: otherSequence)
+        
         return firstConvertedSequence == secondConvertedSequence
     }
     

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -15,7 +15,7 @@ class CalculatorItemQueueTests: XCTestCase {
         try super.setUpWithError()
         sut = CalculatorItemQueue()
     }
-
+    
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         sut = nil
@@ -47,9 +47,57 @@ class CalculatorItemQueueTests: XCTestCase {
         XCTAssertEqual(removedItem, newData)
     }
     
-    func testCalculatorItemQueueDequeue_givenMultipleMixedItems_expectCorrectSequence() {
+    func testCalculatorItemQueueEnqueue_givenMultipleMixedItems_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
-        appendContents(of: newItems, to: sut)
-        XCTAssertTrue(isSameSequence(sut.convertToArray, newItems))
+        appendContents(of: newItems, to: &sut)
+        XCTAssertTrue(isSameSequence(sequence: sut.convertToArray, otherSequence: newItems))
+    }
+    
+    func appendContents(of sequence: [Any], to queue: inout CalculatorItemQueue<Any>) {
+        for item in sequence {
+            queue.enqueue(item)
+        }
+    }
+    
+    func isSameSequence(sequence: [Any], otherSequence: [Any]) -> Bool {
+        let firstConvertedSequence = convertToTestableType(sequence: sequence)
+        let secondConvertedSequence = convertToTestableType(sequence: otherSequence)
+        return firstConvertedSequence == secondConvertedSequence
+    }
+    
+    func convertToTestableType(sequence: [Any]) -> [LinkedListItem] {
+        var testableList: [LinkedListItem] = []
+        for item in sequence {
+            if let convertedItem = convertToLinkedListItem(value: item) {
+                testableList.append(convertedItem)
+            }
+        }
+        return testableList
+    }
+    
+    private func convertToLinkedListItem(value: Any) -> LinkedListItem? {
+        if let value = value as? Int {
+            return LinkedListItem.number(value: value)
+        }
+        if let value = value as? String {
+            return LinkedListItem.symbol(value: value)
+        }
+        return nil
+    }
+}
+
+extension CalculatorItemQueue {
+    var length: Int {
+        return list.length
+    }
+    
+    var convertToArray: [T] {
+        var convertedArray: [T] = []
+        for i in 0..<length {
+            if let node = list.getNode(at: i) {
+                convertedArray.append(node.item)
+            }
+        }
+        return convertedArray
     }
 }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -50,7 +50,7 @@ class CalculatorItemQueueTests: XCTestCase {
     func testCalculatorItemQueueEnqueue_givenMultipleMixedItems_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
-        XCTAssertTrue(isSameSequence(sequence: sut.convertToArray, otherSequence: newItems))
+        XCTAssertTrue(isEqualSequence(sequence: sut.convertToArray, otherSequence: newItems))
     }
     
     func testCalculatorQueueDequeue_givenRemoveAllOfMultipleMixedItems_expectIsEmpty() {
@@ -73,14 +73,14 @@ class CalculatorItemQueueTests: XCTestCase {
         }
     }
     
-    private func isSameSequence(sequence: [Any], otherSequence: [Any]) -> Bool {
+    private func isEqualSequence(sequence: [Any], otherSequence: [Any]) -> Bool {
         let firstConvertedSequence = convertToTestableType(sequence: sequence)
         let secondConvertedSequence = convertToTestableType(sequence: otherSequence)
         return firstConvertedSequence == secondConvertedSequence
     }
     
-    private func convertToTestableType(sequence: [Any]) -> [LinkedListItem] {
-        var testableList: [LinkedListItem] = []
+    private func convertToTestableType(sequence: [Any]) -> [DummyItem] {
+        var testableList: [DummyItem] = []
         for item in sequence {
             if let convertedItem = convertToLinkedListItem(value: item) {
                 testableList.append(convertedItem)
@@ -89,12 +89,12 @@ class CalculatorItemQueueTests: XCTestCase {
         return testableList
     }
     
-    private func convertToLinkedListItem(value: Any) -> LinkedListItem? {
+    private func convertToLinkedListItem(value: Any) -> DummyItem? {
         if let value = value as? Int {
-            return LinkedListItem.number(value: value)
+            return DummyItem.number(value: value)
         }
         if let value = value as? String {
-            return LinkedListItem.symbol(value: value)
+            return DummyItem.symbol(value: value)
         }
         return nil
     }
@@ -111,8 +111,8 @@ extension CalculatorItemQueue {
         return list.length
     }
     
-    var convertToArray: [T] {
-        var convertedArray: [T] = []
+    var convertToArray: [Any] {
+        var convertedArray: [Any] = []
         for i in 0..<length {
             if let node = list.getNode(at: i) {
                 convertedArray.append(node.item)

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -67,19 +67,19 @@ class CalculatorItemQueueTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
-    func appendContents(of sequence: [Any], to queue: inout CalculatorItemQueue<Any>) {
+    private func appendContents(of sequence: [Any], to queue: inout CalculatorItemQueue<Any>) {
         for item in sequence {
             queue.enqueue(item)
         }
     }
     
-    func isSameSequence(sequence: [Any], otherSequence: [Any]) -> Bool {
+    private func isSameSequence(sequence: [Any], otherSequence: [Any]) -> Bool {
         let firstConvertedSequence = convertToTestableType(sequence: sequence)
         let secondConvertedSequence = convertToTestableType(sequence: otherSequence)
         return firstConvertedSequence == secondConvertedSequence
     }
     
-    func convertToTestableType(sequence: [Any]) -> [LinkedListItem] {
+    private func convertToTestableType(sequence: [Any]) -> [LinkedListItem] {
         var testableList: [LinkedListItem] = []
         for item in sequence {
             if let convertedItem = convertToLinkedListItem(value: item) {

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -60,6 +60,13 @@ class CalculatorItemQueueTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
+    func testCalculatorQueueDequeue_givenMultipleDequeue_expectIsEmpty() {
+        let newItems: [Any] = [20, "+", 30, "-", 2]
+        appendContents(of: newItems, to: &sut)
+        removeAll(of: &sut)
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
     func appendContents(of sequence: [Any], to queue: inout CalculatorItemQueue<Any>) {
         for item in sequence {
             queue.enqueue(item)

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -95,18 +95,3 @@ class CalculatorItemQueueTests: XCTestCase {
         }
     }
 }
-
-fileprivate extension LinkedList {
-    var length: Int {
-        var pointer = head
-        var count = 0
-        
-        while pointer != nil {
-            if let node = pointer {
-                pointer = node.next
-                count += 1
-            }
-        }
-        return count
-    }
-}

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import Calculator
 
 class CalculatorItemQueueTests: XCTestCase {
-    var sut: CalculatorItemQueue<LinkedListItem>!
+    var sut: CalculatorItemQueue<Any>!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -23,15 +23,14 @@ class CalculatorItemQueueTests: XCTestCase {
     
     func testCalculatorItemQueueEnqueue_givenNewInteger_expectNotEmpty() {
         let newData = 10
-        let testableItem = LinkedListItem.number(value: newData)
-        sut.enqueue(testableItem)
+        sut.enqueue(newData)
         XCTAssertTrue(sut.isNotEmpty)
     }
     
-    func testCalculatorItemQueueEnqueue_givenNewInteger_expectFirstItemEqualToInsertedItem() {
+    func testCalculatorItemQueueDequeue_givenNewInteger_expectFirstItemEqualToInsertedItem() {
         let newData = 10
-        let testableItem = LinkedListItem.number(value: newData)
-        sut.enqueue(testableItem)
-        XCTAssertEqual(sut.first, testableItem)
+        sut.enqueue(newData)
+        let removedItem = sut.dequeue()
+        XCTAssertEqual(removedItem, newData)
     }
 }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -98,6 +98,12 @@ class CalculatorItemQueueTests: XCTestCase {
         }
         return nil
     }
+    
+    private func removeAll(of queue: inout CalculatorItemQueue<Any>) {
+        while queue.isNotEmpty {
+            let _ = queue.dequeue()
+        }
+    }
 }
 
 extension CalculatorItemQueue {

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -102,7 +102,22 @@ class CalculatorItemQueueTests: XCTestCase {
     }
 }
 
-extension CalculatorItemQueue {
+private extension LinkedList {
+    var length: Int {
+        var pointer = head
+        var count = 0
+        
+        while pointer != nil {
+            if let node = pointer {
+                pointer = node.next
+                count += 1
+            }
+        }
+        return count
+    }
+}
+
+private extension CalculatorItemQueue {
     var length: Int {
         return list.length
     }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -102,7 +102,7 @@ class CalculatorItemQueueTests: XCTestCase {
     }
 }
 
-private extension LinkedList {
+fileprivate extension LinkedList {
     var length: Int {
         var pointer = head
         var count = 0
@@ -117,7 +117,7 @@ private extension LinkedList {
     }
 }
 
-private extension CalculatorItemQueue {
+fileprivate extension CalculatorItemQueue {
     var length: Int {
         return list.length
     }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -31,6 +31,9 @@ class CalculatorItemQueueTests: XCTestCase {
         let newData = 10
         sut.enqueue(newData)
         let removedItem = sut.dequeue()
+        guard let removedItem = removedItem as? Int else {
+            return
+        }
         XCTAssertEqual(removedItem, newData)
     }
 }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -53,6 +53,13 @@ class CalculatorItemQueueTests: XCTestCase {
         XCTAssertTrue(isSameSequence(sequence: sut.convertToArray, otherSequence: newItems))
     }
     
+    func testCalculatorQueueDequeue_givenRemoveAllOfMultipleMixedItems_expectIsEmpty() {
+        let newItems: [Any] = [20, "+", 30, "-", 2]
+        appendContents(of: newItems, to: &sut)
+        sut.removeAll()
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
     func appendContents(of sequence: [Any], to queue: inout CalculatorItemQueue<Any>) {
         for item in sequence {
             queue.enqueue(item)

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -26,4 +26,10 @@ class CalculatorItemQueueTests: XCTestCase {
         sut.enqueue(newData)
         XCTAssertTrue(sut.isNotEmpty)
     }
+    
+    func testCalculatorItemQueueEnqueue_givenNewInteger_expectFirstItemEqualToInsertedItem() {
+        let newData = 10
+        sut.enqueue(newData)
+        XCTAssertEqual(sut.first, newData)
+    }
 }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -36,4 +36,14 @@ class CalculatorItemQueueTests: XCTestCase {
         }
         XCTAssertEqual(removedItem, newData)
     }
+    
+    func testCalculatorItemQueueDequeue_givenNewOperator_expectFirstItemEqualToInsertedItem() {
+        let newData = "+"
+        sut.enqueue(newData)
+        let removedItem = sut.dequeue()
+        guard let removedItem = removedItem as? String else {
+            return
+        }
+        XCTAssertEqual(removedItem, newData)
+    }
 }

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -6,15 +6,19 @@
 //
 
 import XCTest
+@testable import Calculator
 
 class CalculatorItemQueueTests: XCTestCase {
-
+    var sut: CalculatorItemQueue<Any>!
+    
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        try super.setUpWithError()
+        sut = CalculatorItemQueue()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        try super.tearDownWithError()
+        sut = nil
     }
     
     func testCalculatorItemQueueEnqueue_givenNewInteger_expectNotEmpty() {

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -114,7 +114,7 @@ extension CalculatorItemQueue {
     var convertToArray: [Any] {
         var convertedArray: [Any] = []
         for i in 0..<length {
-            if let node = list.getNode(at: i) {
+            if let node = list.retrieveNode(at: i) {
                 convertedArray.append(node.item)
             }
         }

--- a/Calculator/CalculatorTests/DummyItem.swift
+++ b/Calculator/CalculatorTests/DummyItem.swift
@@ -1,0 +1,14 @@
+//
+//  DummyItem.swift
+//  CalculatorTests
+//
+//  Created by Jun Bang on 2021/11/10.
+//
+
+import XCTest
+@testable import Calculator
+
+enum DummyItem: Equatable, CalculateItem {
+    case number(value: Int)
+    case symbol(value: String)
+}

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -80,7 +80,7 @@ class LinkedListTests: XCTestCase {
     func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
-        let _ = sut.removeHead()
+        sut.removeHead()
         let exepectedItems: [Any] = ["+", 30, "-", 2]
         let convertedExpectedItems = convertToLinkedListArray(from: exepectedItems) as [DummyItem]
         XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedExpectedItems)
@@ -96,7 +96,7 @@ class LinkedListTests: XCTestCase {
     func testLinkedListRemoveHead_givenRemoveAtIndexFromMixedElements_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
-        let _ = sut.removeNode(at: 1)
+        sut.removeNode(at: 1)
         let expectedItems: [Any] = [20, 30, "-", 2]
         let convertedExepectedItems = convertToLinkedListArray(from: expectedItems)
         XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedExepectedItems)
@@ -144,7 +144,7 @@ class LinkedListTests: XCTestCase {
     
     private func removeHeadUntilEmpty(from linkedList: inout LinkedList<Any>) {
         while linkedList.isNotEmpty {
-            let _ = linkedList.removeHead()
+            linkedList.removeHead()
         }
     }
 }
@@ -170,6 +170,7 @@ fileprivate extension LinkedList {
         return listContents
     }
     
+    @discardableResult
     mutating func removeNode(at index: Int) -> Node<T>? {
         guard let toBeRemovedNode = retrieveNode(at: index) else {
             return nil

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -103,6 +103,13 @@ class LinkedListTests: XCTestCase {
         XCTAssertEqual(sut.convertedToLinkedListArray, convertedExpectedItems)
     }
     
+    func testLinkedListRemove_givenMultipleRemovedFront_expectIsEmpty() {
+        let newItems: [Any] = [20, "+", 20, "-", 2]
+        appendContents(of: newItems, to: &sut)
+        removeFrontUntilEmpty()
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
     private func hasEqualItems(node: Node<Any>?, item: LinkedListItem) -> Bool {
         guard let node = node else {
             return false

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -46,6 +46,13 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(hasEqualItems(node: sut.first, item: firstItem))
     }
     
+    func testLinkedListAppend_givenNewIntegers_expectTailEqualToLastItem() {
+        let newItems = [1, 2, 3, 4]
+        let lastItem = newItems.last
+        appendContents(of: newItems, to: &sut)
+        XCTAssertTrue(hasEqualItems(node: sut.last, item: lastItem))
+    }
+    
     private func hasEqualItems(node: Node<Any>?, item: Int) -> Bool {
         guard let node = node else {
             return false

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -53,6 +53,12 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(hasEqualItems(node: sut.last, item: lastInsertedItem))
     }
     
+    func testLinkedListAppend_givenNewIntegers_expectSameElements() {
+        let newItems = [1,2,3,4,5,6,7,8,9,10]
+        appendContents(of: newItems, to: &sut)
+        XCTAssertEqual(sut.convertStoredElementsToArray(), newItems)
+    }
+    
     private func hasEqualItems(node: Node<Any>?, item: Int) -> Bool {
         guard let node = node else {
             return false

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -31,21 +31,21 @@ class LinkedListTests: XCTestCase {
         let newItems = [1, 2]
         appendContents(of: newItems, to: &sut)
         let firstInsertedItem = DummyItem.number(value: newItems[0])
-        XCTAssertTrue(hasEqualItems(node: sut.head, item: firstInsertedItem))
+        XCTAssertTrue(hasEqualItems(node: sut.first, item: firstInsertedItem))
     }
     
     func testLinkedListAppend_givenNewIntegers_expectTailEqualToLastInsertedItem() {
         let newItems = [1, 2, 3, 4]
         appendContents(of: newItems, to: &sut)
         let lastInsertedItem = DummyItem.number(value: newItems[newItems.count-1])
-        XCTAssertTrue(hasEqualItems(node: sut.tail, item: lastInsertedItem))
+        XCTAssertTrue(hasEqualItems(node: sut.last, item: lastInsertedItem))
     }
-    
+
     func testLinkedListNode_givenNewOperator_expectHeadEqualToInsertedItem() {
         let newCharacter = "+"
         sut.append(newCharacter)
         let newInsertedItem = DummyItem.symbol(value: newCharacter)
-        XCTAssertTrue(hasEqualItems(node: sut.head, item: newInsertedItem))
+        XCTAssertTrue(hasEqualItems(node: sut.first, item: newInsertedItem))
     }
     
     func testLinkedListAppend_givenNewIntegers_expectCorrectSequence() {
@@ -69,7 +69,7 @@ class LinkedListTests: XCTestCase {
         XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedNewItems)
     }
     
-    func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualToFirstInsertedItem() {
+    func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualsFirstInsertedItem() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         let removedNode = sut.removeHead()
@@ -141,17 +141,10 @@ class LinkedListTests: XCTestCase {
 }
 
 fileprivate extension LinkedList {
-    var first: T? {
-        guard let head = head else {
-            return nil
-        }
-        return head.item
-    }
-    
     var convertedToLinkedListItemArray: [DummyItem] {
-        var pointer = head
+        var pointer = first
         var listContents: [DummyItem] = []
-        
+
         while pointer != nil {
             if let node = pointer, let value = node.convertToLinkedListItem {
                 listContents.append(value)

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -98,12 +98,13 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
-    func testLinkedListRemove_givenIndexOfNodeFromMixedElements_expectCorrectItem() {
+    func testLinkedListRemoveHead_givenRemoveAtIndexFromMixedElements_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
         appendContents(of: newItems, to: &sut)
-        let removedNode = sut.remove(at: 1)
-        let itemAtFirstIndex = convertToLinkedListItem(value: newItems[1])
-        XCTAssertTrue(hasEqualItems(node: removedNode, item: itemAtFirstIndex))
+        let _ = sut.removeNode(at: 1)
+        let expectedItems: [Any] = [20, 20, "-", 2]
+        let convertedExepectedItems = convertToLinkedListArray(from: expectedItems)
+        XCTAssertEqual(sut.convertedToLinkedListArray, convertedExepectedItems)
     }
     
     func testLinkedListRemoveAll_givenRemoveAllFromElements_expectIsEmpty() {
@@ -178,17 +179,12 @@ extension LinkedList {
         return listContents
     }
     
-    func getNode(at index: Int) -> Node<T>? {
-        guard isNotEmpty else {
+    mutating func removeNode(at index: Int) -> Node<T>? {
+        guard let toBeRemovedNode = getNode(at: index) else {
             return nil
         }
-        var currentNode = head
-        for _ in 0..<index {
-            if let node = currentNode {
-                currentNode = node.next
-            }
-        }
-        return currentNode
+        let removedNode = remove(node: toBeRemovedNode)
+        return removedNode
     }
 }
 

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -15,17 +15,17 @@ class LinkedListTests: XCTestCase {
         try super.setUpWithError()
         sut = LinkedList()
     }
-
+    
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         sut = nil
     }
-
+    
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
-
+    
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         measure {
@@ -37,5 +37,21 @@ class LinkedListTests: XCTestCase {
         let newItem = 10
         sut.append(newItem)
         XCTAssertTrue(sut.isNotEmpty)
+    }
+    
+    func testLinkedListAppend_givenNewIntegers_expectHeadEqualtoFirstItem() {
+        let newItems = [1, 2]
+        let firstItem = newItems[0]
+        for item in newItems {
+            sut.append(item)
+        }
+        XCTAssertTrue(hasEqualItems(node: sut.first, item: firstItem))
+    }
+    
+    private func hasEqualItems(node: Node?, item: Int) -> Bool {
+        guard let node = node else {
+            return false
+        }
+        return node.item == item
     }
 }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import Calculator
 
 class LinkedListTests: XCTestCase {
-    var sut: LinkedList!
+    var sut: LinkedList<Any>!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -48,10 +48,10 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(hasEqualItems(node: sut.first, item: firstItem))
     }
     
-    private func hasEqualItems(node: Node?, item: Int) -> Bool {
+    private func hasEqualItems(node: Node<Any>?, item: Int) -> Bool {
         guard let node = node else {
             return false
         }
-        return node.item == item
+        return node.item as? Int == item
     }
 }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -149,25 +149,12 @@ class LinkedListTests: XCTestCase {
     }
 }
 
-extension LinkedList {
+private extension LinkedList {
     var first: T? {
         guard let head = head else {
             return nil
         }
         return head.item
-    }
-    
-    var length: Int {
-        var pointer = head
-        var count = 0
-        
-        while pointer != nil {
-            if let node = pointer {
-                pointer = node.next
-                count += 1
-            }
-        }
-        return count
     }
     
     var convertedToLinkedListItemArray: [DummyItem] {
@@ -192,7 +179,7 @@ extension LinkedList {
     }
 }
 
-extension Node {
+private extension Node {
     var convertToLinkedListItem: DummyItem? {
         if let number = item as? Int {
             return DummyItem.number(value: number)

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -150,6 +150,13 @@ class LinkedListTests: XCTestCase {
 }
 
 extension LinkedList {
+    var first: T? {
+        guard let head = head else {
+            return nil
+        }
+        return head.item
+    }
+    
     var length: Int {
         var pointer = head
         var count = 0
@@ -175,7 +182,7 @@ extension LinkedList {
     }
     
     mutating func removeNode(at index: Int) -> Node<T>? {
-        guard let toBeRemovedNode = getNode(at: index) else {
+        guard let toBeRemovedNode = retrieveNode(at: index) else {
             return nil
         }
         let removedNode = remove(node: toBeRemovedNode)

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -90,7 +90,7 @@ class LinkedListTests: XCTestCase {
         let newItems: [Any] = [20, "+", 20, "-", 2]
         let firstItem = LinkedListItem.number(value: 20)
         appendContents(of: newItems, to: &sut)
-        let removedNode = sut.removeFront()
+        let removedNode = sut.removeHead()
         XCTAssertTrue(hasEqualItems(node: removedNode, item: firstItem))
     }
     

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -93,15 +93,6 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
-    func testLinkedListRemoveHead_givenRemoveAtIndexFromMixedElements_expectCorrectSequence() {
-        let newItems: [Any] = [20, "+", 30, "-", 2]
-        appendContents(of: newItems, to: &sut)
-        sut.removeNode(at: 1)
-        let expectedItems: [Any] = [20, 30, "-", 2]
-        let convertedExepectedItems = convertToLinkedListArray(from: expectedItems)
-        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedExepectedItems)
-    }
-    
     func testLinkedListRemoveAll_givenRemoveAllFromElements_expectIsEmpty() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
@@ -168,15 +159,6 @@ fileprivate extension LinkedList {
             }
         }
         return listContents
-    }
-    
-    @discardableResult
-    mutating func removeNode(at index: Int) -> Node<T>? {
-        guard let toBeRemovedNode = retrieveNode(at: index) else {
-            return nil
-        }
-        let removedNode = remove(node: toBeRemovedNode)
-        return removedNode
     }
 }
 

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -6,15 +6,18 @@
 //
 
 import XCTest
-
+@testable import Calculator
 class LinkedListTests: XCTestCase {
-
+    var sut: LinkedList!
+    
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        try super.setUpWithError()
+        sut = LinkedList()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        try super.tearDownWithError()
+        sut = nil
     }
 
     func testExample() throws {
@@ -30,8 +33,8 @@ class LinkedListTests: XCTestCase {
     }
     
     func testLinkedListAppend_givenNewNode_expectNotEmpty() {
-        let newNode = Node(10)
-        sut.append(newNode)
+        let newItem = 10
+        sut.append(newItem)
         XCTAssertTrue(sut.isNotEmpty)
     }
 }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -98,6 +98,13 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
+    func testLinkedListRemoveAll_givenRemoveAllFromElements_expectIsEmpty() {
+        let newItems: [Any] = [20, "+", 20, "-", 2]
+        appendContents(of: newItems, to: &sut)
+        sut.removeAll()
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
     private func hasEqualItems(node: Node<Any>?, item: LinkedListItem) -> Bool {
         guard let node = node else {
             return false

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 @testable import Calculator
+
 class LinkedListTests: XCTestCase {
     var sut: LinkedList!
     

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -98,6 +98,14 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
+    func testLinkedListRemove_givenIndexOfNodeFromMixedElements_expectCorrectItem() {
+        let newItems: [Any] = [20, "+", 20, "-", 2]
+        appendContents(of: newItems, to: &sut)
+        let removedNode = sut.remove(at: 1)
+        let itemAtFirstIndex = convertToLinkedListItem(value: newItems[1])
+        XCTAssertTrue(hasEqualItems(node: removedNode, item: itemAtFirstIndex))
+    }
+    
     func testLinkedListRemoveAll_givenRemoveAllFromElements_expectIsEmpty() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
         appendContents(of: newItems, to: &sut)

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -42,9 +42,7 @@ class LinkedListTests: XCTestCase {
     func testLinkedListAppend_givenNewIntegers_expectHeadEqualtoFirstItem() {
         let newItems = [1, 2]
         let firstItem = newItems[0]
-        for item in newItems {
-            sut.append(item)
-        }
+        appendContents(of: newItems, to: &sut)
         XCTAssertTrue(hasEqualItems(node: sut.first, item: firstItem))
     }
     
@@ -53,5 +51,11 @@ class LinkedListTests: XCTestCase {
             return false
         }
         return node.item as? Int == item
+    }
+    
+    private func appendContents(of items: [Any], to linkedList: inout LinkedList<Any>) {
+        for item in items {
+            linkedList.append(item)
+        }
     }
 }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -72,25 +72,9 @@ class LinkedListTests: XCTestCase {
     func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualsFirstInsertedItem() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
-        let removedNode = sut.removeHead()
+        let removedValue = sut.retrieveHeadValue()
         let firstInsertedItem = DummyItem.number(value: 20)
-        XCTAssertTrue(hasEqualItems(node: removedNode, item: firstInsertedItem))
-    }
-    
-    func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectCorrectSequence() {
-        let newItems: [Any] = [20, "+", 30, "-", 2]
-        appendContents(of: newItems, to: &sut)
-        sut.removeHead()
-        let exepectedItems: [Any] = ["+", 30, "-", 2]
-        let convertedExpectedItems = convertToLinkedListArray(from: exepectedItems) as [DummyItem]
-        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedExpectedItems)
-    }
-    
-    func testLinkedListRemoveHead_givenMultipleRemovedHeadFromMixedElements_expectIsEmpty() {
-        let newItems: [Any] = [20, "+", 30, "-", 2]
-        appendContents(of: newItems, to: &sut)
-        removeHeadUntilEmpty(from: &sut)
-        XCTAssertTrue(sut.isEmpty)
+        XCTAssertEqual(convertToLinkedListItem(value: removedValue as Any), firstInsertedItem)
     }
     
     func testLinkedListRemoveAll_givenRemoveAllFromElements_expectIsEmpty() {
@@ -130,12 +114,6 @@ class LinkedListTests: XCTestCase {
     private func appendContents(of items: [Any], to linkedList: inout LinkedList<Any>) {
         for item in items {
             linkedList.append(item)
-        }
-    }
-    
-    private func removeHeadUntilEmpty(from linkedList: inout LinkedList<Any>) {
-        while linkedList.isNotEmpty {
-            linkedList.removeHead()
         }
     }
 }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -105,6 +105,14 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
+    func testLinkedListRemoveAll_givenRemoveAllFromElements_expectCleanMemory() {
+        let newItems: [Any] = [20, "+", 20, "-", 2]
+        appendContents(of: newItems, to: &sut)
+        let secondNode = sut.getNode(at: 1)
+        sut.removeAll()
+        XCTAssertEqual(secondNode, nil)
+    }
+    
     private func hasEqualItems(node: Node<Any>?, item: LinkedListItem) -> Bool {
         guard let node = node else {
             return false

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -8,11 +8,9 @@
 import XCTest
 @testable import Calculator
 
-enum Operator: Character {
-    case plus = "+"
-    case minus = "-"
-    case multiply = "*"
-    case division = "/"
+enum LinkedListItem: Equatable {
+    case number(value: Int)
+    case symbol(value: Character)
 }
 
 class LinkedListTests: XCTestCase {
@@ -48,41 +46,70 @@ class LinkedListTests: XCTestCase {
     
     func testLinkedListAppend_givenNewIntegers_expectHeadEqualToFirstItem() {
         let newItems = [1, 2]
-        let firstInsertedItem = newItems[0]
+        let firstInsertedItem = LinkedListItem.number(value: newItems[0])
         appendContents(of: newItems, to: &sut)
         XCTAssertTrue(hasEqualItems(node: sut.head, item: firstInsertedItem))
     }
     
     func testLinkedListAppend_givenNewIntegers_expectTailEqualToLastItem() {
         let newItems = [1, 2, 3, 4]
-        let lastInsertedItem = newItems[newItems.count-1]
+        let lastInsertedItem = LinkedListItem.number(value: newItems[newItems.count-1])
         appendContents(of: newItems, to: &sut)
         XCTAssertTrue(hasEqualItems(node: sut.tail, item: lastInsertedItem))
     }
     
+    func testLinkedListNode_givenNewCharacter_expectHeadEqualToItem() {
+        let newCharacter: Character = "+"
+        let newItem = LinkedListItem.symbol(value: newCharacter)
+        sut.append(newCharacter)
+        XCTAssertTrue(hasEqualItems(node: sut.head, item: newItem))
+    }
+    
     func testLinkedListAppend_givenNewIntegers_expectSameElements() {
         let newItems = [1,2,3,4,5,6,7,8,9,10]
+        let convertedItems = convertToLinkedListArray(from: newItems)
         appendContents(of: newItems, to: &sut)
-        XCTAssertEqual(sut.convertedToIntArray, newItems)
+        XCTAssertEqual(sut.convertedToLinkedListArray, convertedItems)
     }
     
     func testLinkedListAppend_givenNewOperators_expectSameElements() {
-        let newItems: [Operator] = [.plus, .minus, .multiply, .division]
+        let newItems: [Character] = ["+", "-", "*", "/"]
+        let convertedItems = convertToLinkedListArray(from: newItems)
         appendContents(of: newItems, to: &sut)
-        XCTAssertEqual(sut.convertedToCharacterArray, newItems)
+        XCTAssertEqual(sut.convertedToLinkedListArray, convertedItems)
     }
     
     func testLinkedListAppend_givenMixedElements_expectSameElements() {
-        let newItems: [Any] = [10, Operator.plus, 20, Operator.division, 2]
+        let newItems: [LinkedListItem] = [.number(value: 10), .symbol(value: "+"), .number(value: 20), .symbol(value: "/"), .number(value: 2)]
         appendContents(of: newItems, to: &sut)
-        XCTAssertEqual(sut.convertedToArray, newItems)
+        XCTAssertEqual(sut.convertedToLinkedListArray, newItems)
     }
     
-    private func hasEqualItems(node: Node<Any>?, item: Int) -> Bool {
+    private func hasEqualItems(node: Node<Any>?, item: LinkedListItem) -> Bool {
         guard let node = node else {
             return false
         }
-        return node.item as? Int == item
+        return node.convertToLinkedListItem == item
+    }
+    
+    private func convertToLinkedListArray(from sequence: [Any]) -> [LinkedListItem] {
+        var linkedListItemArray: [LinkedListItem] = []
+        for item in sequence {
+            if let convertedItem = convertToLinkedListItem(value: item) {
+                linkedListItemArray.append(convertedItem)
+            }
+        }
+        return linkedListItemArray
+    }
+    
+    private func convertToLinkedListItem(value: Any) -> LinkedListItem? {
+        if let value = value as? Int {
+            return LinkedListItem.number(value: value)
+        }
+        if let value = value as? Character {
+            return LinkedListItem.symbol(value: value)
+        }
+        return nil
     }
     
     private func appendContents(of items: [Any], to linkedList: inout LinkedList<Any>) {
@@ -93,27 +120,53 @@ class LinkedListTests: XCTestCase {
 }
 
 extension LinkedList {
-    var convertedToIntArray: [Int] {
+    var length: Int {
         var pointer = head
-        var listContents: [Int] = []
+        var count = 0
         while pointer != nil {
-            if let node = pointer, let value = node.item as? Int {
+            if let node = pointer {
+                pointer = node.next
+                count += 1
+            }
+        }
+        return count
+    }
+    
+    var convertedToLinkedListArray: [LinkedListItem] {
+        var pointer = head
+        var listContents: [LinkedListItem] = []
+        while pointer != nil {
+            if let node = pointer, let value = node.convertToLinkedListItem {
                 listContents.append(value)
                 pointer = node.next
             }
         }
         return listContents
     }
-    
-    var convertedToCharacterArray: [Operator] {
-        var pointer = head
-        var listContents: [Operator] = []
-        while pointer != nil {
-            if let node = pointer, let value = node.item as? Operator {
-                listContents.append(value)
-                pointer = node.next
-            }
+}
+
+extension Node {
+    var convertToLinkedListItem: LinkedListItem? {
+        if let number = item as? Int {
+            return LinkedListItem.number(value: number)
         }
-        return listContents
+        if let symbol = item as? Character {
+            return LinkedListItem.symbol(value: symbol)
+        }
+        return nil
+    }
+    
+    var convertToInt: Int? {
+        guard let value = item as? Int else {
+            return nil
+        }
+        return value
+    }
+    
+    var convertToCharacter: Character? {
+        guard let value = item as? Character else {
+            return nil
+        }
+        return value
     }
 }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -43,20 +43,20 @@ class LinkedListTests: XCTestCase {
         let newItems = [1, 2]
         let firstInsertedItem = newItems[0]
         appendContents(of: newItems, to: &sut)
-        XCTAssertTrue(hasEqualItems(node: sut.first, item: firstInsertedItem))
+        XCTAssertTrue(hasEqualItems(node: sut.head, item: firstInsertedItem))
     }
     
     func testLinkedListAppend_givenNewIntegers_expectTailEqualToLastItem() {
         let newItems = [1, 2, 3, 4]
         let lastInsertedItem = newItems[newItems.count-1]
         appendContents(of: newItems, to: &sut)
-        XCTAssertTrue(hasEqualItems(node: sut.last, item: lastInsertedItem))
+        XCTAssertTrue(hasEqualItems(node: sut.tail, item: lastInsertedItem))
     }
     
     func testLinkedListAppend_givenNewIntegers_expectSameElements() {
         let newItems = [1,2,3,4,5,6,7,8,9,10]
         appendContents(of: newItems, to: &sut)
-        XCTAssertEqual(sut.convertStoredElementsToArray(), newItems)
+        XCTAssertEqual(sut.convertedToIntArray, newItems)
     }
     
     private func hasEqualItems(node: Node<Any>?, item: Int) -> Bool {
@@ -70,5 +70,19 @@ class LinkedListTests: XCTestCase {
         for item in items {
             linkedList.append(item)
         }
+    }
+}
+
+extension LinkedList {
+    var convertedToIntArray: [Int] {
+        var pointer = head
+        var listContents: [Int] = []
+        while pointer != nil {
+            if let node = pointer, let value = node.item as? Int {
+                listContents.append(value)
+                pointer = node.next
+            }
+        }
+        return listContents
     }
 }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -8,11 +8,6 @@
 import XCTest
 @testable import Calculator
 
-enum LinkedListItem: Equatable, CalculateItem {
-    case number(value: Int)
-    case symbol(value: String)
-}
-
 class LinkedListTests: XCTestCase {
     var sut: LinkedList<Any>!
     
@@ -35,21 +30,21 @@ class LinkedListTests: XCTestCase {
     func testLinkedListAppend_givenNewIntegers_expectHeadEqualToFirstInsertedItem() {
         let newItems = [1, 2]
         appendContents(of: newItems, to: &sut)
-        let firstInsertedItem = LinkedListItem.number(value: newItems[0])
+        let firstInsertedItem = DummyItem.number(value: newItems[0])
         XCTAssertTrue(hasEqualItems(node: sut.head, item: firstInsertedItem))
     }
     
     func testLinkedListAppend_givenNewIntegers_expectTailEqualToLastInsertedItem() {
         let newItems = [1, 2, 3, 4]
         appendContents(of: newItems, to: &sut)
-        let lastInsertedItem = LinkedListItem.number(value: newItems[newItems.count-1])
+        let lastInsertedItem = DummyItem.number(value: newItems[newItems.count-1])
         XCTAssertTrue(hasEqualItems(node: sut.tail, item: lastInsertedItem))
     }
     
     func testLinkedListNode_givenNewOperator_expectHeadEqualToInsertedItem() {
         let newCharacter = "+"
         sut.append(newCharacter)
-        let newInsertedItem = LinkedListItem.symbol(value: newCharacter)
+        let newInsertedItem = DummyItem.symbol(value: newCharacter)
         XCTAssertTrue(hasEqualItems(node: sut.head, item: newInsertedItem))
     }
     
@@ -70,7 +65,7 @@ class LinkedListTests: XCTestCase {
     func testLinkedListAppend_givenMixedElements_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
-        let convertedNewItems = convertToLinkedListArray(from: newItems) as [LinkedListItem]
+        let convertedNewItems = convertToLinkedListArray(from: newItems) as [DummyItem]
         XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedNewItems)
     }
     
@@ -78,7 +73,7 @@ class LinkedListTests: XCTestCase {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         let removedNode = sut.removeHead()
-        let firstInsertedItem = LinkedListItem.number(value: 20)
+        let firstInsertedItem = DummyItem.number(value: 20)
         XCTAssertTrue(hasEqualItems(node: removedNode, item: firstInsertedItem))
     }
     
@@ -87,7 +82,7 @@ class LinkedListTests: XCTestCase {
         appendContents(of: newItems, to: &sut)
         let _ = sut.removeHead()
         let exepectedItems: [Any] = ["+", 30, "-", 2]
-        let convertedExpectedItems = convertToLinkedListArray(from: exepectedItems) as [LinkedListItem]
+        let convertedExpectedItems = convertToLinkedListArray(from: exepectedItems) as [DummyItem]
         XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedExpectedItems)
     }
     
@@ -114,15 +109,15 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
-    private func hasEqualItems(node: Node<Any>?, item: LinkedListItem) -> Bool {
+    private func hasEqualItems(node: Node<Any>?, item: DummyItem) -> Bool {
         guard let node = node else {
             return false
         }
         return node.convertToLinkedListItem == item
     }
     
-    private func convertToLinkedListArray(from sequence: [Any]) -> [LinkedListItem] {
-        var linkedListItemArray: [LinkedListItem] = []
+    private func convertToLinkedListArray(from sequence: [Any]) -> [DummyItem] {
+        var linkedListItemArray: [DummyItem] = []
         for item in sequence {
             if let convertedItem = convertToLinkedListItem(value: item) {
                 linkedListItemArray.append(convertedItem)
@@ -131,12 +126,12 @@ class LinkedListTests: XCTestCase {
         return linkedListItemArray
     }
     
-    private func convertToLinkedListItem(value: Any) -> LinkedListItem? {
+    private func convertToLinkedListItem(value: Any) -> DummyItem? {
         if let value = value as? Int {
-            return LinkedListItem.number(value: value)
+            return DummyItem.number(value: value)
         }
         if let value = value as? String {
-            return LinkedListItem.symbol(value: value)
+            return DummyItem.symbol(value: value)
         }
         return nil
     }
@@ -167,9 +162,9 @@ extension LinkedList {
         return count
     }
     
-    var convertedToLinkedListItemArray: [LinkedListItem] {
+    var convertedToLinkedListItemArray: [DummyItem] {
         var pointer = head
-        var listContents: [LinkedListItem] = []
+        var listContents: [DummyItem] = []
         while pointer != nil {
             if let node = pointer, let value = node.convertToLinkedListItem {
                 listContents.append(value)
@@ -189,12 +184,12 @@ extension LinkedList {
 }
 
 extension Node {
-    var convertToLinkedListItem: LinkedListItem? {
+    var convertToLinkedListItem: DummyItem? {
         if let number = item as? Int {
-            return LinkedListItem.number(value: number)
+            return DummyItem.number(value: number)
         }
         if let symbol = item as? String {
-            return LinkedListItem.symbol(value: symbol)
+            return DummyItem.symbol(value: symbol)
         }
         return nil
     }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import Calculator
 
-enum LinkedListItem: Equatable {
+enum LinkedListItem: Equatable, CalculateItem {
     case number(value: Int)
     case symbol(value: String)
 }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -26,84 +26,72 @@ class LinkedListTests: XCTestCase {
         sut = nil
     }
     
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-    
     func testLinkedListAppend_givenNewNode_expectNotEmpty() {
         let newItem = 10
         sut.append(newItem)
         XCTAssertTrue(sut.isNotEmpty)
     }
     
-    func testLinkedListAppend_givenNewIntegers_expectHeadEqualToFirstItem() {
+    func testLinkedListAppend_givenNewIntegers_expectHeadEqualToFirstInsertedItem() {
         let newItems = [1, 2]
-        let firstInsertedItem = LinkedListItem.number(value: newItems[0])
         appendContents(of: newItems, to: &sut)
+        let firstInsertedItem = LinkedListItem.number(value: newItems[0])
         XCTAssertTrue(hasEqualItems(node: sut.head, item: firstInsertedItem))
     }
     
-    func testLinkedListAppend_givenNewIntegers_expectTailEqualToLastItem() {
+    func testLinkedListAppend_givenNewIntegers_expectTailEqualToLastInsertedItem() {
         let newItems = [1, 2, 3, 4]
-        let lastInsertedItem = LinkedListItem.number(value: newItems[newItems.count-1])
         appendContents(of: newItems, to: &sut)
+        let lastInsertedItem = LinkedListItem.number(value: newItems[newItems.count-1])
         XCTAssertTrue(hasEqualItems(node: sut.tail, item: lastInsertedItem))
     }
     
-    func testLinkedListNode_givenNewCharacter_expectHeadEqualToItem() {
+    func testLinkedListNode_givenNewOperator_expectHeadEqualToInsertedItem() {
         let newCharacter = "+"
-        let newItem = LinkedListItem.symbol(value: newCharacter)
         sut.append(newCharacter)
-        XCTAssertTrue(hasEqualItems(node: sut.head, item: newItem))
+        let newInsertedItem = LinkedListItem.symbol(value: newCharacter)
+        XCTAssertTrue(hasEqualItems(node: sut.head, item: newInsertedItem))
     }
     
-    func testLinkedListAppend_givenNewIntegers_expectSameElements() {
+    func testLinkedListAppend_givenNewIntegers_expectCorrectSequence() {
         let newItems = [1,2,3,4,5,6,7,8,9,10]
-        let convertedItems = convertToLinkedListArray(from: newItems)
         appendContents(of: newItems, to: &sut)
-        XCTAssertEqual(sut.convertedToLinkedListArray, convertedItems)
+        let convertedNewItems = convertToLinkedListArray(from: newItems)
+        XCTAssertEqual(sut.convertedToLinkedListArray, convertedNewItems)
     }
     
-    func testLinkedListAppend_givenNewOperators_expectSameElements() {
+    func testLinkedListAppend_givenNewOperators_expectCorrectSequence() {
         let newItems = ["+", "-", "*", "/"]
-        let convertedItems = convertToLinkedListArray(from: newItems)
         appendContents(of: newItems, to: &sut)
-        XCTAssertEqual(sut.convertedToLinkedListArray, convertedItems)
+        let convertedNewItems = convertToLinkedListArray(from: newItems)
+        XCTAssertEqual(sut.convertedToLinkedListArray, convertedNewItems)
     }
     
-    func testLinkedListAppend_givenMixedElements_expectSameElements() {
+    func testLinkedListAppend_givenMixedElements_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
-        let convertedItems: [LinkedListItem] = convertToLinkedListArray(from: newItems)
         appendContents(of: newItems, to: &sut)
-        XCTAssertEqual(sut.convertedToLinkedListArray, convertedItems)
+        let convertedNewItems = convertToLinkedListArray(from: newItems) as [LinkedListItem]
+        XCTAssertEqual(sut.convertedToLinkedListArray, convertedNewItems)
     }
     
-    func testLinkedListRemove_givenRemovedFront_expectCorrectElement() {
+    func testLinkedListRemove_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualToFirstInsertedItem() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
-        let firstItem = LinkedListItem.number(value: 20)
         appendContents(of: newItems, to: &sut)
         let removedNode = sut.removeHead()
-        XCTAssertTrue(hasEqualItems(node: removedNode, item: firstItem))
+        let firstInsertedItem = LinkedListItem.number(value: 20)
+        XCTAssertTrue(hasEqualItems(node: removedNode, item: firstInsertedItem))
     }
     
-    func testLinkedListRemove_givenRemovedFront_expectCorrectElements() {
+    func testLinkedListRemove_givenRemovedHeadFromMixedElements_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
         appendContents(of: newItems, to: &sut)
         let _ = sut.removeHead()
         let exepectedItems: [Any] = ["+", 20, "-", 2]
-        let convertedExpectedItems: [LinkedListItem] = convertToLinkedListArray(from: exepectedItems)
+        let convertedExpectedItems = convertToLinkedListArray(from: exepectedItems) as [LinkedListItem]
         XCTAssertEqual(sut.convertedToLinkedListArray, convertedExpectedItems)
     }
     
-    func testLinkedListRemove_givenMultipleRemovedFront_expectIsEmpty() {
+    func testLinkedListRemove_givenMultipleRemovedHeadFromMixedElements_expectIsEmpty() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
         appendContents(of: newItems, to: &sut)
         removeHeadUntilEmpty(from: &sut)

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -48,7 +48,7 @@ class LinkedListTests: XCTestCase {
     
     func testLinkedListAppend_givenNewIntegers_expectTailEqualToLastItem() {
         let newItems = [1, 2, 3, 4]
-        let lastItem = newItems.last
+        let lastItem = newItems[newItems.count-1]
         appendContents(of: newItems, to: &sut)
         XCTAssertTrue(hasEqualItems(node: sut.last, item: lastItem))
     }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -160,6 +160,7 @@ extension LinkedList {
     var length: Int {
         var pointer = head
         var count = 0
+        
         while pointer != nil {
             if let node = pointer {
                 pointer = node.next
@@ -172,6 +173,7 @@ extension LinkedList {
     var convertedToLinkedListItemArray: [DummyItem] {
         var pointer = head
         var listContents: [DummyItem] = []
+        
         while pointer != nil {
             if let node = pointer, let value = node.convertToLinkedListItem {
                 listContents.append(value)

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -149,7 +149,7 @@ class LinkedListTests: XCTestCase {
     }
 }
 
-private extension LinkedList {
+fileprivate extension LinkedList {
     var first: T? {
         guard let head = head else {
             return nil
@@ -179,7 +179,7 @@ private extension LinkedList {
     }
 }
 
-private extension Node {
+fileprivate extension Node {
     var convertToLinkedListItem: DummyItem? {
         if let number = item as? Int {
             return DummyItem.number(value: number)

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -74,7 +74,7 @@ class LinkedListTests: XCTestCase {
         XCTAssertEqual(sut.convertedToLinkedListArray, convertedNewItems)
     }
     
-    func testLinkedListRemove_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualToFirstInsertedItem() {
+    func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualToFirstInsertedItem() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
         appendContents(of: newItems, to: &sut)
         let removedNode = sut.removeHead()
@@ -82,7 +82,7 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(hasEqualItems(node: removedNode, item: firstInsertedItem))
     }
     
-    func testLinkedListRemove_givenRemovedHeadFromMixedElements_expectCorrectSequence() {
+    func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
         appendContents(of: newItems, to: &sut)
         let _ = sut.removeHead()
@@ -91,7 +91,7 @@ class LinkedListTests: XCTestCase {
         XCTAssertEqual(sut.convertedToLinkedListArray, convertedExpectedItems)
     }
     
-    func testLinkedListRemove_givenMultipleRemovedHeadFromMixedElements_expectIsEmpty() {
+    func testLinkedListRemoveHead_givenMultipleRemovedHeadFromMixedElements_expectIsEmpty() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
         appendContents(of: newItems, to: &sut)
         removeHeadUntilEmpty(from: &sut)

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -94,6 +94,15 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(hasEqualItems(node: removedNode, item: firstItem))
     }
     
+    func testLinkedListRemove_givenRemovedFront_expectCorrectElements() {
+        let newItems: [Any] = [20, "+", 20, "-", 2]
+        appendContents(of: newItems, to: &sut)
+        let _ = sut.removeHead()
+        let exepectedItems: [Any] = ["+", 20, "-", 2]
+        let convertedExpectedItems: [LinkedListItem] = convertToLinkedListArray(from: exepectedItems)
+        XCTAssertEqual(sut.convertedToLinkedListArray, convertedExpectedItems)
+    }
+    
     private func hasEqualItems(node: Node<Any>?, item: LinkedListItem) -> Bool {
         guard let node = node else {
             return false

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -60,7 +60,7 @@ class LinkedListTests: XCTestCase {
     }
     
     func testLinkedListAppend_givenNewOperators_expectSameElements() {
-        let newItems = ["+", "-", "/", "*"]
+        let newItems: [Character] = ["+", "-", "/", "*"]
         appendContents(of: newItems, to: &sut)
         XCTAssertEqual(sut.convertedToCharacterArray, newItems)
     }
@@ -85,6 +85,18 @@ extension LinkedList {
         var listContents: [Int] = []
         while pointer != nil {
             if let node = pointer, let value = node.item as? Int {
+                listContents.append(value)
+                pointer = node.next
+            }
+        }
+        return listContents
+    }
+    
+    var convertedToCharacterArray: [Character] {
+        var pointer = head
+        var listContents: [Character] = []
+        while pointer != nil {
+            if let node = pointer, let value = node.item as? Character {
                 listContents.append(value)
                 pointer = node.next
             }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -72,6 +72,12 @@ class LinkedListTests: XCTestCase {
         XCTAssertEqual(sut.convertedToCharacterArray, newItems)
     }
     
+    func testLinkedListAppend_givenMixedElements_expectSameElements() {
+        let newItems: [Any] = [10, Operator.plus, 20, Operator.division, 2]
+        appendContents(of: newItems, to: &sut)
+        XCTAssertEqual(sut.convertedToArray, newItems)
+    }
+    
     private func hasEqualItems(node: Node<Any>?, item: Int) -> Bool {
         guard let node = node else {
             return false

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -8,6 +8,13 @@
 import XCTest
 @testable import Calculator
 
+enum Operator: Character {
+    case plus = "+"
+    case minus = "-"
+    case multiply = "*"
+    case division = "/"
+}
+
 class LinkedListTests: XCTestCase {
     var sut: LinkedList<Any>!
     
@@ -60,7 +67,7 @@ class LinkedListTests: XCTestCase {
     }
     
     func testLinkedListAppend_givenNewOperators_expectSameElements() {
-        let newItems: [Character] = ["+", "-", "/", "*"]
+        let newItems: [Operator] = [.plus, .minus, .multiply, .division]
         appendContents(of: newItems, to: &sut)
         XCTAssertEqual(sut.convertedToCharacterArray, newItems)
     }
@@ -92,11 +99,11 @@ extension LinkedList {
         return listContents
     }
     
-    var convertedToCharacterArray: [Character] {
+    var convertedToCharacterArray: [Operator] {
         var pointer = head
-        var listContents: [Character] = []
+        var listContents: [Operator] = []
         while pointer != nil {
-            if let node = pointer, let value = node.item as? Character {
+            if let node = pointer, let value = node.item as? Operator {
                 listContents.append(value)
                 pointer = node.next
             }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -52,21 +52,21 @@ class LinkedListTests: XCTestCase {
         let newItems = [1,2,3,4,5,6,7,8,9,10]
         appendContents(of: newItems, to: &sut)
         let convertedNewItems = convertToLinkedListArray(from: newItems)
-        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedNewItems)
+        XCTAssertEqual(sut.convertedToDummyItemArray, convertedNewItems)
     }
     
     func testLinkedListAppend_givenNewOperators_expectCorrectSequence() {
         let newItems = ["+", "-", "*", "/"]
         appendContents(of: newItems, to: &sut)
         let convertedNewItems = convertToLinkedListArray(from: newItems)
-        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedNewItems)
+        XCTAssertEqual(sut.convertedToDummyItemArray, convertedNewItems)
     }
     
     func testLinkedListAppend_givenMixedElements_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         let convertedNewItems = convertToLinkedListArray(from: newItems) as [DummyItem]
-        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedNewItems)
+        XCTAssertEqual(sut.convertedToDummyItemArray, convertedNewItems)
     }
     
     func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualsFirstInsertedItem() {
@@ -88,7 +88,7 @@ class LinkedListTests: XCTestCase {
         guard let node = node else {
             return false
         }
-        return node.convertToLinkedListItem == item
+        return node.convertToDummyItem == item
     }
     
     private func convertToLinkedListArray(from sequence: [Any]) -> [DummyItem] {
@@ -119,12 +119,12 @@ class LinkedListTests: XCTestCase {
 }
 
 fileprivate extension LinkedList {
-    var convertedToLinkedListItemArray: [DummyItem] {
+    var convertedToDummyItemArray: [DummyItem] {
         var pointer = first
         var listContents: [DummyItem] = []
 
         while pointer != nil {
-            if let node = pointer, let value = node.convertToLinkedListItem {
+            if let node = pointer, let value = node.convertToDummyItem {
                 listContents.append(value)
                 pointer = node.next
             }
@@ -134,7 +134,7 @@ fileprivate extension LinkedList {
 }
 
 fileprivate extension Node {
-    var convertToLinkedListItem: DummyItem? {
+    var convertToDummyItem: DummyItem? {
         if let number = item as? Int {
             return DummyItem.number(value: number)
         }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -57,21 +57,21 @@ class LinkedListTests: XCTestCase {
         let newItems = [1,2,3,4,5,6,7,8,9,10]
         appendContents(of: newItems, to: &sut)
         let convertedNewItems = convertToLinkedListArray(from: newItems)
-        XCTAssertEqual(sut.convertedToLinkedListArray, convertedNewItems)
+        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedNewItems)
     }
     
     func testLinkedListAppend_givenNewOperators_expectCorrectSequence() {
         let newItems = ["+", "-", "*", "/"]
         appendContents(of: newItems, to: &sut)
         let convertedNewItems = convertToLinkedListArray(from: newItems)
-        XCTAssertEqual(sut.convertedToLinkedListArray, convertedNewItems)
+        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedNewItems)
     }
     
     func testLinkedListAppend_givenMixedElements_expectCorrectSequence() {
         let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         let convertedNewItems = convertToLinkedListArray(from: newItems) as [LinkedListItem]
-        XCTAssertEqual(sut.convertedToLinkedListArray, convertedNewItems)
+        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedNewItems)
     }
     
     func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualToFirstInsertedItem() {
@@ -88,7 +88,7 @@ class LinkedListTests: XCTestCase {
         let _ = sut.removeHead()
         let exepectedItems: [Any] = ["+", 30, "-", 2]
         let convertedExpectedItems = convertToLinkedListArray(from: exepectedItems) as [LinkedListItem]
-        XCTAssertEqual(sut.convertedToLinkedListArray, convertedExpectedItems)
+        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedExpectedItems)
     }
     
     func testLinkedListRemoveHead_givenMultipleRemovedHeadFromMixedElements_expectIsEmpty() {
@@ -104,7 +104,7 @@ class LinkedListTests: XCTestCase {
         let _ = sut.removeNode(at: 1)
         let expectedItems: [Any] = [20, 30, "-", 2]
         let convertedExepectedItems = convertToLinkedListArray(from: expectedItems)
-        XCTAssertEqual(sut.convertedToLinkedListArray, convertedExepectedItems)
+        XCTAssertEqual(sut.convertedToLinkedListItemArray, convertedExepectedItems)
     }
     
     func testLinkedListRemoveAll_givenRemoveAllFromElements_expectIsEmpty() {
@@ -167,7 +167,7 @@ extension LinkedList {
         return count
     }
     
-    var convertedToLinkedListArray: [LinkedListItem] {
+    var convertedToLinkedListItemArray: [LinkedListItem] {
         var pointer = head
         var listContents: [LinkedListItem] = []
         while pointer != nil {

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -86,6 +86,14 @@ class LinkedListTests: XCTestCase {
         XCTAssertEqual(sut.convertedToLinkedListArray, convertedItems)
     }
     
+    func testLinkedListRemove_givenRemovedFront_expectCorrectElement() {
+        let newItems: [Any] = [20, "+", 20, "-", 2]
+        let firstItem = LinkedListItem.number(value: 20)
+        appendContents(of: newItems, to: &sut)
+        let removedNode = sut.removeFront()
+        XCTAssertTrue(hasEqualItems(node: removedNode, item: firstItem))
+    }
+    
     private func hasEqualItems(node: Node<Any>?, item: LinkedListItem) -> Bool {
         guard let node = node else {
             return false

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -105,14 +105,6 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
-    func testLinkedListRemoveAll_givenRemoveAllFromElements_expectCleanMemory() {
-        let newItems: [Any] = [20, "+", 20, "-", 2]
-        appendContents(of: newItems, to: &sut)
-        let secondNode = sut.getNode(at: 1)
-        sut.removeAll()
-        XCTAssertEqual(secondNode, nil)
-    }
-    
     private func hasEqualItems(node: Node<Any>?, item: LinkedListItem) -> Bool {
         guard let node = node else {
             return false
@@ -176,6 +168,19 @@ extension LinkedList {
             }
         }
         return listContents
+    }
+    
+    func getNode(at index: Int) -> Node<T>? {
+        guard isNotEmpty else {
+            return nil
+        }
+        var currentNode = head
+        for _ in 0..<index {
+            if let node = currentNode {
+                currentNode = node.next
+            }
+        }
+        return currentNode
     }
 }
 

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 enum LinkedListItem: Equatable {
     case number(value: Int)
-    case symbol(value: Character)
+    case symbol(value: String)
 }
 
 class LinkedListTests: XCTestCase {
@@ -59,7 +59,7 @@ class LinkedListTests: XCTestCase {
     }
     
     func testLinkedListNode_givenNewCharacter_expectHeadEqualToItem() {
-        let newCharacter: Character = "+"
+        let newCharacter = "+"
         let newItem = LinkedListItem.symbol(value: newCharacter)
         sut.append(newCharacter)
         XCTAssertTrue(hasEqualItems(node: sut.head, item: newItem))
@@ -73,16 +73,17 @@ class LinkedListTests: XCTestCase {
     }
     
     func testLinkedListAppend_givenNewOperators_expectSameElements() {
-        let newItems: [Character] = ["+", "-", "*", "/"]
+        let newItems = ["+", "-", "*", "/"]
         let convertedItems = convertToLinkedListArray(from: newItems)
         appendContents(of: newItems, to: &sut)
         XCTAssertEqual(sut.convertedToLinkedListArray, convertedItems)
     }
     
     func testLinkedListAppend_givenMixedElements_expectSameElements() {
-        let newItems: [LinkedListItem] = [.number(value: 10), .symbol(value: "+"), .number(value: 20), .symbol(value: "/"), .number(value: 2)]
+        let newItems: [Any] = [20, "+", 20, "-", 2]
+        let convertedItems: [LinkedListItem] = convertToLinkedListArray(from: newItems)
         appendContents(of: newItems, to: &sut)
-        XCTAssertEqual(sut.convertedToLinkedListArray, newItems)
+        XCTAssertEqual(sut.convertedToLinkedListArray, convertedItems)
     }
     
     private func hasEqualItems(node: Node<Any>?, item: LinkedListItem) -> Bool {
@@ -106,7 +107,7 @@ class LinkedListTests: XCTestCase {
         if let value = value as? Int {
             return LinkedListItem.number(value: value)
         }
-        if let value = value as? Character {
+        if let value = value as? String {
             return LinkedListItem.symbol(value: value)
         }
         return nil
@@ -150,7 +151,7 @@ extension Node {
         if let number = item as? Int {
             return LinkedListItem.number(value: number)
         }
-        if let symbol = item as? Character {
+        if let symbol = item as? String {
             return LinkedListItem.symbol(value: symbol)
         }
         return nil

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -68,14 +68,14 @@ class LinkedListTests: XCTestCase {
     }
     
     func testLinkedListAppend_givenMixedElements_expectCorrectSequence() {
-        let newItems: [Any] = [20, "+", 20, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         let convertedNewItems = convertToLinkedListArray(from: newItems) as [LinkedListItem]
         XCTAssertEqual(sut.convertedToLinkedListArray, convertedNewItems)
     }
     
     func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualToFirstInsertedItem() {
-        let newItems: [Any] = [20, "+", 20, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         let removedNode = sut.removeHead()
         let firstInsertedItem = LinkedListItem.number(value: 20)
@@ -83,32 +83,32 @@ class LinkedListTests: XCTestCase {
     }
     
     func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectCorrectSequence() {
-        let newItems: [Any] = [20, "+", 20, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         let _ = sut.removeHead()
-        let exepectedItems: [Any] = ["+", 20, "-", 2]
+        let exepectedItems: [Any] = ["+", 30, "-", 2]
         let convertedExpectedItems = convertToLinkedListArray(from: exepectedItems) as [LinkedListItem]
         XCTAssertEqual(sut.convertedToLinkedListArray, convertedExpectedItems)
     }
     
     func testLinkedListRemoveHead_givenMultipleRemovedHeadFromMixedElements_expectIsEmpty() {
-        let newItems: [Any] = [20, "+", 20, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         removeHeadUntilEmpty(from: &sut)
         XCTAssertTrue(sut.isEmpty)
     }
     
     func testLinkedListRemoveHead_givenRemoveAtIndexFromMixedElements_expectCorrectSequence() {
-        let newItems: [Any] = [20, "+", 20, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         let _ = sut.removeNode(at: 1)
-        let expectedItems: [Any] = [20, 20, "-", 2]
+        let expectedItems: [Any] = [20, 30, "-", 2]
         let convertedExepectedItems = convertToLinkedListArray(from: expectedItems)
         XCTAssertEqual(sut.convertedToLinkedListArray, convertedExepectedItems)
     }
     
     func testLinkedListRemoveAll_givenRemoveAllFromElements_expectIsEmpty() {
-        let newItems: [Any] = [20, "+", 20, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "-", 2]
         appendContents(of: newItems, to: &sut)
         sut.removeAll()
         XCTAssertTrue(sut.isEmpty)

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -39,18 +39,18 @@ class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isNotEmpty)
     }
     
-    func testLinkedListAppend_givenNewIntegers_expectHeadEqualtoFirstItem() {
+    func testLinkedListAppend_givenNewIntegers_expectHeadEqualToFirstItem() {
         let newItems = [1, 2]
-        let firstItem = newItems[0]
+        let firstInsertedItem = newItems[0]
         appendContents(of: newItems, to: &sut)
-        XCTAssertTrue(hasEqualItems(node: sut.first, item: firstItem))
+        XCTAssertTrue(hasEqualItems(node: sut.first, item: firstInsertedItem))
     }
     
     func testLinkedListAppend_givenNewIntegers_expectTailEqualToLastItem() {
         let newItems = [1, 2, 3, 4]
-        let lastItem = newItems[newItems.count-1]
+        let lastInsertedItem = newItems[newItems.count-1]
         appendContents(of: newItems, to: &sut)
-        XCTAssertTrue(hasEqualItems(node: sut.last, item: lastItem))
+        XCTAssertTrue(hasEqualItems(node: sut.last, item: lastInsertedItem))
     }
     
     private func hasEqualItems(node: Node<Any>?, item: Int) -> Bool {

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -106,7 +106,7 @@ class LinkedListTests: XCTestCase {
     func testLinkedListRemove_givenMultipleRemovedFront_expectIsEmpty() {
         let newItems: [Any] = [20, "+", 20, "-", 2]
         appendContents(of: newItems, to: &sut)
-        removeFrontUntilEmpty()
+        removeHeadUntilEmpty(from: &sut)
         XCTAssertTrue(sut.isEmpty)
     }
     
@@ -140,6 +140,12 @@ class LinkedListTests: XCTestCase {
     private func appendContents(of items: [Any], to linkedList: inout LinkedList<Any>) {
         for item in items {
             linkedList.append(item)
+        }
+    }
+    
+    private func removeHeadUntilEmpty(from linkedList: inout LinkedList<Any>) {
+        while linkedList.isNotEmpty {
+            let _ = linkedList.removeHead()
         }
     }
 }

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -59,6 +59,12 @@ class LinkedListTests: XCTestCase {
         XCTAssertEqual(sut.convertedToIntArray, newItems)
     }
     
+    func testLinkedListAppend_givenNewOperators_expectSameElements() {
+        let newItems = ["+", "-", "/", "*"]
+        appendContents(of: newItems, to: &sut)
+        XCTAssertEqual(sut.convertedToCharacterArray, newItems)
+    }
+    
     private func hasEqualItems(node: Node<Any>?, item: Int) -> Bool {
         guard let node = node else {
             return false

--- a/Calculator/CalculatorTests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/LinkedListTests.swift
@@ -155,18 +155,4 @@ extension Node {
         }
         return nil
     }
-    
-    var convertToInt: Int? {
-        guard let value = item as? Int else {
-            return nil
-        }
-        return value
-    }
-    
-    var convertToCharacter: Character? {
-        guard let value = item as? Character else {
-            return nil
-        }
-        return value
-    }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## iOS 커리어 스타터 캠프
+# iOS 커리어 스타터 캠프
 
-### 계산기 프로젝트 저장소
+## 계산기 프로젝트 저장소
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
-
+## UML
+![UML class](https://user-images.githubusercontent.com/33091784/141096278-2996dade-cdb3-4cda-94c9-d8e8a669d1e5.png)


### PR DESCRIPTION
안녕하세요 쿠마(@leejun6694)!
계산기 프로젝트 Step 1를 마쳐서 PR 보냅니다!
TDD가 너무 어려워서 엉망으로 한 것 같지만..😎
리뷰 잘부탁드립니다🙏

프로젝트를 하면서 고민했던 점들을 정리 해봤습니다~

# 조언을 구하고싶은 점

## 1. TDD 의 Git Workflow에 대해서 고민해봤습니다.

- 원래 git 관리를 할때 실제코드/production 코드만 들어가는 브랜치를 다른 브랜치들과 분리하는 경우가 많다고 들었는데.
- TDD에서 테스팅을 하는 테스트 코드는 따로 Test branch 를 파서 해야되나?라는 생각이 들었습니다.
- 그래서 TDD를 통해 최종적인 Production Code 에 들어갈 코드가 작성되면 그때 실제 코드가 있는 브랜치로 merge 시키는게 좋을지에 대한 고민을 해봤습니다.
- 현업에서는 단위 테스트 코드에 대한 관리는 Git상으로 어떻게 하는지 궁금합니다!

## 2. 테스트 코드에서 `Generic` 타입끼리의 비교를 하면서 문제에 부딪혔습니다.

- 이번 Step 을 하면서, `LinkedList` 와 `CalculateItemQueue` 를 모두 `Generic` 으로 구현해봤습니다.
- 그리고 `String` 타입의 연산자("+", "-", "/", "*")와 `Int` 타입의 숫자들을 섞어서 `LinkedList` 타입과 `CalculateItemQueue` 에 넣어 보고싶었는데, 테스트를 하면서 부딪혔던 문제가 많습니다.
- 타입이 다른 데이터들을 섞어서 `Queue` 또는 `LinkedList` 에 넣고나서, 그 데이터들이 제대로 들어갔는지 확인하기 위해서는 `Generic` 타입끼리의 비교를 하게 됐는데, `Generic` 자체로는 `Equatable` 을 채택할 수 없어서 비교가 안되는 문제점에 부딪혔습니다.
- 이 문제를 해결하기위해 `CalculateItem` 이라는 비어있는 프로토콜을 채택하는 `DummyItem` 을 만들어서 테스트 했습니다.
    
    ```swift
    enum DummyItem: Equatable, CalculateItem {
        case number(value: Int)
        case symbol(value: String)
    }
    
    ```
    
- 근데 이게 맞는건지 계속 고민됐습니다..
- 테스트 코드와 실제 코드의 독립성을 유지하기 위해서 `Generic` 타입들을 `DummyItem` 으로 감싸서 비교를 했는데, 그게 아니라 실제 코드에서 `CalculateItem` 을 채택하는 타입을 만들었어야 하는지에 대한 고민을 계속 했습니다.
- **혹시 더 좋은 방법은 없었을지에 대한 쿠마의 의견이 궁금합니다!**
<br>

## 3. 테스트를 위해 특정 타입의 변경사항을 주는 방법에 대한 고민을 했습니다.

- 예를 들어 만약에 실제 코드에서는 연결리스트의 `head` , `tail` 속성들을 `private` 로 사용하고싶다면, 테스트에서는 이걸 접근할 수 없는데 테스트를 어떻게 하지?라는 고민이 생겼습니다.
- 테스트를 위해 실제 코드에서 잠깐 `private` 를 `internal` 로 바꾸는것도 맞지 않다고 생각해서, 어떻게 하면 테스트코드와 실제 코드의 독립성을 유지하면서 작성할지가 고민이었습니다.
- 그렇다면 이걸 어떤 방법으로 하는게 맞을까요?
- **제가 고민해본 방법들은 다음과 같은데 쿠마의 의견이 궁금합니다!**
    - `LinkedList`를 그대로 테스트 파일에서 또 구현해서 필요한 메서드만 추가한다.
    - `LinkedList`를 `protocol`로 만들어서 테스트 파일에서 `struct MockLinkedList: LinkedList` 이런 식으로 사용한다.
        - 근데 그러면 `protocol` 을 채택하면서 `private` 는 사용이 안돼서 또 문제네요...ㅠㅠㅠㅠ
        - 그리고 이것도 어떻게 보면 테스트를 위해 실제 코드를 변경하는것 같다는 생각이 들었습니다.
        - `extension` 을 사용하면 테스트 파일에서만 사용하는 타입의 속성/기능들을 추가해서 사용할 수 있는걸로 아는데, 저장 속성인 `head` 와 `tail` 은 변경이 안돼서 또 막혀버렸습니다ㅎㅎ
- 그렇다면 **"Testable"** 한 코드를 작성하기 위해서 `head` 와 `tail` 을 굳이 `private` 로 안하는것도 좋은 방법인가?? 라는 생각에 그냥 `private` 를 `internal` 로 바꿔서 코드를 작성했습니다. 😂
- 어떤 방법이 좋아보이는지에 대한 쿠마의 의견이 궁금합니다 :)

<br>

### 4. `String` 대신에 `Character` 를 사용하는 이점이 있는지에 대한 쿠마의 의견이 궁금합니다.

- 연산자 하나 (예: "+") 를 `Character` 로 타입을 지정할지 `String` 으로 지정할지에 대한 고민을 했습니다.
- 숫자와 연산자가 섞인 `Any` 타입의 배열을 연결리스트로 변환 시켜서 테스트를 할때, "+", "-", 같은 문자열은 스위프트가 `Character` 가 아닌 `String` 으로 추론을 하더라고요.
- 저는 "+" 를 `String` 보다 작은 단위인 `Character` 로 사용하는게 맞지않을까?라는 막연한 생각에 "연산자는 `Character` 로 사용하자" 라는 생각을 했었는데, 생각해볼 수록 근거가 없더라고요.
- `String` 을 쓰던 `Character` 를 쓰던 연산자 하나가 들어가면 (예: "+", "-"..) 16 바이트로 사이즈도 동일하고, `Character` 를 쓰는 이점이 전혀 떠오르지않더라고요...
- `String` vs `Character` 의 쓰임에 대해 주실만한 팁이 있는지 궁금합니다:)
<br>

## 5. 작성하는 데에 어려움을 느꼈던 단위 테스트가 있었습니다.

- 연결리스트의 모든 노드를 삭제하는 `removeAll()` 를 수행할때, 기존에 존재했던 모든 연결리스트 노드들이 메모리 상으로도 완전히 삭제가 됐는지 확인하는 테스트를 작성해 보고싶었습니다.
- `removeAll()` 에 대한 첫번째 테스트를 작성하고, (TDD 과정 중의 RED)
- 만약에 그 테스트를 통과하기 위한 최소한의 코드를 작성했을때(TDD과정 중의 GREEN),
- 만약에 아래와 같은 코드가 나왔으면

```swift
 mutating func removeAll() {
    head = nil
    tail = nil
 }

```

- 겉으로 봤을때는 연결리스트의 모든 노드가 없어진것 같지만, 메모리 상으로는 `head` 와 `tail` 사이에 존재했던 `node` 인스턴스들의 흔적이 남아있지않을까 라는 생각을 했습니다.
- 그런데 위 코드를 반증하는 테스트를 못 만들어서 그냥 뒀습니다. 
    - 원래는 `tail` 부터 한 `node` 씩 역순으로 탐색하면서 메모리에서 완전히 지우고싶었는데, TDD 의 과정으로는 반증이 된 후에 refactor를 해야되는것 같아서 내버려뒀습니다!
- **그래서 제가 궁금한것은!**
- `removeAll()` 을 수행하기전에, 확인하고싶은 `node` 의 메모리 주소를 잠깐 저장해뒀다가, `removeAll()` 이 수행된 후에 그 메모리 주소에 뭔가가 남아있는지 확인하는 방법은 없는건가요???

## 긴 글 읽어주셔서 감사합니다!