### PR TITLE
계산기[STEP 2] : 호랭이 

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -28,6 +28,14 @@
 		4825E8CA273EC77200E2CD09 /* extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89E273E942B00E2CD09 /* extension.swift */; };
 		4825E8CB273EC77400E2CD09 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
 		4825E8CC273EC77A00E2CD09 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
+		4825E8D4273ED74C00E2CD09 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E8D3273ED74C00E2CD09 /* FormulaTests.swift */; };
+		4825E8DA273ED82400E2CD09 /* extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89E273E942B00E2CD09 /* extension.swift */; };
+		4825E8DB273ED82700E2CD09 /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
+		4825E8DC273ED82A00E2CD09 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
+		4825E8DD273ED82C00E2CD09 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
+		4825E8DE273ED82E00E2CD09 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89C273E93C700E2CD09 /* ExpressionParser.swift */; };
+		4825E8DF273ED83100E2CD09 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
+		4825E8E0273ED83400E2CD09 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E8A0273E958E00E2CD09 /* Error.swift */; };
 		48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -53,6 +61,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		4825E8D5273ED74C00E2CD09 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -65,6 +80,8 @@
 		4825E8A8273EB68D00E2CD09 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		4825E8BD273EC72100E2CD09 /* ExpressionParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4825E8BF273EC72100E2CD09 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
+		4825E8D1273ED74C00E2CD09 /* Formula.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Formula.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4825E8D3273ED74C00E2CD09 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		48B95108273D1A5B0009B8E3 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -86,6 +103,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4825E8BA273EC72100E2CD09 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4825E8CE273ED74C00E2CD09 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -118,12 +142,21 @@
 			path = ExpressionParserTests;
 			sourceTree = "<group>";
 		};
+		4825E8D2273ED74C00E2CD09 /* Formula */ = {
+			isa = PBXGroup;
+			children = (
+				4825E8D3273ED74C00E2CD09 /* FormulaTests.swift */,
+			);
+			path = Formula;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				4825E8A7273EB68D00E2CD09 /* CalculatorTests */,
 				4825E8BE273EC72100E2CD09 /* ExpressionParserTests */,
+				4825E8D2273ED74C00E2CD09 /* Formula */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -134,6 +167,7 @@
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				4825E8A6273EB68D00E2CD09 /* CalculatorTests.xctest */,
 				4825E8BD273EC72100E2CD09 /* ExpressionParserTests.xctest */,
+				4825E8D1273ED74C00E2CD09 /* Formula.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -198,6 +232,24 @@
 			productReference = 4825E8BD273EC72100E2CD09 /* ExpressionParserTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		4825E8D0273ED74C00E2CD09 /* Formula */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4825E8D7273ED74C00E2CD09 /* Build configuration list for PBXNativeTarget "Formula" */;
+			buildPhases = (
+				4825E8CD273ED74C00E2CD09 /* Sources */,
+				4825E8CE273ED74C00E2CD09 /* Frameworks */,
+				4825E8CF273ED74C00E2CD09 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4825E8D6273ED74C00E2CD09 /* PBXTargetDependency */,
+			);
+			name = Formula;
+			productName = Formula;
+			productReference = 4825E8D1273ED74C00E2CD09 /* Formula.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -232,6 +284,10 @@
 						CreatedOnToolsVersion = 13.0;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					4825E8D0273ED74C00E2CD09 = {
+						CreatedOnToolsVersion = 13.0;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -253,6 +309,7 @@
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				4825E8A5273EB68D00E2CD09 /* CalculatorTests */,
 				4825E8BC273EC72100E2CD09 /* ExpressionParserTests */,
+				4825E8D0273ED74C00E2CD09 /* Formula */,
 			);
 		};
 /* End PBXProject section */
@@ -266,6 +323,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4825E8BB273EC72100E2CD09 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4825E8CF273ED74C00E2CD09 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -315,6 +379,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4825E8CD273ED74C00E2CD09 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4825E8E0273ED83400E2CD09 /* Error.swift in Sources */,
+				4825E8D4273ED74C00E2CD09 /* FormulaTests.swift in Sources */,
+				4825E8DA273ED82400E2CD09 /* extension.swift in Sources */,
+				4825E8DC273ED82A00E2CD09 /* LinkedList.swift in Sources */,
+				4825E8DD273ED82C00E2CD09 /* Formula.swift in Sources */,
+				4825E8DF273ED83100E2CD09 /* Operator.swift in Sources */,
+				4825E8DE273ED82E00E2CD09 /* ExpressionParser.swift in Sources */,
+				4825E8DB273ED82700E2CD09 /* Calculator.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -344,6 +423,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 4825E8C1273EC72100E2CD09 /* PBXContainerItemProxy */;
+		};
+		4825E8D6273ED74C00E2CD09 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 4825E8D5273ED74C00E2CD09 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -461,6 +545,57 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = a.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		4825E8D8273ED74C00E2CD09 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 54T77SSM5Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = a.Formula;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		4825E8D9273ED74C00E2CD09 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 54T77SSM5Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = a.Formula;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -645,6 +780,15 @@
 			buildConfigurations = (
 				4825E8C4273EC72100E2CD09 /* Debug */,
 				4825E8C5273EC72100E2CD09 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4825E8D7273ED74C00E2CD09 /* Build configuration list for PBXNativeTarget "Formula" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4825E8D8273ED74C00E2CD09 /* Debug */,
+				4825E8D9273ED74C00E2CD09 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -18,6 +18,16 @@
 		4825E8B1273EB69D00E2CD09 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
 		4825E8B3273EB6A200E2CD09 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
 		4825E8B4273EB6A500E2CD09 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E8A0273E958E00E2CD09 /* Error.swift */; };
+		4825E8B5273EB87F00E2CD09 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
+		4825E8B7273EBB3100E2CD09 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89C273E93C700E2CD09 /* ExpressionParser.swift */; };
+		4825E8C0273EC72100E2CD09 /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E8BF273EC72100E2CD09 /* ExpressionParserTests.swift */; };
+		4825E8C6273EC73E00E2CD09 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
+		4825E8C7273EC74100E2CD09 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89C273E93C700E2CD09 /* ExpressionParser.swift */; };
+		4825E8C8273EC76800E2CD09 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E8A0273E958E00E2CD09 /* Error.swift */; };
+		4825E8C9273EC76F00E2CD09 /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
+		4825E8CA273EC77200E2CD09 /* extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89E273E942B00E2CD09 /* extension.swift */; };
+		4825E8CB273EC77400E2CD09 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
+		4825E8CC273EC77A00E2CD09 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
 		48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -36,6 +46,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		4825E8C1273EC72100E2CD09 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +63,8 @@
 		4825E8A0273E958E00E2CD09 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		4825E8A6273EB68D00E2CD09 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4825E8A8273EB68D00E2CD09 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
+		4825E8BD273EC72100E2CD09 /* ExpressionParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4825E8BF273EC72100E2CD09 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		48B95108273D1A5B0009B8E3 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -60,6 +79,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		4825E8A3273EB68D00E2CD09 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4825E8BA273EC72100E2CD09 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -84,11 +110,20 @@
 			path = CalculatorTests;
 			sourceTree = "<group>";
 		};
+		4825E8BE273EC72100E2CD09 /* ExpressionParserTests */ = {
+			isa = PBXGroup;
+			children = (
+				4825E8BF273EC72100E2CD09 /* ExpressionParserTests.swift */,
+			);
+			path = ExpressionParserTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				4825E8A7273EB68D00E2CD09 /* CalculatorTests */,
+				4825E8BE273EC72100E2CD09 /* ExpressionParserTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -98,6 +133,7 @@
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				4825E8A6273EB68D00E2CD09 /* CalculatorTests.xctest */,
+				4825E8BD273EC72100E2CD09 /* ExpressionParserTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -144,6 +180,24 @@
 			productReference = 4825E8A6273EB68D00E2CD09 /* CalculatorTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		4825E8BC273EC72100E2CD09 /* ExpressionParserTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4825E8C3273EC72100E2CD09 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */;
+			buildPhases = (
+				4825E8B9273EC72100E2CD09 /* Sources */,
+				4825E8BA273EC72100E2CD09 /* Frameworks */,
+				4825E8BB273EC72100E2CD09 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4825E8C2273EC72100E2CD09 /* PBXTargetDependency */,
+			);
+			name = ExpressionParserTests;
+			productName = ExpressionParserTests;
+			productReference = 4825E8BD273EC72100E2CD09 /* ExpressionParserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -174,6 +228,10 @@
 						CreatedOnToolsVersion = 13.0;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					4825E8BC273EC72100E2CD09 = {
+						CreatedOnToolsVersion = 13.0;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -194,12 +252,20 @@
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				4825E8A5273EB68D00E2CD09 /* CalculatorTests */,
+				4825E8BC273EC72100E2CD09 /* ExpressionParserTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		4825E8A4273EB68D00E2CD09 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4825E8BB273EC72100E2CD09 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -224,11 +290,28 @@
 			buildActionMask = 2147483647;
 			files = (
 				4825E8B3273EB6A200E2CD09 /* Operator.swift in Sources */,
+				4825E8B5273EB87F00E2CD09 /* Formula.swift in Sources */,
 				4825E8A9273EB68D00E2CD09 /* CalculatorTests.swift in Sources */,
 				4825E8AF273EB69800E2CD09 /* extension.swift in Sources */,
 				4825E8B1273EB69D00E2CD09 /* LinkedList.swift in Sources */,
 				4825E8B4273EB6A500E2CD09 /* Error.swift in Sources */,
+				4825E8B7273EBB3100E2CD09 /* ExpressionParser.swift in Sources */,
 				4825E8B0273EB69A00E2CD09 /* Calculator.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4825E8B9273EC72100E2CD09 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4825E8C8273EC76800E2CD09 /* Error.swift in Sources */,
+				4825E8C6273EC73E00E2CD09 /* Formula.swift in Sources */,
+				4825E8C7273EC74100E2CD09 /* ExpressionParser.swift in Sources */,
+				4825E8CA273EC77200E2CD09 /* extension.swift in Sources */,
+				4825E8C9273EC76F00E2CD09 /* Calculator.swift in Sources */,
+				4825E8CC273EC77A00E2CD09 /* Operator.swift in Sources */,
+				4825E8C0273EC72100E2CD09 /* ExpressionParserTests.swift in Sources */,
+				4825E8CB273EC77400E2CD09 /* LinkedList.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -256,6 +339,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 4825E8AA273EB68D00E2CD09 /* PBXContainerItemProxy */;
+		};
+		4825E8C2273EC72100E2CD09 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 4825E8C1273EC72100E2CD09 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -322,6 +410,57 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		4825E8C4273EC72100E2CD09 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 54T77SSM5Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = a.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		4825E8C5273EC72100E2CD09 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 54T77SSM5Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = a.ExpressionParserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -497,6 +636,15 @@
 			buildConfigurations = (
 				4825E8AD273EB68D00E2CD09 /* Debug */,
 				4825E8AE273EB68D00E2CD09 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4825E8C3273EC72100E2CD09 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4825E8C4273EC72100E2CD09 /* Debug */,
+				4825E8C5273EC72100E2CD09 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
 		481FCCAC273CEDC900349B74 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
+		4825E89D273E93C700E2CD09 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89C273E93C700E2CD09 /* ExpressionParser.swift */; };
 		48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -22,6 +23,7 @@
 /* Begin PBXFileReference section */
 		481FCCA9273CE96000349B74 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		481FCCAB273CEDC900349B74 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		4825E89C273E93C700E2CD09 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		48B95108273D1A5B0009B8E3 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -67,6 +69,7 @@
 				48C16C4D273916BC006E1BBC /* Calculator.swift */,
 				481FCCA9273CE96000349B74 /* LinkedList.swift */,
 				481FCCAB273CEDC900349B74 /* Formula.swift */,
+				4825E89C273E93C700E2CD09 /* ExpressionParser.swift */,
 				48B95108273D1A5B0009B8E3 /* Operator.swift */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
@@ -155,6 +158,7 @@
 				481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */,
 				48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				4825E89D273E93C700E2CD09 /* ExpressionParser.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		481FCCAC273CEDC900349B74 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
 		4825E89D273E93C700E2CD09 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89C273E93C700E2CD09 /* ExpressionParser.swift */; };
 		4825E89F273E942B00E2CD09 /* extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89E273E942B00E2CD09 /* extension.swift */; };
+		4825E8A1273E958E00E2CD09 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E8A0273E958E00E2CD09 /* Error.swift */; };
 		48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -26,6 +27,7 @@
 		481FCCAB273CEDC900349B74 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		4825E89C273E93C700E2CD09 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		4825E89E273E942B00E2CD09 /* extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = extension.swift; sourceTree = "<group>"; };
+		4825E8A0273E958E00E2CD09 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		48B95108273D1A5B0009B8E3 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -74,6 +76,7 @@
 				481FCCAB273CEDC900349B74 /* Formula.swift */,
 				4825E89C273E93C700E2CD09 /* ExpressionParser.swift */,
 				48B95108273D1A5B0009B8E3 /* Operator.swift */,
+				4825E8A0273E958E00E2CD09 /* Error.swift */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
 				C713D9452570E5EB001C3AFC /* ViewController.swift */,
@@ -163,6 +166,7 @@
 				48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				4825E89D273E93C700E2CD09 /* ExpressionParser.swift in Sources */,
+				4825E8A1273E958E00E2CD09 /* Error.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -9,12 +9,7 @@
 /* Begin PBXBuildFile section */
 		481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
 		481FCCAC273CEDC900349B74 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
-		481FCCAD273CEF3B00349B74 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
-		481FCCAE273CEF4200349B74 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
-		481FCCAF273CEFEF00349B74 /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4427391173006E1BBC /* CalculatorTests.swift */; };
 		48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
-		48C16C4527391173006E1BBC /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4427391173006E1BBC /* CalculatorTests.swift */; };
-		48C16C4F27391F63006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
@@ -24,22 +19,10 @@
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		48C16C4627391173006E1BBC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
-			remoteInfo = Calculator;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
 		481FCCA9273CE96000349B74 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		481FCCAB273CEDC900349B74 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		48B95108273D1A5B0009B8E3 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
-		48C16C4227391173006E1BBC /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		48C16C4427391173006E1BBC /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -52,13 +35,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		48C16C3F27391173006E1BBC /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C713D93B2570E5EB001C3AFC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -69,19 +45,10 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		48C16C4327391173006E1BBC /* CalculatorTests */ = {
-			isa = PBXGroup;
-			children = (
-				48C16C4427391173006E1BBC /* CalculatorTests.swift */,
-			);
-			path = CalculatorTests;
-			sourceTree = "<group>";
-		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
-				48C16C4327391173006E1BBC /* CalculatorTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -90,7 +57,6 @@
 			isa = PBXGroup;
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
-				48C16C4227391173006E1BBC /* CalculatorTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -116,24 +82,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		48C16C4127391173006E1BBC /* CalculatorTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 48C16C4A27391173006E1BBC /* Build configuration list for PBXNativeTarget "CalculatorTests" */;
-			buildPhases = (
-				48C16C3E27391173006E1BBC /* Sources */,
-				48C16C3F27391173006E1BBC /* Frameworks */,
-				48C16C4027391173006E1BBC /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				48C16C4727391173006E1BBC /* PBXTargetDependency */,
-			);
-			name = CalculatorTests;
-			productName = CalculatorTests;
-			productReference = 48C16C4227391173006E1BBC /* CalculatorTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -160,10 +108,6 @@
 				LastSwiftUpdateCheck = 1300;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
-					48C16C4127391173006E1BBC = {
-						CreatedOnToolsVersion = 13.0;
-						TestTargetID = C713D93D2570E5EB001C3AFC;
-					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -183,19 +127,11 @@
 			projectRoot = "";
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
-				48C16C4127391173006E1BBC /* CalculatorTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		48C16C4027391173006E1BBC /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C713D93C2570E5EB001C3AFC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -209,22 +145,10 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		48C16C3E27391173006E1BBC /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				48C16C4527391173006E1BBC /* CalculatorTests.swift in Sources */,
-				48C16C4F27391F63006E1BBC /* Calculator.swift in Sources */,
-				481FCCAE273CEF4200349B74 /* LinkedList.swift in Sources */,
-				481FCCAD273CEF3B00349B74 /* Formula.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				481FCCAF273CEFEF00349B74 /* CalculatorTests.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				48C16C5227393B66006E1BBC /* Calculator.swift in Sources */,
 				481FCCAC273CEDC900349B74 /* Formula.swift in Sources */,
@@ -236,14 +160,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		48C16C4727391173006E1BBC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C713D93D2570E5EB001C3AFC /* Calculator */;
-			targetProxy = 48C16C4627391173006E1BBC /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C713D9472570E5EB001C3AFC /* Main.storyboard */ = {
@@ -265,53 +181,6 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		48C16C4827391173006E1BBC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
-			};
-			name = Debug;
-		};
-		48C16C4927391173006E1BBC /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
-			};
-			name = Release;
-		};
 		C713D9502570E5ED001C3AFC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -474,15 +343,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		48C16C4A27391173006E1BBC /* Build configuration list for PBXNativeTarget "CalculatorTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				48C16C4827391173006E1BBC /* Debug */,
-				48C16C4927391173006E1BBC /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		C713D9392570E5EB001C3AFC /* Build configuration list for PBXProject "Calculator" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -8,9 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
+		481FCCAC273CEDC900349B74 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
+		481FCCAD273CEF3B00349B74 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
+		481FCCAE273CEF4200349B74 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
+		481FCCAF273CEFEF00349B74 /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4427391173006E1BBC /* CalculatorTests.swift */; };
 		48C16C4527391173006E1BBC /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4427391173006E1BBC /* CalculatorTests.swift */; };
 		48C16C4F27391F63006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
+		48DAB5FA273CF3CA00CB4A34 /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -27,13 +32,22 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		48DAB5F5273CF3AD00CB4A34 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		481FCCA9273CE96000349B74 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		481FCCAB273CEDC900349B74 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		48C16C4227391173006E1BBC /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		48C16C4427391173006E1BBC /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
+		48DAB5F1273CF3AD00CB4A34 /* CalculatorTests2.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests2.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -46,6 +60,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		48C16C3F27391173006E1BBC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		48DAB5EE273CF3AD00CB4A34 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -84,6 +105,7 @@
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				48C16C4227391173006E1BBC /* CalculatorTests.xctest */,
+				48DAB5F1273CF3AD00CB4A34 /* CalculatorTests2.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -93,6 +115,7 @@
 			children = (
 				48C16C4D273916BC006E1BBC /* Calculator.swift */,
 				481FCCA9273CE96000349B74 /* LinkedList.swift */,
+				481FCCAB273CEDC900349B74 /* Formula.swift */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
 				C713D9452570E5EB001C3AFC /* ViewController.swift */,
@@ -125,6 +148,24 @@
 			productReference = 48C16C4227391173006E1BBC /* CalculatorTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		48DAB5F0273CF3AD00CB4A34 /* CalculatorTests2 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 48DAB5F7273CF3AD00CB4A34 /* Build configuration list for PBXNativeTarget "CalculatorTests2" */;
+			buildPhases = (
+				48DAB5ED273CF3AD00CB4A34 /* Sources */,
+				48DAB5EE273CF3AD00CB4A34 /* Frameworks */,
+				48DAB5EF273CF3AD00CB4A34 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				48DAB5F6273CF3AD00CB4A34 /* PBXTargetDependency */,
+			);
+			name = CalculatorTests2;
+			productName = CalculatorTests2;
+			productReference = 48DAB5F1273CF3AD00CB4A34 /* CalculatorTests2.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -153,6 +194,9 @@
 				TargetAttributes = {
 					48C16C4127391173006E1BBC = {
 						CreatedOnToolsVersion = 13.0;
+					};
+					48DAB5F0273CF3AD00CB4A34 = {
+						CreatedOnToolsVersion = 13.0;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
 					C713D93D2570E5EB001C3AFC = {
@@ -175,12 +219,20 @@
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				48C16C4127391173006E1BBC /* CalculatorTests */,
+				48DAB5F0273CF3AD00CB4A34 /* CalculatorTests2 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		48C16C4027391173006E1BBC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		48DAB5EF273CF3AD00CB4A34 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -206,6 +258,16 @@
 			files = (
 				48C16C4527391173006E1BBC /* CalculatorTests.swift in Sources */,
 				48C16C4F27391F63006E1BBC /* Calculator.swift in Sources */,
+				481FCCAE273CEF4200349B74 /* LinkedList.swift in Sources */,
+				481FCCAD273CEF3B00349B74 /* Formula.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		48DAB5ED273CF3AD00CB4A34 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				48DAB5FA273CF3CA00CB4A34 /* Calculator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -213,8 +275,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				481FCCAF273CEFEF00349B74 /* CalculatorTests.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				48C16C5227393B66006E1BBC /* Calculator.swift in Sources */,
+				481FCCAC273CEDC900349B74 /* Formula.swift in Sources */,
 				481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
@@ -228,6 +292,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 48C16C4627391173006E1BBC /* PBXContainerItemProxy */;
+		};
+		48DAB5F6273CF3AD00CB4A34 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 48DAB5F5273CF3AD00CB4A34 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -254,7 +323,6 @@
 		48C16C4827391173006E1BBC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -272,11 +340,32 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
 			};
 			name = Debug;
 		};
 		48C16C4927391173006E1BBC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		48DAB5F8273CF3AD00CB4A34 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -291,7 +380,32 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests2;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		48DAB5F9273CF3AD00CB4A34 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -467,6 +581,15 @@
 			buildConfigurations = (
 				48C16C4827391173006E1BBC /* Debug */,
 				48C16C4927391173006E1BBC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		48DAB5F7273CF3AD00CB4A34 /* Build configuration list for PBXNativeTarget "CalculatorTests2" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				48DAB5F8273CF3AD00CB4A34 /* Debug */,
+				48DAB5F9273CF3AD00CB4A34 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
 		48C16C4527391173006E1BBC /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4427391173006E1BBC /* CalculatorTests.swift */; };
 		48C16C4F27391F63006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		481FCCA9273CE96000349B74 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		48C16C4227391173006E1BBC /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		48C16C4427391173006E1BBC /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
@@ -90,6 +92,7 @@
 			isa = PBXGroup;
 			children = (
 				48C16C4D273916BC006E1BBC /* Calculator.swift */,
+				481FCCA9273CE96000349B74 /* LinkedList.swift */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
 				C713D9452570E5EB001C3AFC /* ViewController.swift */,
@@ -212,6 +215,7 @@
 			files = (
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				48C16C5227393B66006E1BBC /* Calculator.swift in Sources */,
+				481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
 		481FCCAC273CEDC900349B74 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
 		4825E89D273E93C700E2CD09 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89C273E93C700E2CD09 /* ExpressionParser.swift */; };
+		4825E89F273E942B00E2CD09 /* extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89E273E942B00E2CD09 /* extension.swift */; };
 		48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -24,6 +25,7 @@
 		481FCCA9273CE96000349B74 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		481FCCAB273CEDC900349B74 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		4825E89C273E93C700E2CD09 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		4825E89E273E942B00E2CD09 /* extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = extension.swift; sourceTree = "<group>"; };
 		48B95108273D1A5B0009B8E3 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -66,6 +68,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				4825E89E273E942B00E2CD09 /* extension.swift */,
 				48C16C4D273916BC006E1BBC /* Calculator.swift */,
 				481FCCA9273CE96000349B74 /* LinkedList.swift */,
 				481FCCAB273CEDC900349B74 /* Formula.swift */,
@@ -155,6 +158,7 @@
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				48C16C5227393B66006E1BBC /* Calculator.swift in Sources */,
 				481FCCAC273CEDC900349B74 /* Formula.swift in Sources */,
+				4825E89F273E942B00E2CD09 /* extension.swift in Sources */,
 				481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */,
 				48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		481FCCAD273CEF3B00349B74 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCAB273CEDC900349B74 /* Formula.swift */; };
 		481FCCAE273CEF4200349B74 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
 		481FCCAF273CEFEF00349B74 /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4427391173006E1BBC /* CalculatorTests.swift */; };
+		48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
 		48C16C4527391173006E1BBC /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4427391173006E1BBC /* CalculatorTests.swift */; };
 		48C16C4F27391F63006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
@@ -44,6 +45,7 @@
 /* Begin PBXFileReference section */
 		481FCCA9273CE96000349B74 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		481FCCAB273CEDC900349B74 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		48B95108273D1A5B0009B8E3 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		48C16C4227391173006E1BBC /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		48C16C4427391173006E1BBC /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 				48C16C4D273916BC006E1BBC /* Calculator.swift */,
 				481FCCA9273CE96000349B74 /* LinkedList.swift */,
 				481FCCAB273CEDC900349B74 /* Formula.swift */,
+				48B95108273D1A5B0009B8E3 /* Operator.swift */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
 				C713D9452570E5EB001C3AFC /* ViewController.swift */,
@@ -280,6 +283,7 @@
 				48C16C5227393B66006E1BBC /* Calculator.swift in Sources */,
 				481FCCAC273CEDC900349B74 /* Formula.swift in Sources */,
 				481FCCAA273CE96000349B74 /* LinkedList.swift in Sources */,
+				48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		48C16C4527391173006E1BBC /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4427391173006E1BBC /* CalculatorTests.swift */; };
 		48C16C4F27391F63006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
-		48DAB5FA273CF3CA00CB4A34 /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -33,13 +32,6 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
-		48DAB5F5273CF3AD00CB4A34 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
-			remoteInfo = Calculator;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -49,7 +41,6 @@
 		48C16C4227391173006E1BBC /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		48C16C4427391173006E1BBC /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
-		48DAB5F1273CF3AD00CB4A34 /* CalculatorTests2.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests2.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -62,13 +53,6 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		48C16C3F27391173006E1BBC /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		48DAB5EE273CF3AD00CB4A34 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -107,7 +91,6 @@
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				48C16C4227391173006E1BBC /* CalculatorTests.xctest */,
-				48DAB5F1273CF3AD00CB4A34 /* CalculatorTests2.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -151,24 +134,6 @@
 			productReference = 48C16C4227391173006E1BBC /* CalculatorTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		48DAB5F0273CF3AD00CB4A34 /* CalculatorTests2 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 48DAB5F7273CF3AD00CB4A34 /* Build configuration list for PBXNativeTarget "CalculatorTests2" */;
-			buildPhases = (
-				48DAB5ED273CF3AD00CB4A34 /* Sources */,
-				48DAB5EE273CF3AD00CB4A34 /* Frameworks */,
-				48DAB5EF273CF3AD00CB4A34 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				48DAB5F6273CF3AD00CB4A34 /* PBXTargetDependency */,
-			);
-			name = CalculatorTests2;
-			productName = CalculatorTests2;
-			productReference = 48DAB5F1273CF3AD00CB4A34 /* CalculatorTests2.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -197,9 +162,6 @@
 				TargetAttributes = {
 					48C16C4127391173006E1BBC = {
 						CreatedOnToolsVersion = 13.0;
-					};
-					48DAB5F0273CF3AD00CB4A34 = {
-						CreatedOnToolsVersion = 13.0;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
 					C713D93D2570E5EB001C3AFC = {
@@ -222,20 +184,12 @@
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				48C16C4127391173006E1BBC /* CalculatorTests */,
-				48DAB5F0273CF3AD00CB4A34 /* CalculatorTests2 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		48C16C4027391173006E1BBC /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		48DAB5EF273CF3AD00CB4A34 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -266,14 +220,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		48DAB5ED273CF3AD00CB4A34 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				48DAB5FA273CF3CA00CB4A34 /* Calculator.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -296,11 +242,6 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 48C16C4627391173006E1BBC /* PBXContainerItemProxy */;
-		};
-		48DAB5F6273CF3AD00CB4A34 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C713D93D2570E5EB001C3AFC /* Calculator */;
-			targetProxy = 48DAB5F5273CF3AD00CB4A34 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -344,6 +285,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
 			};
 			name = Debug;
 		};
@@ -362,54 +304,6 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
-		48DAB5F8273CF3AD00CB4A34 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests2;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
-			};
-			name = Debug;
-		};
-		48DAB5F9273CF3AD00CB4A34 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -585,15 +479,6 @@
 			buildConfigurations = (
 				48C16C4827391173006E1BBC /* Debug */,
 				48C16C4927391173006E1BBC /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		48DAB5F7273CF3AD00CB4A34 /* Build configuration list for PBXNativeTarget "CalculatorTests2" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				48DAB5F8273CF3AD00CB4A34 /* Debug */,
-				48DAB5F9273CF3AD00CB4A34 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -12,6 +12,12 @@
 		4825E89D273E93C700E2CD09 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89C273E93C700E2CD09 /* ExpressionParser.swift */; };
 		4825E89F273E942B00E2CD09 /* extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89E273E942B00E2CD09 /* extension.swift */; };
 		4825E8A1273E958E00E2CD09 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E8A0273E958E00E2CD09 /* Error.swift */; };
+		4825E8A9273EB68D00E2CD09 /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E8A8273EB68D00E2CD09 /* CalculatorTests.swift */; };
+		4825E8AF273EB69800E2CD09 /* extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E89E273E942B00E2CD09 /* extension.swift */; };
+		4825E8B0273EB69A00E2CD09 /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
+		4825E8B1273EB69D00E2CD09 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FCCA9273CE96000349B74 /* LinkedList.swift */; };
+		4825E8B3273EB6A200E2CD09 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
+		4825E8B4273EB6A500E2CD09 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4825E8A0273E958E00E2CD09 /* Error.swift */; };
 		48B95109273D1A5B0009B8E3 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B95108273D1A5B0009B8E3 /* Operator.swift */; };
 		48C16C5227393B66006E1BBC /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C16C4D273916BC006E1BBC /* Calculator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -22,12 +28,24 @@
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		4825E8AA273EB68D00E2CD09 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		481FCCA9273CE96000349B74 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		481FCCAB273CEDC900349B74 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		4825E89C273E93C700E2CD09 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		4825E89E273E942B00E2CD09 /* extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = extension.swift; sourceTree = "<group>"; };
 		4825E8A0273E958E00E2CD09 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		4825E8A6273EB68D00E2CD09 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4825E8A8273EB68D00E2CD09 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		48B95108273D1A5B0009B8E3 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -41,6 +59,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4825E8A3273EB68D00E2CD09 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93B2570E5EB001C3AFC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -51,10 +76,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4825E8A7273EB68D00E2CD09 /* CalculatorTests */ = {
+			isa = PBXGroup;
+			children = (
+				4825E8A8273EB68D00E2CD09 /* CalculatorTests.swift */,
+			);
+			path = CalculatorTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
+				4825E8A7273EB68D00E2CD09 /* CalculatorTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -63,6 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
+				4825E8A6273EB68D00E2CD09 /* CalculatorTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -91,6 +126,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4825E8A5273EB68D00E2CD09 /* CalculatorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4825E8AC273EB68D00E2CD09 /* Build configuration list for PBXNativeTarget "CalculatorTests" */;
+			buildPhases = (
+				4825E8A2273EB68D00E2CD09 /* Sources */,
+				4825E8A3273EB68D00E2CD09 /* Frameworks */,
+				4825E8A4273EB68D00E2CD09 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4825E8AB273EB68D00E2CD09 /* PBXTargetDependency */,
+			);
+			name = CalculatorTests;
+			productName = CalculatorTests;
+			productReference = 4825E8A6273EB68D00E2CD09 /* CalculatorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -117,6 +170,10 @@
 				LastSwiftUpdateCheck = 1300;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					4825E8A5273EB68D00E2CD09 = {
+						CreatedOnToolsVersion = 13.0;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -136,11 +193,19 @@
 			projectRoot = "";
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
+				4825E8A5273EB68D00E2CD09 /* CalculatorTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4825E8A4273EB68D00E2CD09 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93C2570E5EB001C3AFC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -154,6 +219,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4825E8A2273EB68D00E2CD09 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4825E8B3273EB6A200E2CD09 /* Operator.swift in Sources */,
+				4825E8A9273EB68D00E2CD09 /* CalculatorTests.swift in Sources */,
+				4825E8AF273EB69800E2CD09 /* extension.swift in Sources */,
+				4825E8B1273EB69D00E2CD09 /* LinkedList.swift in Sources */,
+				4825E8B4273EB6A500E2CD09 /* Error.swift in Sources */,
+				4825E8B0273EB69A00E2CD09 /* Calculator.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -172,6 +250,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		4825E8AB273EB68D00E2CD09 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 4825E8AA273EB68D00E2CD09 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C713D9472570E5EB001C3AFC /* Main.storyboard */ = {
@@ -193,6 +279,57 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		4825E8AD273EB68D00E2CD09 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 54T77SSM5Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		4825E8AE273EB68D00E2CD09 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 54T77SSM5Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = a.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
 		C713D9502570E5ED001C3AFC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -355,6 +492,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4825E8AC273EB68D00E2CD09 /* Build configuration list for PBXNativeTarget "CalculatorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4825E8AD273EB68D00E2CD09 /* Debug */,
+				4825E8AE273EB68D00E2CD09 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C713D9392570E5EB001C3AFC /* Build configuration list for PBXProject "Calculator" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -80,7 +80,7 @@
 		4825E8A8273EB68D00E2CD09 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		4825E8BD273EC72100E2CD09 /* ExpressionParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4825E8BF273EC72100E2CD09 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
-		4825E8D1273ED74C00E2CD09 /* Formula.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Formula.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4825E8D1273ED74C00E2CD09 /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4825E8D3273ED74C00E2CD09 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		48B95108273D1A5B0009B8E3 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		48C16C4D273916BC006E1BBC /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
@@ -167,7 +167,7 @@
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				4825E8A6273EB68D00E2CD09 /* CalculatorTests.xctest */,
 				4825E8BD273EC72100E2CD09 /* ExpressionParserTests.xctest */,
-				4825E8D1273ED74C00E2CD09 /* Formula.xctest */,
+				4825E8D1273ED74C00E2CD09 /* FormulaTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -232,9 +232,9 @@
 			productReference = 4825E8BD273EC72100E2CD09 /* ExpressionParserTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		4825E8D0273ED74C00E2CD09 /* Formula */ = {
+		4825E8D0273ED74C00E2CD09 /* FormulaTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4825E8D7273ED74C00E2CD09 /* Build configuration list for PBXNativeTarget "Formula" */;
+			buildConfigurationList = 4825E8D7273ED74C00E2CD09 /* Build configuration list for PBXNativeTarget "FormulaTests" */;
 			buildPhases = (
 				4825E8CD273ED74C00E2CD09 /* Sources */,
 				4825E8CE273ED74C00E2CD09 /* Frameworks */,
@@ -245,9 +245,9 @@
 			dependencies = (
 				4825E8D6273ED74C00E2CD09 /* PBXTargetDependency */,
 			);
-			name = Formula;
+			name = FormulaTests;
 			productName = Formula;
-			productReference = 4825E8D1273ED74C00E2CD09 /* Formula.xctest */;
+			productReference = 4825E8D1273ED74C00E2CD09 /* FormulaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
@@ -274,7 +274,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1300;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1300;
 				TargetAttributes = {
 					4825E8A5273EB68D00E2CD09 = {
 						CreatedOnToolsVersion = 13.0;
@@ -309,7 +309,7 @@
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				4825E8A5273EB68D00E2CD09 /* CalculatorTests */,
 				4825E8BC273EC72100E2CD09 /* ExpressionParserTests */,
-				4825E8D0273ED74C00E2CD09 /* Formula */,
+				4825E8D0273ED74C00E2CD09 /* FormulaTests */,
 			);
 		};
 /* End PBXProject section */
@@ -658,7 +658,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -784,7 +784,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4825E8D7273ED74C00E2CD09 /* Build configuration list for PBXNativeTarget "Formula" */ = {
+		4825E8D7273ED74C00E2CD09 /* Build configuration list for PBXNativeTarget "FormulaTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4825E8D8273ED74C00E2CD09 /* Debug */,

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -68,6 +68,16 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4825E8D0273ED74C00E2CD09"
+               BuildableName = "Formula.xctest"
+               BlueprintName = "Formula"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -38,6 +38,26 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "481FCCB3273CF14D00349B74"
+               BuildableName = "LinkedListTests.xctest"
+               BlueprintName = "LinkedListTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "48DAB5F0273CF3AD00CB4A34"
+               BuildableName = "CalculatorTests2.xctest"
+               BlueprintName = "CalculatorTests2"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "48C16C4127391173006E1BBC"
+               BlueprintIdentifier = "4825E8A5273EB68D00E2CD09"
                BuildableName = "CalculatorTests.xctest"
                BlueprintName = "CalculatorTests"
                ReferencedContainer = "container:Calculator.xcodeproj">
@@ -55,6 +55,16 @@
                BlueprintIdentifier = "48DAB5F0273CF3AD00CB4A34"
                BuildableName = "CalculatorTests2.xctest"
                BlueprintName = "CalculatorTests2"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4825E8BC273EC72100E2CD09"
+               BuildableName = "ExpressionParserTests.xctest"
+               BlueprintName = "ExpressionParserTests"
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -74,7 +74,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4825E8D0273ED74C00E2CD09"
                BuildableName = "Formula.xctest"
-               BlueprintName = "Formula"
+               BlueprintName = "FormulaTests"
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -4,10 +4,6 @@ protocol CalculateItem {
     
 }
 
-extension Double: CalculateItem {
-    
-}
-
 struct CalculatorItemQueue<Element>: CalculateItem {
     var linkedList = LinkedListManager<Element>(head: nil)
     
@@ -23,5 +19,3 @@ struct CalculatorItemQueue<Element>: CalculateItem {
         return deletedValue
     }
 }
-
-

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -11,6 +11,7 @@ struct CalculatorItemQueue<Element> {
         linkedList.addNewNode(insertValue)
     }
     
+    @discardableResult
     func deleteFromQueue() throws -> Element {
         guard let deletedValue = linkedList.head?.nodeValue else {
             throw ErrorCase.emptyQueue 

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -2,14 +2,16 @@ protocol CalculateItem {
     
 }
 
-class CalculatorItemQueue<Element>: LinkedListManager<Element>, CalculateItem {
+struct CalculatorItemQueue<Element>: CalculateItem {
+    var linkedList = LinkedListManager<Element>(head: nil)
+    
     func insertToQueue(_ insertValue: Element) {
-        super.addNewNode(insertValue)
+        linkedList.addNewNode(insertValue)
     }
     
     func deleteFromQueue() {
-        guard self.head?.nodeValue != nil else { return }
-        super.deleteFirstNode()
+        guard linkedList.head?.nodeValue != nil else { return }
+        linkedList.deleteFirstNode()
     }
 }
 

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -1,6 +1,10 @@
-import Foundation
+import UIKit
 
 protocol CalculateItem {
+    
+}
+
+extension Double: CalculateItem {
     
 }
 

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -1,6 +1,3 @@
-import Foundation
-
-
 protocol CalculateItem {
     
 }
@@ -16,36 +13,4 @@ class CalculatorItemQueue<Element>: LinkedListManager<Element>, CalculateItem {
     }
 }
 
-class Node<Element> {
-    let nodeValue: Element
-    var pointer: Node?
-    
-    init(_ nodeValue: Element, pointer: Node? = nil) {
-        self.nodeValue = nodeValue
-        self.pointer = pointer
-    }
-}
-    
-class LinkedListManager<Element> {
-    var head: Node<Element>?
-    
-    init(head: Node<Element>?) {
-        self.head = head
-    }
-    
-    func addNewNode(_ nodeValue: Element) {
-        if head == nil {
-            head = Node(nodeValue)
-            return
-        }
-        var finderToLastNode: Node<Element>? = head
-        while finderToLastNode?.pointer != nil {
-            finderToLastNode = finderToLastNode?.pointer
-        }
-        finderToLastNode?.pointer = Node(nodeValue)
-    }
-    
-    func deleteFirstNode() {
-        head = head?.pointer
-    }
-}
+

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 protocol CalculateItem {
     
 }

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -11,9 +11,9 @@ struct CalculatorItemQueue<Element>: CalculateItem {
         linkedList.addNewNode(insertValue)
     }
     
-    func deleteFromQueue() -> Element {
+    func deleteFromQueue() throws -> Element {
         guard let deletedValue = linkedList.head?.nodeValue else {
-            return fatalError() as! Element   // 에러처리 구문 추가할 때 수정 예정
+            throw ErrorCase.emptyQueue 
         }
         linkedList.deleteFirstNode()
         return deletedValue

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -4,7 +4,7 @@ protocol CalculateItem {
     
 }
 
-struct CalculatorItemQueue<Element>: CalculateItem {
+struct CalculatorItemQueue<Element> {
     var linkedList = LinkedListManager<Element>(head: nil)
     
     func insertToQueue(_ insertValue: Element) {

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -5,8 +5,8 @@ protocol CalculateItem {
     
 }
 
-class CalculatorItemQueue<T>: LinkedListManager<T>, CalculateItem {
-    func insertToQueue(_ insertValue: T) {
+class CalculatorItemQueue<Element>: LinkedListManager<Element>, CalculateItem {
+    func insertToQueue(_ insertValue: Element) {
         super.addNewNode(insertValue)
     }
     
@@ -16,29 +16,29 @@ class CalculatorItemQueue<T>: LinkedListManager<T>, CalculateItem {
     }
 }
 
-class Node<T> {
-    let nodeValue: T
+class Node<Element> {
+    let nodeValue: Element
     var pointer: Node?
     
-    init(_ nodeValue: T, pointer: Node? = nil) {
+    init(_ nodeValue: Element, pointer: Node? = nil) {
         self.nodeValue = nodeValue
         self.pointer = pointer
     }
 }
     
-class LinkedListManager<T> {
-    var head: Node<T>?
+class LinkedListManager<Element> {
+    var head: Node<Element>?
     
-    init(head: Node<T>?) {
+    init(head: Node<Element>?) {
         self.head = head
     }
     
-    func addNewNode(_ nodeValue: T) {
+    func addNewNode(_ nodeValue: Element) {
         if head == nil {
             head = Node(nodeValue)
             return
         }
-        var finderToLastNode: Node<T>? = head
+        var finderToLastNode: Node<Element>? = head
         while finderToLastNode?.pointer != nil {
             finderToLastNode = finderToLastNode?.pointer
         }

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -15,9 +15,12 @@ struct CalculatorItemQueue<Element>: CalculateItem {
         linkedList.addNewNode(insertValue)
     }
     
-    func deleteFromQueue() {
-        guard linkedList.head?.nodeValue != nil else { return }
+    func deleteFromQueue() -> Element {
+        guard let deletedValue = linkedList.head?.nodeValue else {
+            return fatalError() as! Element   // 에러처리 구문 추가할 때 수정 예정
+        }
         linkedList.deleteFirstNode()
+        return deletedValue
     }
 }
 

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 
 protocol CalculateItem {
     

--- a/Calculator/Calculator/Error.swift
+++ b/Calculator/Calculator/Error.swift
@@ -3,5 +3,4 @@ import Foundation
 enum ErrorCase: Error {
     case emptyQueue
     case divideByZero
-    case invaildOperator
 }

--- a/Calculator/Calculator/Error.swift
+++ b/Calculator/Calculator/Error.swift
@@ -3,4 +3,5 @@ import Foundation
 enum ErrorCase: Error {
     case emptyQueue
     case divideByZero
+    case invaildOperator
 }

--- a/Calculator/Calculator/Error.swift
+++ b/Calculator/Calculator/Error.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum ErrorCase: Error {
+    case emptyQueue
+    case divideByZero
+}

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -8,12 +8,13 @@ enum ExpressionParser {
         let inputOperands = componentsByOperators(from: input)
         
         let formula = Formula()
-        for operandIndex in 0..<inputOperands.count {
-            formula.operands.insertToQueue(Double(inputOperands[operandIndex]) ?? 0)
+        for inputOperands in inputOperands {
+            formula.operands.insertToQueue(Double(inputOperands) ?? 0)
         }
-        for operatorIndex in 0..<inputOperator.count {
-            formula.operators.insertToQueue(Character(inputOperator[operatorIndex]))
+        for inputOperator in inputOperator {
+            formula.operators.insertToQueue(Character(inputOperator))
         }
+
         return formula
     }
 

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -8,10 +8,10 @@ enum ExpressionParser {
         let inputOperands = componentsByOperators(from: input)
         
         let formula = Formula()
-        for operandIndex in 0...inputOperands.count - 1 {
+        for operandIndex in 0..<inputOperands.count {
             formula.operands.insertToQueue(Double(inputOperands[operandIndex]) ?? 0)
         }
-        for operatorIndex in 0...inputOperator.count - 1 {
+        for operatorIndex in 0..<inputOperator.count {
             formula.operators.insertToQueue(Character(inputOperator[operatorIndex]))
         }
         return formula

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -4,7 +4,7 @@ enum ExpressionParser {
     static func parse(from input: String) -> Formula {
         let operatorEnumArray = Operator.allCases.map { String($0.rawValue) }
         let inputCharacters = Array(input).map { String($0) }
-        let inputOperator = inputCharacters.filter { operatorEnumArray.contains($0) == true }
+        let inputOperator = inputCharacters.filter { operatorEnumArray.contains($0) }
         let inputOperands = componentsByOperators(from: input)
         
         let formula = Formula()

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -18,13 +18,13 @@ enum ExpressionParser {
     }
 
     private static func componentsByOperators(from input: String) -> [String] {
-        var splitedWithTarget: [String]
-        var joinedString = input
+        var arrayOfBeingSplit: [String]
+        var stringOfSplitTarget = input
         for operatorCase in Operator.allCases {
-            splitedWithTarget = joinedString.split(with: operatorCase.rawValue)
-            joinedString = splitedWithTarget.joined(separator: " ")
+            arrayOfBeingSplit = stringOfSplitTarget.split(with: operatorCase.rawValue)
+            stringOfSplitTarget = arrayOfBeingSplit.joined(separator: " ")
         }
-        let inputOperands = joinedString.components(separatedBy: " ")
+        let inputOperands = stringOfSplitTarget.components(separatedBy: " ")
         return inputOperands
     }
 }

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum ExpressionParser {
+    func parse(from input: String) -> Formula {
+        let operatorEnumArray = Operator.allCases.map { String($0.rawValue) }
+        let inputCharacters = Array(input).map { String($0) }
+        let inputOperator = inputCharacters.filter { operatorEnumArray.contains($0) == true }
+        let inputOperands = componentsByOperators(from: input)
+        
+        let formula = Formula()
+        for operandIndex in 0...inputOperands.count {
+            formula.operands.insertToQueue(Double(inputOperands[operandIndex]) ?? 0)
+        }
+        for operatorIndex in 0...inputOperator.count {
+            formula.operators.insertToQueue(Character(inputOperator[operatorIndex]))
+        }
+        return formula
+    }
+
+    private func componentsByOperators(from input: String) -> [String] {
+        var splitedWithTarget: [String]
+        var joinedString = input
+        for operatorCase in Operator.allCases {
+            splitedWithTarget = joinedString.split(with: operatorCase.rawValue)
+            joinedString = splitedWithTarget.joined(separator: " ")
+        }
+        let inputOperands = joinedString.components(separatedBy: " ")
+        return inputOperands
+    }
+}

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -19,13 +19,11 @@ enum ExpressionParser {
     }
 
     private static func componentsByOperators(from input: String) -> [String] {
-        var arrayOfBeingSplit: [String]
-        var stringOfSplitTarget = input
+        var stringOfSplitTarget = [input]
         for operatorCase in Operator.allCases {
-            arrayOfBeingSplit = stringOfSplitTarget.split(with: operatorCase.rawValue)
-            stringOfSplitTarget = arrayOfBeingSplit.joined(separator: " ")
+            stringOfSplitTarget = stringOfSplitTarget.flatMap{ $0.split(with: operatorCase.rawValue)}
         }
-        let inputOperands = stringOfSplitTarget.components(separatedBy: " ")
+        let inputOperands = stringOfSplitTarget
         return inputOperands
     }
 }

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -1,23 +1,23 @@
 import Foundation
 
 enum ExpressionParser {
-    func parse(from input: String) -> Formula {
+    static func parse(from input: String) -> Formula {
         let operatorEnumArray = Operator.allCases.map { String($0.rawValue) }
         let inputCharacters = Array(input).map { String($0) }
         let inputOperator = inputCharacters.filter { operatorEnumArray.contains($0) == true }
         let inputOperands = componentsByOperators(from: input)
         
         let formula = Formula()
-        for operandIndex in 0...inputOperands.count {
+        for operandIndex in 0...inputOperands.count - 1 {
             formula.operands.insertToQueue(Double(inputOperands[operandIndex]) ?? 0)
         }
-        for operatorIndex in 0...inputOperator.count {
+        for operatorIndex in 0...inputOperator.count - 1 {
             formula.operators.insertToQueue(Character(inputOperator[operatorIndex]))
         }
         return formula
     }
 
-    private func componentsByOperators(from input: String) -> [String] {
+    private static func componentsByOperators(from input: String) -> [String] {
         var splitedWithTarget: [String]
         var joinedString = input
         for operatorCase in Operator.allCases {

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -8,7 +8,7 @@ struct Formula {
         guard var tempValue = try? operands.deleteFromQueue() else {
             throw ErrorCase.emptyQueue
         }
-        while operands.linkedList.head == nil {
+        while operands.linkedList.head != nil {
             if let currentOperand = try? operands.deleteFromQueue(),
                let currentOperator = try? operators.deleteFromQueue() {
                 let operatorCase = Operator(rawValue: currentOperator)

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -16,14 +16,3 @@ struct Formula {
         return result
     }
 }
-
-extension String {
-    func split(with target: Character) -> [String] {
-        let splitedString = self.split(separator: target).map { String($0) }
-        return splitedString
-    }
-}
-
-
-
-

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -1,4 +1,3 @@
-import Foundation
 import UIKit
 
 struct Formula {

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 
 struct Formula {
     var operands = CalculatorItemQueue<Element>()

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-struct Formula<Element> {
-    var operands = CalculatorItemQueue<Element>()
-    var operators = CalculatorItemQueue<Element>()
+struct Formula {
+    var operands = CalculatorItemQueue<Double>()
+    var operators = CalculatorItemQueue<String>()
     
-    func result() -> Double {
-
-
-    }
+//    func result() -> Double {
+//
+//
+//    }
 }
 
 extension String {
@@ -16,3 +16,32 @@ extension String {
         return splitedString
     }
 }
+
+
+enum ExpressionParser {
+    static let operatorEnumArray = Operator.allCases.map { String($0.rawValue) }
+    
+    func parse(from input: String) -> Formula {
+        var formula = Formula()
+        
+        let inputCharacters = Array(input).map { String($0) }
+        let operandsArray = componentsByOperators(from: input)
+        let operatorArray = inputCharacters.filter { ExpressionParser.operatorEnumArray.contains($0) == true }
+        
+        for operandIndex in 0...operandsArray.count {
+            formula.operands.insertToQueue(Double(operandsArray[operandIndex]) ?? 0)
+        }
+        
+        for operatorIndex in 0...operatorArray.count {
+            formula.operators.insertToQueue(operatorArray[operatorIndex])
+        }
+         //입력받은 값 피연산자or연산자를 두개의 큐 중 적절한 큐에 저장
+        return formula
+    }
+
+    private func componentsByOperators(from input: String) -> [String] {
+        return input.components(separatedBy: ["+","-","/","*"])
+        
+    }
+}
+

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -19,23 +19,19 @@ extension String {
 
 
 enum ExpressionParser {
-    static let operatorEnumArray = Operator.allCases.map { String($0.rawValue) }
-    
     func parse(from input: String) -> Formula {
-        var formula = Formula()
-        
+        let operatorEnumArray = Operator.allCases.map { String($0.rawValue) }
         let inputCharacters = Array(input).map { String($0) }
-        let operandsArray = componentsByOperators(from: input)
-        let operatorArray = inputCharacters.filter { ExpressionParser.operatorEnumArray.contains($0) == true }
+        let inputOperands = componentsByOperators(from: input)
+        let inputOperator = inputCharacters.filter { operatorEnumArray.contains($0) == true }
         
-        for operandIndex in 0...operandsArray.count {
-            formula.operands.insertToQueue(Double(operandsArray[operandIndex]) ?? 0)
+        let formula = Formula()
+        for operandIndex in 0...inputOperands.count {
+            formula.operands.insertToQueue(Double(inputOperands[operandIndex]) ?? 0)
         }
-        
-        for operatorIndex in 0...operatorArray.count {
-            formula.operators.insertToQueue(operatorArray[operatorIndex])
+        for operatorIndex in 0...inputOperator.count {
+            formula.operators.insertToQueue(inputOperator[operatorIndex])
         }
-         //입력받은 값 피연산자or연산자를 두개의 큐 중 적절한 큐에 저장
         return formula
     }
 

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -11,8 +11,8 @@ struct Formula {
         while operands.linkedList.head == nil {
             if let currentOperand = try? operands.deleteFromQueue(),
                let currentOperator = try? operators.deleteFromQueue() {
-                let `operator` = Operator(rawValue: currentOperator)
-                tempValue = `operator`?.calculate(lhs: tempValue, rhs: currentOperand) ?? 0
+                let operatorCase = Operator(rawValue: currentOperator)
+                tempValue = operatorCase?.calculate(lhs: tempValue, rhs: currentOperand) ?? 0
             }
         }
         return tempValue

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -4,10 +4,9 @@ struct Formula {
     var operands = CalculatorItemQueue<Double>()
     var operators = CalculatorItemQueue<String>()
     
-//    func result() -> Double {
-//
-//
-//    }
+    func result() -> Double {
+
+    }
 }
 
 extension String {
@@ -20,11 +19,10 @@ extension String {
 
 enum ExpressionParser {
     func parse(from input: String) -> Formula {
-        let inputOperands = componentsByOperators(from: input)
-        
         let operatorEnumArray = Operator.allCases.map { String($0.rawValue) }
         let inputCharacters = Array(input).map { String($0) }
         let inputOperator = inputCharacters.filter { operatorEnumArray.contains($0) == true }
+        let inputOperands = componentsByOperators(from: input)
         
         let formula = Formula()
         for operandIndex in 0...inputOperands.count {

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 struct Formula {
     var operands = CalculatorItemQueue<Element>()
@@ -9,3 +10,4 @@ struct Formula {
         
     }
 }
+

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -2,10 +2,18 @@ import Foundation
 
 struct Formula {
     var operands = CalculatorItemQueue<Double>()
-    var operators = CalculatorItemQueue<String>()
+    var operators = CalculatorItemQueue<Character>()
     
     func result() -> Double {
-
+        var result: Double = 0
+        while operands.linkedList.head == nil {
+            let value = operands.deleteFromQueue()
+            guard let oper = Operator(rawValue: operators.deleteFromQueue()) else {
+                return 0      // 에러처리 구문 추가 시 수정
+            }
+            result = oper.calculate(lhs: result, rhs: value)
+        }
+        return result
     }
 }
 
@@ -17,32 +25,5 @@ extension String {
 }
 
 
-enum ExpressionParser {
-    func parse(from input: String) -> Formula {
-        let operatorEnumArray = Operator.allCases.map { String($0.rawValue) }
-        let inputCharacters = Array(input).map { String($0) }
-        let inputOperator = inputCharacters.filter { operatorEnumArray.contains($0) == true }
-        let inputOperands = componentsByOperators(from: input)
-        
-        let formula = Formula()
-        for operandIndex in 0...inputOperands.count {
-            formula.operands.insertToQueue(Double(inputOperands[operandIndex]) ?? 0)
-        }
-        for operatorIndex in 0...inputOperator.count {
-            formula.operators.insertToQueue(inputOperator[operatorIndex])
-        }
-        return formula
-    }
 
-    private func componentsByOperators(from input: String) -> [String] {
-        var splitedWithTarget: [String]
-        var joinedString = input
-        for operatorCase in Operator.allCases {
-            splitedWithTarget = joinedString.split(with: operatorCase.rawValue)
-            joinedString = splitedWithTarget.joined(separator: " ")
-        }
-        let inputOperands = joinedString.components(separatedBy: " ")
-        return inputOperands
-    }
-}
 

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -1,12 +1,18 @@
 import Foundation
 
-struct Formula {
+struct Formula<Element> {
     var operands = CalculatorItemQueue<Element>()
     var operators = CalculatorItemQueue<Element>()
     
     func result() -> Double {
-        
-        
+
+
     }
 }
 
+extension String {
+    func split(with target: Character) -> [String] {
+        let splitedString = self.split(separator: target).map { String($0) }
+        return splitedString
+    }
+}

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct Formula {
+    var operands = CalculatorItemQueue<Element>()
+    var operators = CalculatorItemQueue<Element>()
+    
+    func result() -> Double {
+        
+        
+    }
+}

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -4,15 +4,17 @@ struct Formula {
     var operands = CalculatorItemQueue<Double>()
     var operators = CalculatorItemQueue<Character>()
     
-    func result() -> Double {
-        var result: Double = 0
-        while operands.linkedList.head == nil {
-            let value = operands.deleteFromQueue()
-            guard let oper = Operator(rawValue: operators.deleteFromQueue()) else {
-                return 0      // 에러처리 구문 추가 시 수정
-            }
-            result = oper.calculate(lhs: result, rhs: value)
+    func result() throws -> Double {
+        guard var tempValue = try? operands.deleteFromQueue() else {
+            throw ErrorCase.emptyQueue
         }
-        return result
+        while operands.linkedList.head == nil {
+            if let currentOperand = try? operands.deleteFromQueue(),
+               let currentOperator = try? operators.deleteFromQueue() {
+                let `operator` = Operator(rawValue: currentOperator)
+                tempValue = `operator`?.calculate(lhs: tempValue, rhs: currentOperand) ?? 0
+            }
+        }
+        return tempValue
     }
 }

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -20,9 +20,10 @@ extension String {
 
 enum ExpressionParser {
     func parse(from input: String) -> Formula {
+        let inputOperands = componentsByOperators(from: input)
+        
         let operatorEnumArray = Operator.allCases.map { String($0.rawValue) }
         let inputCharacters = Array(input).map { String($0) }
-        let inputOperands = componentsByOperators(from: input)
         let inputOperator = inputCharacters.filter { operatorEnumArray.contains($0) == true }
         
         let formula = Formula()
@@ -36,8 +37,14 @@ enum ExpressionParser {
     }
 
     private func componentsByOperators(from input: String) -> [String] {
-        return input.components(separatedBy: ["+","-","/","*"])
-        
+        var splitedWithTarget: [String]
+        var joinedString = input
+        for operatorCase in Operator.allCases {
+            splitedWithTarget = joinedString.split(with: operatorCase.rawValue)
+            joinedString = splitedWithTarget.joined(separator: " ")
+        }
+        let inputOperands = joinedString.components(separatedBy: " ")
+        return inputOperands
     }
 }
 

--- a/Calculator/Calculator/LinkedList.swift
+++ b/Calculator/Calculator/LinkedList.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 
 class Node<Element> {
     let nodeValue: Element

--- a/Calculator/Calculator/LinkedList.swift
+++ b/Calculator/Calculator/LinkedList.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 class Node<Element> {
     let nodeValue: Element
     var pointer: Node?

--- a/Calculator/Calculator/LinkedList.swift
+++ b/Calculator/Calculator/LinkedList.swift
@@ -1,0 +1,33 @@
+class Node<Element> {
+    let nodeValue: Element
+    var pointer: Node?
+    
+    init(_ nodeValue: Element, pointer: Node? = nil) {
+        self.nodeValue = nodeValue
+        self.pointer = pointer
+    }
+}
+    
+class LinkedListManager<Element> {
+    var head: Node<Element>?
+    
+    init(head: Node<Element>?) {
+        self.head = head
+    }
+    
+    func addNewNode(_ nodeValue: Element) {
+        if head == nil {
+            head = Node(nodeValue)
+            return
+        }
+        var finderToLastNode: Node<Element>? = head
+        while finderToLastNode?.pointer != nil {
+            finderToLastNode = finderToLastNode?.pointer
+        }
+        finderToLastNode?.pointer = Node(nodeValue)
+    }
+    
+    func deleteFirstNode() {
+        head = head?.pointer
+    }
+}

--- a/Calculator/Calculator/LinkedList.swift
+++ b/Calculator/Calculator/LinkedList.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 class Node<Element> {
     let nodeValue: Element

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -1,0 +1,31 @@
+enum Operator: Character, CaseIterable {
+    case add
+    case subtract
+    case divide
+    case multiply
+    
+    func calculate(lhs: Double, rhs: Double) -> Double {
+        switch self {
+        case .add:
+            add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            subtract(lhs: lhs, rhs: rhs)
+        case .divide:
+            divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            multiply(lhs: lsh, rhs: rhs)
+        }
+    }
+    private func add(lhs: Double, rhs: Double) -> Double {
+        return lhs + rhs
+    }
+    private func subtract(lhs: Double, rhs: Double) -> Double {
+        return lhs - rhs
+    }
+    private func divide(lhs: Double, rhs: Double) -> Double {
+        return lhs / rhs
+    }
+    private func multiply(lhs: Double, rhs: Double) -> Double {
+        return lhs * rhs
+    }
+}

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -1,4 +1,4 @@
-enum Operator: Character, CaseIterable {
+enum Operator: Character, CaseIterable, CalculateItem {
     case add
     case subtract
     case divide

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -1,21 +1,21 @@
-import UIKit
+import Foundation
 
 enum Operator: Character, CaseIterable, CalculateItem {
-    case add
-    case subtract
-    case divide
-    case multiply
+    case add = "+"
+    case subtract = "-"
+    case divide = "/"
+    case multiply = "*"
     
     func calculate(lhs: Double, rhs: Double) -> Double {
         switch self {
         case .add:
-            add(lhs: lhs, rhs: rhs)
+            return add(lhs: lhs, rhs: rhs)
         case .subtract:
-            subtract(lhs: lhs, rhs: rhs)
+            return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            divide(lhs: lhs, rhs: rhs)
+            return divide(lhs: lhs, rhs: rhs)
         case .multiply:
-            multiply(lhs: lsh, rhs: rhs)
+            return multiply(lhs: lhs, rhs: rhs)
         }
     }
     private func add(lhs: Double, rhs: Double) -> Double {

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -13,10 +13,13 @@ enum Operator: Character, CaseIterable, CalculateItem {
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            guard let result = try? divide(lhs: lhs, rhs: rhs) else {
+            do {
+                let result = try divide(lhs: lhs, rhs: rhs)
+                return result
+            } catch {
                 return .nan
             }
-            return result
+            
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
         }

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -13,7 +13,8 @@ enum Operator: Character, CaseIterable, CalculateItem {
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            return divide(lhs: lhs, rhs: rhs)
+            guard let result = try? divide(lhs: lhs, rhs: rhs) else { return 0 }
+            return result
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
         }
@@ -24,7 +25,10 @@ enum Operator: Character, CaseIterable, CalculateItem {
     private func subtract(lhs: Double, rhs: Double) -> Double {
         return lhs - rhs
     }
-    private func divide(lhs: Double, rhs: Double) -> Double {
+    private func divide(lhs: Double, rhs: Double) throws -> Double {
+        guard rhs == 0 else {
+            throw ErrorCase.divideByZero
+        }
         return lhs / rhs
     }
     private func multiply(lhs: Double, rhs: Double) -> Double {

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -13,7 +13,9 @@ enum Operator: Character, CaseIterable, CalculateItem {
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            guard let result = try? divide(lhs: lhs, rhs: rhs) else { return 0 }
+            guard let result = try? divide(lhs: lhs, rhs: rhs) else {
+                return .nan
+            }
             return result
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
@@ -26,7 +28,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
         return lhs - rhs
     }
     private func divide(lhs: Double, rhs: Double) throws -> Double {
-        guard rhs == 0 else {
+        guard rhs != 0 else {
             throw ErrorCase.divideByZero
         }
         return lhs / rhs

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 enum Operator: Character, CaseIterable, CalculateItem {
     case add
     case subtract

--- a/Calculator/Calculator/extension.swift
+++ b/Calculator/Calculator/extension.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension Double: CalculateItem {
+    
+}
+
+extension String {
+    func split(with target: Character) -> [String] {
+        let splitedString = self.split(separator: target).map { String($0) }
+        return splitedString
+    }
+}

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -36,7 +36,11 @@ class CalculatorTests: XCTestCase {
     func test_빈큐에_deleteFromQueue하면_emptyQueue오류발생() {
         let queue = CalculatorItemQueue<Int>()
         XCTAssertNil(queue.linkedList.head?.nodeValue)
-        try? queue.deleteFromQueue()
-        XCTAssertThrowsError(ErrorCase.emptyQueue)
+        
+        do {
+            try? queue.deleteFromQueue()
+        } catch ErrorCase.emptyQueue {
+            XCTAssertThrowsError(ErrorCase.emptyQueue)
+        }
     }
 }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -41,6 +41,8 @@ class CalculatorTests: XCTestCase {
             try queue.deleteFromQueue()
         } catch ErrorCase.emptyQueue {
             XCTAssertThrowsError(ErrorCase.emptyQueue)
+        } catch {
+            return
         }
     }
 }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -38,7 +38,7 @@ class CalculatorTests: XCTestCase {
         XCTAssertNil(queue.linkedList.head?.nodeValue)
         
         do {
-            try? queue.deleteFromQueue()
+            try queue.deleteFromQueue()
         } catch ErrorCase.emptyQueue {
             XCTAssertThrowsError(ErrorCase.emptyQueue)
         }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 
+
 class CalculatorTests: XCTestCase {
     func test_빈_큐에_1을_put하면_1이_남는다() {
         let queue = CalculatorItemQueue<Int>(head: nil)

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -2,11 +2,41 @@ import XCTest
 
 class CalculatorTests: XCTestCase {
 
-    func test_빈큐에_delete를_하면_에러발생() {
-        let cal = CalculatorItemQueue<Double>()
-        try? cal.deleteFromQueue()
-        XCTAssertNoThrow(ErrorCase.emptyQueue)
+    func test_빈_큐에_1을_put하면_1이_남는다() {
+        let queue = CalculatorItemQueue<Int>()
+        queue.insertToQueue(1)
+        XCTAssertEqual(queue.linkedList.head?.nodeValue, 1)
+        XCTAssertNil(queue.linkedList.head?.pointer)
     }
-    
-    
+
+    func test_1이_있는_큐에_2를_put하면_1과_2가_남는다() {
+        let queue = CalculatorItemQueue<Int>()
+        queue.linkedList.head = Node(1)
+        queue.insertToQueue(2)
+        XCTAssertEqual(queue.linkedList.head?.nodeValue, 1)
+        XCTAssertEqual(queue.linkedList.head?.pointer?.nodeValue, 2)
+        XCTAssertNil(queue.linkedList.head?.pointer?.pointer)
+    }
+
+    func test_1만_있는_큐에_get을_하면_빈_큐가_된다() {
+        let queue = CalculatorItemQueue<Int>()
+        queue.linkedList.head = Node(1)
+        try! queue.deleteFromQueue()
+        XCTAssertNil(queue.linkedList.head?.nodeValue)
+    }
+    func test_1과_2가_있는_큐에_get을_하면_2가_남는다() {
+        let queue = CalculatorItemQueue<Int>()
+        queue.linkedList.head = Node(1)
+        queue.linkedList.head?.pointer = Node(2)
+        try! queue.deleteFromQueue()
+        XCTAssertEqual(queue.linkedList.head?.nodeValue, 2)
+        XCTAssertNil(queue.linkedList.head?.pointer)
+    }
+
+    func test_빈큐에_deleteFromQueue하면_emptyQueue오류발생() {
+        let queue = CalculatorItemQueue<Int>()
+        XCTAssertNil(queue.linkedList.head?.nodeValue)
+        try? queue.deleteFromQueue()
+        XCTAssertThrowsError(ErrorCase.emptyQueue)
+    }
 }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -1,40 +1,12 @@
 import XCTest
 
-
 class CalculatorTests: XCTestCase {
-    func test_빈_큐에_1을_put하면_1이_남는다() {
-        let queue = CalculatorItemQueue<Int>(head: nil)
-        queue.insertToQueue(1)
-        XCTAssertEqual(queue.head?.nodeValue, 1)
-        XCTAssertNil(queue.head?.pointer)
-    }
-        
-    func test_1이_있는_큐에_2를_put하면_1과_2가_남는다() {
-        let queue = CalculatorItemQueue<Int>(head: Node(1))
-        queue.insertToQueue(2)
-        XCTAssertEqual(queue.head?.nodeValue, 1)
-        XCTAssertEqual(queue.head?.pointer?.nodeValue, 2)
-        XCTAssertNil(queue.head?.pointer?.pointer)
-    }
 
-    func test_1만_있는_큐에_get을_하면_빈_큐가_된다() {
-        let queue = CalculatorItemQueue<Int>(head: Node(1))
-        queue.deleteFromQueue()
-        XCTAssertNil(queue.head?.nodeValue)
+    func test_빈큐에_delete를_하면_에러발생() {
+        let cal = CalculatorItemQueue<Double>()
+        try? cal.deleteFromQueue()
+        XCTAssertNoThrow(ErrorCase.emptyQueue)
     }
-
-    func test_1과_2가_있는_큐에_get을_하면_2가_남는다() {
-        let queue = CalculatorItemQueue<Int>(head: Node(1, pointer: Node(2)))
-        queue.deleteFromQueue()
-        XCTAssertEqual(queue.head?.nodeValue, 2)
-        XCTAssertNil(queue.head?.pointer)
-    }
-
-    func test_비어있는_큐에는_getFromQueue_함수를_쓰더라도_아무변화가_없다() {
-        let queue = CalculatorItemQueue<Int>(head: nil)
-        XCTAssertNil(queue.head?.nodeValue)
-        queue.deleteFromQueue()
-        XCTAssertNil(queue.head?.nodeValue)
-    }
-
+    
+    
 }

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -27,4 +27,6 @@ class ExpressionParserTests: XCTestCase {
         var testArr: [Character] = ["+", "*"]
         XCTAssertEqual(formulaQueueArr, testArr)
     }
+
+    
 }

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+class ExpressionParserTests: XCTestCase {
+    var sut: ExpressionParser.Type! = ExpressionParser.self
+    
+    func test_1더하기2곱하기3_을_했을_경우_피연산큐에_123_저장() {
+        var formula = Formula()
+        formula = sut.parse(from: "1+2*3")
+        
+        var formulaQueueArr = [Double]()
+        formulaQueueArr.append(formula.operands.linkedList.head!.nodeValue)
+        formulaQueueArr.append(formula.operands.linkedList.head!.pointer!.nodeValue)
+        formulaQueueArr.append(formula.operands.linkedList.head!.pointer!.pointer!.nodeValue)
+        
+        var testArr: [Double] = [1, 2, 3]
+        XCTAssertEqual(formulaQueueArr, testArr)
+    }
+    
+    func test_1더하기2곱하기3을_하면_연산큐에_더하기곱하기_기호_저장() {
+        var formula = Formula()
+        formula = sut.parse(from: "1+2*3")
+        
+        var formulaQueueArr = [Character]()
+        formulaQueueArr.append(formula.operators.linkedList.head!.nodeValue)
+        formulaQueueArr.append(formula.operators.linkedList.head!.pointer!.nodeValue)
+
+        var testArr: [Character] = ["+", "*"]
+        XCTAssertEqual(formulaQueueArr, testArr)
+    }
+}

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -12,7 +12,7 @@ class ExpressionParserTests: XCTestCase {
         formulaQueueArr.append(formula.operands.linkedList.head!.pointer!.nodeValue)
         formulaQueueArr.append(formula.operands.linkedList.head!.pointer!.pointer!.nodeValue)
         
-        var testArr: [Double] = [1, 2, 3]
+        let testArr: [Double] = [1, 2, 3]
         XCTAssertEqual(formulaQueueArr, testArr)
     }
     
@@ -24,7 +24,7 @@ class ExpressionParserTests: XCTestCase {
         formulaQueueArr.append(formula.operators.linkedList.head!.nodeValue)
         formulaQueueArr.append(formula.operators.linkedList.head!.pointer!.nodeValue)
 
-        var testArr: [Character] = ["+", "*"]
+        let testArr: [Character] = ["+", "*"]
         XCTAssertEqual(formulaQueueArr, testArr)
     }
 

--- a/Calculator/Formula/FormulaTests.swift
+++ b/Calculator/Formula/FormulaTests.swift
@@ -3,7 +3,7 @@ import XCTest
 class FormulaTests: XCTestCase {
     var sut: ExpressionParser.Type! = ExpressionParser.self
     
-    func 일_더하기_이를_입력하면_삼_반환() {
+    func test_일_더하기_이를_입력하면_삼_반환() {
         var formula = Formula()
         formula = sut.parse(from: "1+2")
         let result = try? formula.result()
@@ -19,5 +19,6 @@ class FormulaTests: XCTestCase {
         }
     }
     
+
 
 }

--- a/Calculator/Formula/FormulaTests.swift
+++ b/Calculator/Formula/FormulaTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+class FormulaTests: XCTestCase {
+    var sut: ExpressionParser.Type! = ExpressionParser.self
+    
+    func 일_더하기_이를_입력하면_삼_반환() {
+        var formula = Formula()
+        formula = sut.parse(from: "1+2")
+        let result = try? formula.result()
+        XCTAssertEqual(result, 3)
+    }
+        
+    func test_나누기0을_하면_divideByZero에러_throw() {
+        var formula = Formula()
+        do {
+            try formula = sut.parse(from: "1+2/0")
+        } catch ErrorCase.divideByZero {
+            XCTAssertThrowsError(ErrorCase.divideByZero)
+        }
+    }
+    
+
+}

--- a/Calculator/Formula/FormulaTests.swift
+++ b/Calculator/Formula/FormulaTests.swift
@@ -14,7 +14,6 @@ class FormulaTests: XCTestCase {
         var formula = Formula()
         formula = sut.parse(from: "4*2/0")
         let result = try? formula.result()
-        XCTAssertEqual(result, .nan)
+        XCTAssertTrue(result!.isNaN)
     }
-    
 }

--- a/Calculator/Formula/FormulaTests.swift
+++ b/Calculator/Formula/FormulaTests.swift
@@ -10,15 +10,11 @@ class FormulaTests: XCTestCase {
         XCTAssertEqual(result, 3)
     }
         
-    func test_나누기0을_하면_divideByZero에러_throw() {
+    func test_나누기0을_하면_nan_반환() {
         var formula = Formula()
-        do {
-            try formula = sut.parse(from: "1+2/0")
-        } catch ErrorCase.divideByZero {
-            XCTAssertThrowsError(ErrorCase.divideByZero)
-        }
+        formula = sut.parse(from: "4*2/0")
+        let result = try? formula.result()
+        XCTAssertEqual(result, .nan)
     }
     
-
-
 }


### PR DESCRIPTION
안녕하세요 @jae57 🙂
계산기 프로젝트 STEP2 PR 제출합니다!

하면 할수록 부족함을 많이 느끼게 되네요.
이번 피드백도 잘 부탁드려요. 감사합니다. 💕


## 고민했던 점

- 피연산자 분리 방법
    
    → `componentsByoeprators` 메소드에서 열거형의 `rawValue`를 `components`의 세퍼레이터로 하고싶은데 방법을 못찾아서 아래와 같은 방법으로 피연산자를 분리했습니다.
    
    1. `var ****arrayOfBeingSplit`: 나누어지는 과정에서 임시로 저장하는 배열
    2. `var stringOfSplitTarget`: 나누어지는 과정에서 분리의 대상이 되는 문자열(초기값: `input`)
    3. 입력 문자열을 연산자 기준으로 분리합니다. 다만, 연산자 4개를 한번에 적용해서 분리하는 방법을 찾지 못해서 `for문`을 돌며 순서대로 분리를 했습니다.
        
        → 처음엔 `components(separatedBy: ["+", "-", "/", "*")`와 같이 분리를 했었는데, 이보다는 `Operator` 타입을 활용하고 싶어서 로직을 변경했습니다.
        
    4. `arrayOfBeingSplit`(임시배열)에 +를 기준으로 나눈 값을 저장 후, 이 배열들을 공백 한칸을 기준으로 한 `joined`를 이용하여 문자열로 만든 다음, 다음 루프에서 다시 -를 기준으로 나누는 과정을 반복합니다.
    5. 최종적으로 나온 문자열을 (예: 1 2 3 4) 공백을 기준으로 `components`하여 피연산자배열에 넣습니다.

- 연산자 분리 방법
    
    → 입력 문자열 전체를 문자 단위로 쪼갠 배열 (예: [1,2,+,3,0,0,/,2]에서 `Operator`의 `allCases` 배열을 필터링하여 입력 연산자 배열을 만들었습니다.
    

- 연산자가 2번 이상 입력되는 경우 생길 수 있는 오류처리
    
    위의 방법으로 피연산자와 연산자를 분리했을 때, 연산자가 2번 이상 연속으로 입력되었을 때, 오류를 잡아내지 못할 수 있습니다. 고민해본 결과 이 문제는 추후에 입력받는 부분을 코딩할 때 해결해야 할 것으로 판단했습니다. 입력을 받을 때마다 연산자/피연산자 전환을 알려주는 기능을 갖는 변수를 사용하여 애초에 연산자의 연속 입력이 불가능하도록 하면 되지 않을까 생각하고 있습니다. 연산자를 두번 이상 입력할 경우 맨 마지막 연산자만 유효하다는 조건이 있기 때문에 그 기능과 함께 구현해도 될 것 같다는 생각도 막연히...하고있습니다. 🤣
    

- 아래 코드의 테스트과정에서 inputOperands가 빈배열일 경우 count-1 부분 때문에 오류가 발생했습니다. 처음에는 어떻게 고쳐야할까 고민했는데, 생각해보니 계산기 입력시에 아무 입력도 없다면 연산 관련 코드들을 호출하지 않을 것이기 때문에 이부분은 이대로도 괜찮다고 생각했습니다. 제 생각이 맞을까요?
    
    ```swift
    for operandIndex in 0...inputOperands.count - 1 {
                formula.operands.insertToQueue(Double(inputOperands[operandIndex]) ?? 0)
            }
    ```
    

 

## 조언을 얻고 싶은 부분

- 코드를 파일별로 나눌때 어떤 기준으로 나누는 게 좋을까요? 일단 지금은 클래스별로 나누고, 익스텐션을 따로 나누어놨는데 익스텐션이나 프로토콜은 별도의 파일로 관리하는 게 바람직할까요? 또, 만약에 익스텐션이나 프로토콜이 여러개라면 각각 따로 나누는 게 좋을지 익스텐션은 익스텐션끼리 두는 방식으로 묶으면 좋을지 궁금합니다.
- 테스트를 하는 과정에서 아래 오류가 생겼는데 제가 보기에는 두개의 값이 같은거 같은데...!? 왜 이게 뜨는지 모르겠습니다..조언부탁드려요ㅠㅠ

![](https://i.imgur.com/Th8Ljfg.png)