### PR TITLE
계산기 [STEP 2] 제이티

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -99,6 +99,13 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
+		6B3F68F82742DCBF00BBD390 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		6B471727273A60F00012D081 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
@@ -176,6 +183,7 @@
 			isa = PBXGroup;
 			children = (
 				6B2FCE04273A040500205344 /* Model */,
+				6B3F68F82742DCBF00BBD390 /* Error */,
 				6B471727273A60F00012D081 /* Protocol */,
 				6B3F68DD2741331000BBD390 /* Extension */,
 				6B95977D27390EBC00C705D1 /* ViewController */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6B2FCE06273A041400205344 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2FCE05273A041400205344 /* CalculatorItemQueue.swift */; };
 		6B3F68DF274133F700BBD390 /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68DE274133F700BBD390 /* Double+Extensions.swift */; };
 		6B3F68E12741357E00BBD390 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E02741357E00BBD390 /* Operator.swift */; };
+		6B3F68E527413A3000BBD390 /* AddOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -34,6 +35,7 @@
 		6B2FCE05273A041400205344 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		6B3F68DE274133F700BBD390 /* Double+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extensions.swift"; sourceTree = "<group>"; };
 		6B3F68E02741357E00BBD390 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOperatorTests.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 			isa = PBXGroup;
 			children = (
 				6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */,
+				6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -266,6 +269,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */,
+				6B3F68E527413A3000BBD390 /* AddOperatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		6B3F68E12741357E00BBD390 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E02741357E00BBD390 /* Operator.swift */; };
 		6B3F68E527413A3000BBD390 /* AddOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */; };
 		6B3F68E727413D4600BBD390 /* SubtractOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */; };
+		6B3F68E927413DA900BBD390 /* DivideOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -38,6 +39,7 @@
 		6B3F68E02741357E00BBD390 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOperatorTests.swift; sourceTree = "<group>"; };
 		6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtractOperatorTests.swift; sourceTree = "<group>"; };
+		6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivideOperatorTests.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 				6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */,
 				6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */,
 				6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */,
+				6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -271,6 +274,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B3F68E927413DA900BBD390 /* DivideOperatorTests.swift in Sources */,
 				6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */,
 				6B3F68E527413A3000BBD390 /* AddOperatorTests.swift in Sources */,
 				6B3F68E727413D4600BBD390 /* SubtractOperatorTests.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		6B2FCE06273A041400205344 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2FCE05273A041400205344 /* CalculatorItemQueue.swift */; };
 		6B3F68DF274133F700BBD390 /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68DE274133F700BBD390 /* Double+Extensions.swift */; };
+		6B3F68E12741357E00BBD390 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E02741357E00BBD390 /* Operator.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -32,6 +33,7 @@
 /* Begin PBXFileReference section */
 		6B2FCE05273A041400205344 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		6B3F68DE274133F700BBD390 /* Double+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extensions.swift"; sourceTree = "<group>"; };
+		6B3F68E02741357E00BBD390 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
@@ -67,6 +69,7 @@
 			isa = PBXGroup;
 			children = (
 				6B2FCE05273A041400205344 /* CalculatorItemQueue.swift */,
+				6B3F68E02741357E00BBD390 /* Operator.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -274,6 +277,7 @@
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				6B3F68DF274133F700BBD390 /* Double+Extensions.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				6B3F68E12741357E00BBD390 /* Operator.swift in Sources */,
 				6B2FCE06273A041400205344 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		6B3F68E727413D4600BBD390 /* SubtractOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */; };
 		6B3F68E927413DA900BBD390 /* DivideOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */; };
 		6B3F68EB2741401D00BBD390 /* MultiplyOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */; };
+		6B3F68ED274140C700BBD390 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68EC274140C700BBD390 /* String+Extensions.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -42,6 +43,7 @@
 		6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtractOperatorTests.swift; sourceTree = "<group>"; };
 		6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivideOperatorTests.swift; sourceTree = "<group>"; };
 		6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplyOperatorTests.swift; sourceTree = "<group>"; };
+		6B3F68EC274140C700BBD390 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -86,6 +88,7 @@
 			isa = PBXGroup;
 			children = (
 				6B3F68DE274133F700BBD390 /* Double+Extensions.swift */,
+				6B3F68EC274140C700BBD390 /* String+Extensions.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -293,6 +296,7 @@
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				6B3F68DF274133F700BBD390 /* Double+Extensions.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				6B3F68ED274140C700BBD390 /* String+Extensions.swift in Sources */,
 				6B3F68E12741357E00BBD390 /* Operator.swift in Sources */,
 				6B2FCE06273A041400205344 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		6B3F68ED274140C700BBD390 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68EC274140C700BBD390 /* String+Extensions.swift */; };
 		6B3F68F1274142B600BBD390 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F0274142B600BBD390 /* Formula.swift */; };
 		6B3F68F32741484300BBD390 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F22741484300BBD390 /* ExpressionParser.swift */; };
+		6B3F68FA2742DEFC00BBD390 /* OperatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F92742DEFC00BBD390 /* OperatorError.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -48,6 +49,7 @@
 		6B3F68EC274140C700BBD390 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		6B3F68F0274142B600BBD390 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		6B3F68F22741484300BBD390 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		6B3F68F92742DEFC00BBD390 /* OperatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorError.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 		6B3F68F82742DCBF00BBD390 /* Error */ = {
 			isa = PBXGroup;
 			children = (
+				6B3F68F92742DEFC00BBD390 /* OperatorError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -306,6 +309,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B3F68FA2742DEFC00BBD390 /* OperatorError.swift in Sources */,
 				6B3F68F32741484300BBD390 /* ExpressionParser.swift in Sources */,
 				6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -69,6 +69,13 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		6B3F68DD2741331000BBD390 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		6B471727273A60F00012D081 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
@@ -143,6 +150,7 @@
 			children = (
 				6B2FCE04273A040500205344 /* Model */,
 				6B471727273A60F00012D081 /* Protocol */,
+				6B3F68DD2741331000BBD390 /* Extension */,
 				6B95977D27390EBC00C705D1 /* ViewController */,
 				6B95977E27390EC800C705D1 /* Storyboard */,
 				6B95977C27390EAA00C705D1 /* App Lifecycle */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		6B3F68E927413DA900BBD390 /* DivideOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */; };
 		6B3F68EB2741401D00BBD390 /* MultiplyOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */; };
 		6B3F68ED274140C700BBD390 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68EC274140C700BBD390 /* String+Extensions.swift */; };
+		6B3F68F1274142B600BBD390 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F0274142B600BBD390 /* Formula.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -44,6 +45,7 @@
 		6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivideOperatorTests.swift; sourceTree = "<group>"; };
 		6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplyOperatorTests.swift; sourceTree = "<group>"; };
 		6B3F68EC274140C700BBD390 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
+		6B3F68F0274142B600BBD390 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 			children = (
 				6B2FCE05273A041400205344 /* CalculatorItemQueue.swift */,
 				6B3F68E02741357E00BBD390 /* Operator.swift */,
+				6B3F68F0274142B600BBD390 /* Formula.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -300,6 +303,7 @@
 				6B3F68E12741357E00BBD390 /* Operator.swift in Sources */,
 				6B2FCE06273A041400205344 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				6B3F68F1274142B600BBD390 /* Formula.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		6B3F68F32741484300BBD390 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F22741484300BBD390 /* ExpressionParser.swift */; };
 		6B3F68FA2742DEFC00BBD390 /* OperatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F92742DEFC00BBD390 /* OperatorError.swift */; };
 		6B3F69002742EC0C00BBD390 /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68FF2742EC0C00BBD390 /* ExpressionParserTests.swift */; };
+		6B3F6902274410A700BBD390 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F6901274410A700BBD390 /* FormulaTests.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -52,6 +53,7 @@
 		6B3F68F22741484300BBD390 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		6B3F68F92742DEFC00BBD390 /* OperatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorError.swift; sourceTree = "<group>"; };
 		6B3F68FF2742EC0C00BBD390 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
+		6B3F6901274410A700BBD390 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */,
 				6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */,
 				6B3F68FF2742EC0C00BBD390 /* ExpressionParserTests.swift */,
+				6B3F6901274410A700BBD390 /* FormulaTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -300,6 +303,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B3F6902274410A700BBD390 /* FormulaTests.swift in Sources */,
 				6B3F68E927413DA900BBD390 /* DivideOperatorTests.swift in Sources */,
 				6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */,
 				6B3F69002742EC0C00BBD390 /* ExpressionParserTests.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		6B3F68F1274142B600BBD390 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F0274142B600BBD390 /* Formula.swift */; };
 		6B3F68F32741484300BBD390 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F22741484300BBD390 /* ExpressionParser.swift */; };
 		6B3F68FA2742DEFC00BBD390 /* OperatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F92742DEFC00BBD390 /* OperatorError.swift */; };
+		6B3F69002742EC0C00BBD390 /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68FF2742EC0C00BBD390 /* ExpressionParserTests.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -50,6 +51,7 @@
 		6B3F68F0274142B600BBD390 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		6B3F68F22741484300BBD390 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		6B3F68F92742DEFC00BBD390 /* OperatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorError.swift; sourceTree = "<group>"; };
+		6B3F68FF2742EC0C00BBD390 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */,
 				6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */,
 				6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */,
+				6B3F68FF2742EC0C00BBD390 /* ExpressionParserTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -299,6 +302,7 @@
 			files = (
 				6B3F68E927413DA900BBD390 /* DivideOperatorTests.swift in Sources */,
 				6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */,
+				6B3F69002742EC0C00BBD390 /* ExpressionParserTests.swift in Sources */,
 				6B3F68E527413A3000BBD390 /* AddOperatorTests.swift in Sources */,
 				6B3F68EB2741401D00BBD390 /* MultiplyOperatorTests.swift in Sources */,
 				6B3F68E727413D4600BBD390 /* SubtractOperatorTests.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6B2FCE06273A041400205344 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2FCE05273A041400205344 /* CalculatorItemQueue.swift */; };
+		6B3F68DF274133F700BBD390 /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68DE274133F700BBD390 /* Double+Extensions.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -30,6 +31,7 @@
 
 /* Begin PBXFileReference section */
 		6B2FCE05273A041400205344 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
+		6B3F68DE274133F700BBD390 /* Double+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extensions.swift"; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
@@ -72,6 +74,7 @@
 		6B3F68DD2741331000BBD390 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				6B3F68DE274133F700BBD390 /* Double+Extensions.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -269,6 +272,7 @@
 			files = (
 				6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
+				6B3F68DF274133F700BBD390 /* Double+Extensions.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				6B2FCE06273A041400205344 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		6B3F68EB2741401D00BBD390 /* MultiplyOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */; };
 		6B3F68ED274140C700BBD390 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68EC274140C700BBD390 /* String+Extensions.swift */; };
 		6B3F68F1274142B600BBD390 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F0274142B600BBD390 /* Formula.swift */; };
+		6B3F68F32741484300BBD390 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68F22741484300BBD390 /* ExpressionParser.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -46,6 +47,7 @@
 		6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplyOperatorTests.swift; sourceTree = "<group>"; };
 		6B3F68EC274140C700BBD390 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		6B3F68F0274142B600BBD390 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		6B3F68F22741484300BBD390 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 				6B2FCE05273A041400205344 /* CalculatorItemQueue.swift */,
 				6B3F68E02741357E00BBD390 /* Operator.swift */,
 				6B3F68F0274142B600BBD390 /* Formula.swift */,
+				6B3F68F22741484300BBD390 /* ExpressionParser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -295,6 +298,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B3F68F32741484300BBD390 /* ExpressionParser.swift in Sources */,
 				6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				6B3F68DF274133F700BBD390 /* Double+Extensions.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		6B3F68DF274133F700BBD390 /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68DE274133F700BBD390 /* Double+Extensions.swift */; };
 		6B3F68E12741357E00BBD390 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E02741357E00BBD390 /* Operator.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
-		6B959795273910CB00C705D1 /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorTests.swift */; };
+		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
@@ -36,7 +36,7 @@
 		6B3F68E02741357E00BBD390 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		6B959794273910CB00C705D1 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
+		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -128,7 +128,7 @@
 		6B959793273910CB00C705D1 /* CalculatorTests */ = {
 			isa = PBXGroup;
 			children = (
-				6B959794273910CB00C705D1 /* CalculatorTests.swift */,
+				6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -265,7 +265,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6B959795273910CB00C705D1 /* CalculatorTests.swift in Sources */,
+				6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		6B3F68DF274133F700BBD390 /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68DE274133F700BBD390 /* Double+Extensions.swift */; };
 		6B3F68E12741357E00BBD390 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E02741357E00BBD390 /* Operator.swift */; };
 		6B3F68E527413A3000BBD390 /* AddOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */; };
+		6B3F68E727413D4600BBD390 /* SubtractOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -36,6 +37,7 @@
 		6B3F68DE274133F700BBD390 /* Double+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extensions.swift"; sourceTree = "<group>"; };
 		6B3F68E02741357E00BBD390 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOperatorTests.swift; sourceTree = "<group>"; };
+		6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtractOperatorTests.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 			children = (
 				6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */,
 				6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */,
+				6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -270,6 +273,7 @@
 			files = (
 				6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */,
 				6B3F68E527413A3000BBD390 /* AddOperatorTests.swift in Sources */,
+				6B3F68E727413D4600BBD390 /* SubtractOperatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		6B3F68E527413A3000BBD390 /* AddOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */; };
 		6B3F68E727413D4600BBD390 /* SubtractOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */; };
 		6B3F68E927413DA900BBD390 /* DivideOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */; };
+		6B3F68EB2741401D00BBD390 /* MultiplyOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */; };
 		6B471729273A60FD0012D081 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B471728273A60FD0012D081 /* CalculateItem.swift */; };
 		6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -40,6 +41,7 @@
 		6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOperatorTests.swift; sourceTree = "<group>"; };
 		6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtractOperatorTests.swift; sourceTree = "<group>"; };
 		6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivideOperatorTests.swift; sourceTree = "<group>"; };
+		6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplyOperatorTests.swift; sourceTree = "<group>"; };
 		6B471728273A60FD0012D081 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		6B959792273910CB00C705D1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B959794273910CB00C705D1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 				6B3F68E427413A3000BBD390 /* AddOperatorTests.swift */,
 				6B3F68E627413D4600BBD390 /* SubtractOperatorTests.swift */,
 				6B3F68E827413DA900BBD390 /* DivideOperatorTests.swift */,
+				6B3F68EA2741401D00BBD390 /* MultiplyOperatorTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -277,6 +280,7 @@
 				6B3F68E927413DA900BBD390 /* DivideOperatorTests.swift in Sources */,
 				6B959795273910CB00C705D1 /* CalculatorItemQueueTests.swift in Sources */,
 				6B3F68E527413A3000BBD390 /* AddOperatorTests.swift in Sources */,
+				6B3F68EB2741401D00BBD390 /* MultiplyOperatorTests.swift in Sources */,
 				6B3F68E727413D4600BBD390 /* SubtractOperatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator/Error/OperatorError.swift
+++ b/Calculator/Calculator/Error/OperatorError.swift
@@ -1,0 +1,12 @@
+//
+//  OperatorError.swift
+//  Calculator
+//
+//  Created by 김진태 on 2021/11/16.
+//
+
+import Foundation
+
+enum OperatorError: Error {
+    case divisionByZero
+}

--- a/Calculator/Calculator/Extension/Double+Extensions.swift
+++ b/Calculator/Calculator/Extension/Double+Extensions.swift
@@ -1,0 +1,10 @@
+//
+//  Double+Ext.swift
+//  Calculator
+//
+//  Created by 김진태 on 2021/11/14.
+//
+
+import Foundation
+
+extension Double: CalculateItem {}

--- a/Calculator/Calculator/Extension/String+Extensions.swift
+++ b/Calculator/Calculator/Extension/String+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  String+Extensions.swift
+//  Calculator
+//
+//  Created by 김진태 on 2021/11/14.
+//
+
+import Foundation
+
+extension String {
+    func split(with target: Character) -> [String] {
+        let splittedSubstrings = self.split(separator: target)
+        return splittedSubstrings.map { String($0) }
+    }
+}

--- a/Calculator/Calculator/Extension/String+Extensions.swift
+++ b/Calculator/Calculator/Extension/String+Extensions.swift
@@ -9,7 +9,12 @@ import Foundation
 
 extension String {
     func split(with target: Character) -> [String] {
-        let splittedSubstrings = self.split(separator: target)
-        return splittedSubstrings.map { String($0) }
+        let targetString = String(target)
+        let splittedStrings = self.components(separatedBy: targetString)
+                                  .flatMap { [$0, targetString] }
+                                  .dropLast()
+                                  .filter { !$0.isEmpty }
+                                  .map { String($0) }
+        return splittedStrings
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -13,11 +13,13 @@ enum ExpressionParser {
     }
     
     private func componentsByOperators(from input: String) -> [String] {
-        let operatorCharacters = Operator.allCases.map{ $0.rawValue }
+        let operatorRawValues = Operator.allCases.map{ $0.rawValue }
         
-        let components = operatorCharacters.reduce([input]) {
-            (result: [String], operatorCharacter: Character) in
-            return result.flatMap { $0.split(with: operatorCharacter) }
+        let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        let components = operatorRawValues.reduce([trimmedInput]) {
+            (result: [String], operatorRawValue: Character) in
+            return result.flatMap { $0.split(with: operatorRawValue) }
         }
         return components
     }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -16,6 +16,10 @@ enum ExpressionParser {
         let operandComponents = components.filter { !operatorRawValues.contains($0) }
         var formula = Formula()
         
+        print(components)
+        print(operatorComponents)
+        print(operandComponents)
+        
         operatorComponents.forEach { operatorComponent in
             guard let enumOperator = Operator(rawValue: operatorComponent) else { return }
             formula.operators.insert(enumOperator)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -31,15 +31,41 @@ enum ExpressionParser {
     
     private static func componentsByOperators(from input: String) -> [String] {
         let allOperatorSymbols = Operator.allCases.map { $0.rawValue }
+        let multiplyDivideSymbols = [Operator.multiply.rawValue, Operator.divide.rawValue]
+        let signs = [Operator.add.rawValue, Operator.subtract.rawValue]
+        let emptySpace = Character(" ")
+        
+        let multiplyDivideSymbolsWithSign = multiplyDivideSymbols.flatMap { operatorSymbol in
+            signs.map { sign in "\(operatorSymbol)\(sign)" }
+        }
         
         let inputWithoutWhitespace = input.components(separatedBy: .whitespacesAndNewlines).joined()
         
-        let components = allOperatorSymbols.reduce([inputWithoutWhitespace]) {
+        var components = multiplyDivideSymbolsWithSign.reduce([inputWithoutWhitespace]) {
+            (result: [String], operatorSymbolWithSign: String) in
+            guard let operatorSymbol = operatorSymbolWithSign.first else { return result }
+            guard let sign = operatorSymbolWithSign.last else { return result }
+            let operatorSymbolWithEmptySpaceAndSign = "\(emptySpace)\(operatorSymbol)\(emptySpace)\(sign)"
+            
+            return result
+                        .map {
+                            $0.replacingOccurrences(of: operatorSymbolWithSign, with: operatorSymbolWithEmptySpaceAndSign)
+                        }
+                        .flatMap { $0.components(separatedBy: "\(emptySpace)") }
+        }
+        
+        components = allOperatorSymbols.reduce(components) {
             (result: [String], operatorSymbol: Character) in
             return result
-                .flatMap { component -> [String] in
-                    return component.split(with: operatorSymbol)
-                }
+                        .flatMap { component -> [String] in
+                            guard let firstCharacter = component.first else { return [component] }
+                            let result = signs.contains(firstCharacter)
+                                            && component.count > 1
+                                            && component.filter { allOperatorSymbols.contains($0) }.count == 1
+                                                ? [component]
+                                                : component.split(with: operatorSymbol)
+                            return result
+                        }
         }
         
         return components

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -32,9 +32,9 @@ enum ExpressionParser {
     private static func componentsByOperators(from input: String) -> [String] {
         let operatorRawValues = Operator.allCases.map{ $0.rawValue }
         
-        let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        let inputWithoutWhitespace = input.components(separatedBy: .whitespacesAndNewlines).joined()
         
-        let components = operatorRawValues.reduce([trimmedInput]) {
+        let components = operatorRawValues.reduce([inputWithoutWhitespace]) {
             (result: [String], operatorRawValue: Character) in
             return result.flatMap { $0.split(with: operatorRawValue) }
         }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -10,10 +10,10 @@ import Foundation
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
         let components = componentsByOperators(from: input)
-        let operatorRawValues = Operator.allCases.map { String($0.rawValue) }
+        let allOperatorSymbols = Operator.allCases.map { String($0.rawValue) }
         
-        let operatorComponents = components.filter { operatorRawValues.contains($0) }.map { Character($0) }
-        let operandComponents = components.filter { !operatorRawValues.contains($0) }
+        let operatorComponents = components.filter { allOperatorSymbols.contains($0) }.map { Character($0) }
+        let operandComponents = components.filter { !allOperatorSymbols.contains($0) }
         var formula = Formula()
         
         operatorComponents.forEach { operatorComponent in
@@ -30,14 +30,46 @@ enum ExpressionParser {
     }
     
     private static func componentsByOperators(from input: String) -> [String] {
-        let operatorRawValues = Operator.allCases.map{ $0.rawValue }
+        let allOperatorSymbols = Operator.allCases.map { $0.rawValue }
+        let signs = [Operator.add.rawValue, Operator.subtract.rawValue]
+        let emptySpace = Character(" ")
+        
+        let allOperatorSymbolsWithSign = allOperatorSymbols.flatMap { operatorSymbol in
+            signs.map { sign in "\(operatorSymbol)\(sign)" }
+        }
         
         let inputWithoutWhitespace = input.components(separatedBy: .whitespacesAndNewlines).joined()
         
-        let components = operatorRawValues.reduce([inputWithoutWhitespace]) {
-            (result: [String], operatorRawValue: Character) in
-            return result.flatMap { $0.split(with: operatorRawValue) }
+        var components = allOperatorSymbolsWithSign.reduce([inputWithoutWhitespace]) {
+            (result: [String], operatorSymbolWithSign: String) in
+            guard let operatorSymbol = operatorSymbolWithSign.first else { return result }
+            guard let sign = operatorSymbolWithSign.last else { return result }
+            let operatorSymbolWithEmptySpaceAndSign = "\(emptySpace)\(operatorSymbol)\(emptySpace)\(sign)"
+            
+            return result
+                        .map {
+                            $0.replacingOccurrences(of: operatorSymbolWithSign, with: operatorSymbolWithEmptySpaceAndSign)
+                        }
+                        .flatMap { $0.components(separatedBy: "\(emptySpace)") }
         }
+        
+        components = allOperatorSymbols.reduce(components) {
+            (result: [String], operatorSymbol: Character) in
+            let operatorSymbolWithEmptySpace = "\(emptySpace)\(operatorSymbol)"
+            return result
+                        .map {
+                            $0.replacingOccurrences(of: "\(operatorSymbol)", with: operatorSymbolWithEmptySpace)
+                        }
+                        .flatMap { $0.split(separator: emptySpace).map { String($0) } }
+                        .flatMap { component -> [String] in
+                            guard let firstCharacter = component.first else { return [component] }
+                            let result = signs.contains(firstCharacter) && component.count > 1
+                                                ? [component]
+                                                : component.split(with: operatorSymbol)
+                            return result
+                        }
+        }
+        
         return components
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -14,7 +14,7 @@ enum ExpressionParser {
         
         let operatorComponents = components.filter { operatorRawValues.contains($0) }.map { Character($0) }
         let operandComponents = components.filter { !operatorRawValues.contains($0) }
-        let formula = Formula()
+        var formula = Formula()
         
         operatorComponents.forEach { operatorComponent in
             guard let enumOperator = Operator(rawValue: operatorComponent) else { return }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -55,19 +55,16 @@ enum ExpressionParser {
         
         components = allOperatorSymbols.reduce(components) {
             (result: [String], operatorSymbol: Character) in
-            let operatorSymbolWithEmptySpace = "\(emptySpace)\(operatorSymbol)"
             return result
-                        .map {
-                            $0.replacingOccurrences(of: "\(operatorSymbol)", with: operatorSymbolWithEmptySpace)
-                        }
-                        .flatMap { $0.split(separator: emptySpace).map { String($0) } }
-                        .flatMap { component -> [String] in
-                            guard let firstCharacter = component.first else { return [component] }
-                            let result = signs.contains(firstCharacter) && component.count > 1
-                                                ? [component]
-                                                : component.split(with: operatorSymbol)
-                            return result
-                        }
+                .flatMap { component -> [String] in
+                    guard let firstCharacter = component.first else { return [component] }
+                    let result = signs.contains(firstCharacter)
+                                    && component.count > 1
+                                    && component.filter { allOperatorSymbols.contains($0) }.count == 1
+                                        ? [component]
+                                        : component.split(with: operatorSymbol)
+                    return result
+                }
         }
         
         return components

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -31,39 +31,14 @@ enum ExpressionParser {
     
     private static func componentsByOperators(from input: String) -> [String] {
         let allOperatorSymbols = Operator.allCases.map { $0.rawValue }
-        let signs = [Operator.add.rawValue, Operator.subtract.rawValue]
-        let emptySpace = Character(" ")
-        
-        let allOperatorSymbolsWithSign = allOperatorSymbols.flatMap { operatorSymbol in
-            signs.map { sign in "\(operatorSymbol)\(sign)" }
-        }
         
         let inputWithoutWhitespace = input.components(separatedBy: .whitespacesAndNewlines).joined()
         
-        var components = allOperatorSymbolsWithSign.reduce([inputWithoutWhitespace]) {
-            (result: [String], operatorSymbolWithSign: String) in
-            guard let operatorSymbol = operatorSymbolWithSign.first else { return result }
-            guard let sign = operatorSymbolWithSign.last else { return result }
-            let operatorSymbolWithEmptySpaceAndSign = "\(emptySpace)\(operatorSymbol)\(emptySpace)\(sign)"
-            
-            return result
-                        .map {
-                            $0.replacingOccurrences(of: operatorSymbolWithSign, with: operatorSymbolWithEmptySpaceAndSign)
-                        }
-                        .flatMap { $0.components(separatedBy: "\(emptySpace)") }
-        }
-        
-        components = allOperatorSymbols.reduce(components) {
+        let components = allOperatorSymbols.reduce([inputWithoutWhitespace]) {
             (result: [String], operatorSymbol: Character) in
             return result
                 .flatMap { component -> [String] in
-                    guard let firstCharacter = component.first else { return [component] }
-                    let result = signs.contains(firstCharacter)
-                                    && component.count > 1
-                                    && component.filter { allOperatorSymbols.contains($0) }.count == 1
-                                        ? [component]
-                                        : component.split(with: operatorSymbol)
-                    return result
+                    return component.split(with: operatorSymbol)
                 }
         }
         

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -16,10 +16,6 @@ enum ExpressionParser {
         let operandComponents = components.filter { !operatorRawValues.contains($0) }
         var formula = Formula()
         
-        print(components)
-        print(operatorComponents)
-        print(operandComponents)
-        
         operatorComponents.forEach { operatorComponent in
             guard let enumOperator = Operator(rawValue: operatorComponent) else { return }
             formula.operators.insert(enumOperator)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum ExpressionParser {
-    func parse(from input: String) -> Formula {
+    static func parse(from input: String) -> Formula {
         let components = componentsByOperators(from: input)
         let operatorRawValues = Operator.allCases.map { String($0.rawValue) }
         
@@ -29,7 +29,7 @@ enum ExpressionParser {
         return formula
     }
     
-    private func componentsByOperators(from input: String) -> [String] {
+    private static func componentsByOperators(from input: String) -> [String] {
         let operatorRawValues = Operator.allCases.map{ $0.rawValue }
         
         let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -13,6 +13,12 @@ enum ExpressionParser {
     }
     
     private func componentsByOperators(from input: String) -> [String] {
-        return []
+        let operatorCharacters = Operator.allCases.map{ $0.rawValue }
+        
+        let components = operatorCharacters.reduce([input]) {
+            (result: [String], operatorCharacter: Character) in
+            return result.flatMap { $0.split(with: operatorCharacter) }
+        }
+        return components
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,0 +1,18 @@
+//
+//  ExpressionParser.swift
+//  Calculator
+//
+//  Created by 김진태 on 2021/11/14.
+//
+
+import Foundation
+
+enum ExpressionParser {
+    func parse(from input: String) -> Formula {
+        return Formula()
+    }
+    
+    private func componentsByOperators(from input: String) -> [String] {
+        return []
+    }
+}

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -58,13 +58,13 @@ enum ExpressionParser {
             (result: [String], operatorSymbol: Character) in
             return result
                         .flatMap { component -> [String] in
-                            guard let firstCharacter = component.first else { return [component] }
-                            let result = signs.contains(firstCharacter)
-                                            && component.count > 1
-                                            && component.filter { allOperatorSymbols.contains($0) }.count == 1
-                                                ? [component]
-                                                : component.split(with: operatorSymbol)
-                            return result
+                            let splittedComponents = component.split(with: operatorSymbol)
+                            guard let firstString = splittedComponents.first, firstString.count == 1, splittedComponents.count > 1 else { return splittedComponents }
+                            let firstCharacter = Character(firstString)
+                            guard signs.contains(firstCharacter) else { return splittedComponents }
+                            let firstOpponent = "\(firstString)\(splittedComponents[1])"
+                            guard splittedComponents.count > 2 else { return [firstOpponent] }
+                            return ([firstOpponent] + Array(splittedComponents[2...]))
                         }
         }
         

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -9,7 +9,24 @@ import Foundation
 
 enum ExpressionParser {
     func parse(from input: String) -> Formula {
-        return Formula()
+        let components = componentsByOperators(from: input)
+        let operatorRawValues = Operator.allCases.map { String($0.rawValue) }
+        
+        let operatorComponents = components.filter { operatorRawValues.contains($0) }.map { Character($0) }
+        let operandComponents = components.filter { !operatorRawValues.contains($0) }
+        let formula = Formula()
+        
+        operatorComponents.forEach { operatorComponent in
+            guard let enumOperator = Operator(rawValue: operatorComponent) else { return }
+            formula.operators.insert(enumOperator)
+        }
+        
+        operandComponents.forEach { operandComponent in
+            guard let doubleOperand = Double(operandComponent) else { return }
+            formula.operands.insert(doubleOperand)
+        }
+        
+        return formula
     }
     
     private func componentsByOperators(from input: String) -> [String] {

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct Formula {
-    let operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>()
-    let operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
+    var operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>()
+    var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
     
     func result() -> Double {
         return 0.0

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,0 +1,17 @@
+//
+//  Formula.swift
+//  Calculator
+//
+//  Created by 김진태 on 2021/11/14.
+//
+
+import Foundation
+
+struct Formula {
+    let operands: CalculatorItemQueue<Double>
+    let operators: CalculatorItemQueue<Operator>
+    
+    func result() -> Double {
+        return 0.0
+    }
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -11,7 +11,17 @@ struct Formula {
     var operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>()
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
     
-    func result() -> Double {
-        return 0.0
+    mutating func result() throws -> Double {
+        let zeroValue = 0.0
+        guard var resultValue = operands.delete() else { return zeroValue }
+        
+        while true {
+            guard let operatorInstance = operators.delete(), let operandValue = operands.delete() else {
+                break
+            }
+            resultValue = try operatorInstance.calculate(lhs: resultValue, rhs: operandValue)
+        }
+        
+        return resultValue
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct Formula {
-    let operands: CalculatorItemQueue<Double>
-    let operators: CalculatorItemQueue<Operator>
+    let operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>()
+    let operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
     
     func result() -> Double {
         return 0.0

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -14,7 +14,16 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case multiply = "*"
     
     func calculate(lhs: Double, rhs: Double) -> Double {
-        return 0.0
+        switch self {
+        case .add:
+            return add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            return subtract(lhs: lhs, rhs: rhs)
+        case .divide:
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
+        }
     }
     
     private func add(lhs: Double, rhs: Double) -> Double {

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -1,0 +1,15 @@
+//
+//  Operator.swift
+//  Calculator
+//
+//  Created by 김진태 on 2021/11/14.
+//
+
+import Foundation
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+"
+    case subtract = "-"
+    case divide = "/"
+    case multiply = "*"
+}

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -13,14 +13,14 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "/"
     case multiply = "*"
     
-    func calculate(lhs: Double, rhs: Double) -> Double {
+    func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {
         case .add:
             return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            return divide(lhs: lhs, rhs: rhs)
+            return try divide(lhs: lhs, rhs: rhs)
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
         }
@@ -36,7 +36,8 @@ enum Operator: Character, CaseIterable, CalculateItem {
         return result
     }
     
-    private func divide(lhs: Double, rhs: Double) -> Double {
+    private func divide(lhs: Double, rhs: Double) throws -> Double {
+        guard rhs != 0.0 else { throw OperatorError.divisionByZero }
         let result = lhs / rhs
         return result
     }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -12,4 +12,24 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case subtract = "-"
     case divide = "/"
     case multiply = "*"
+    
+    func calculate(lhs: Double, rls: Double) -> Double {
+        return 0.0
+    }
+    
+    private func add(lhs: Double, rls: Double) -> Double {
+        return 0.0
+    }
+    
+    private func subtract(lhs: Double, rls: Double) -> Double {
+        return 0.0
+    }
+    
+    private func divide(lhs: Double, rls: Double) -> Double {
+        return 0.0
+    }
+    
+    private func multiply(lhs: Double, rls: Double) -> Double {
+        return 0.0
+    }
 }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -18,18 +18,22 @@ enum Operator: Character, CaseIterable, CalculateItem {
     }
     
     private func add(lhs: Double, rhs: Double) -> Double {
-        return 0.0
+        let result = lhs + rhs
+        return result
     }
     
     private func subtract(lhs: Double, rhs: Double) -> Double {
-        return 0.0
+        let result = lhs - rhs
+        return result
     }
     
     private func divide(lhs: Double, rhs: Double) -> Double {
-        return 0.0
+        let result = lhs / rhs
+        return result
     }
     
     private func multiply(lhs: Double, rhs: Double) -> Double {
-        return 0.0
+        let result = lhs * rhs
+        return result
     }
 }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -13,23 +13,23 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "/"
     case multiply = "*"
     
-    func calculate(lhs: Double, rls: Double) -> Double {
+    func calculate(lhs: Double, rhs: Double) -> Double {
         return 0.0
     }
     
-    private func add(lhs: Double, rls: Double) -> Double {
+    private func add(lhs: Double, rhs: Double) -> Double {
         return 0.0
     }
     
-    private func subtract(lhs: Double, rls: Double) -> Double {
+    private func subtract(lhs: Double, rhs: Double) -> Double {
         return 0.0
     }
     
-    private func divide(lhs: Double, rls: Double) -> Double {
+    private func divide(lhs: Double, rhs: Double) -> Double {
         return 0.0
     }
     
-    private func multiply(lhs: Double, rls: Double) -> Double {
+    private func multiply(lhs: Double, rhs: Double) -> Double {
         return 0.0
     }
 }

--- a/Calculator/Calculator/Storyboard/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Storyboard/Base.lproj/Main.storyboard
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -12,26 +14,26 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="CalculatorViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -39,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -264,19 +266,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>

--- a/Calculator/CalculatorTests/AddOperatorTests.swift
+++ b/Calculator/CalculatorTests/AddOperatorTests.swift
@@ -25,7 +25,7 @@ class AddOperatorTests: XCTestCase {
         let firstNumber = 3.0
         let secondNumber = 6.0
         
-        let calculatedResult = sut.calculate(lhs: firstNumber, rls: secondNumber)
+        let calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
         XCTAssertEqual(calculatedResult, firstNumber + secondNumber)
     }
 }

--- a/Calculator/CalculatorTests/AddOperatorTests.swift
+++ b/Calculator/CalculatorTests/AddOperatorTests.swift
@@ -21,21 +21,21 @@ class AddOperatorTests: XCTestCase {
         sut = nil
     }
     
-    func testAddTwoNumbers() {
+    func testAddTwoNumbers() throws {
         let firstNumber = 3.0
         let secondNumber = 6.0
         
-        let calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        let calculatedResult = try sut.calculate(lhs: firstNumber, rhs: secondNumber)
         XCTAssertEqual(calculatedResult, firstNumber + secondNumber)
     }
     
-    func testAddThreeNumbers() {
+    func testAddThreeNumbers() throws {
         let firstNumber = 6.0
         let secondNumber = 9.0
         let thirdNumber = 96.0
         
-        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
-        calculatedResult = sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
+        var calculatedResult = try sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        calculatedResult = try sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
         
         XCTAssertEqual(calculatedResult, firstNumber + secondNumber + thirdNumber)
     }

--- a/Calculator/CalculatorTests/AddOperatorTests.swift
+++ b/Calculator/CalculatorTests/AddOperatorTests.swift
@@ -1,0 +1,23 @@
+//
+//  AddOperatorTests.swift
+//  CalculatorTests
+//
+//  Created by 김진태 on 2021/11/14.
+//
+
+import XCTest
+@testable import Calculator
+
+class AddOperatorTests: XCTestCase {
+    var sut: Operator!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Operator(rawValue: "+")
+    }
+    
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+}

--- a/Calculator/CalculatorTests/AddOperatorTests.swift
+++ b/Calculator/CalculatorTests/AddOperatorTests.swift
@@ -20,4 +20,12 @@ class AddOperatorTests: XCTestCase {
         try super.tearDownWithError()
         sut = nil
     }
+    
+    func testAddTwoNumbers() {
+        let firstNumber = 3.0
+        let secondNumber = 6.0
+        
+        let calculatedResult = sut.calculate(lhs: firstNumber, rls: secondNumber)
+        XCTAssertEqual(calculatedResult, firstNumber + secondNumber)
+    }
 }

--- a/Calculator/CalculatorTests/AddOperatorTests.swift
+++ b/Calculator/CalculatorTests/AddOperatorTests.swift
@@ -28,4 +28,15 @@ class AddOperatorTests: XCTestCase {
         let calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
         XCTAssertEqual(calculatedResult, firstNumber + secondNumber)
     }
+    
+    func testAddThreeNumbers() {
+        let firstNumber = 6.0
+        let secondNumber = 9.0
+        let thirdNumber = 96.0
+        
+        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        calculatedResult = sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
+        
+        XCTAssertEqual(calculatedResult, firstNumber + secondNumber + thirdNumber)
+    }
 }

--- a/Calculator/CalculatorTests/AddOperatorTests.swift
+++ b/Calculator/CalculatorTests/AddOperatorTests.swift
@@ -13,7 +13,7 @@ class AddOperatorTests: XCTestCase {
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        sut = Operator(rawValue: "+")
+        sut = .add
     }
     
     override func tearDownWithError() throws {

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -8,15 +8,13 @@
 import XCTest
 @testable import Calculator
 
-extension Int: CalculateItem {}
-
 class CalculatorItemQueueTests: XCTestCase {
     
-    var sut: CalculatorItemQueue<Int>!
+    var sut: CalculatorItemQueue<Double>!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        sut = CalculatorItemQueue<Int>()
+        sut = CalculatorItemQueue<Double>()
     }
 
     override func tearDownWithError() throws {
@@ -49,7 +47,7 @@ class CalculatorItemQueueTests: XCTestCase {
         
         func repeatInsert(times: Int) {
             for _ in 0..<times {
-                let randomNumber = Int.random(in: 0...259)
+                let randomNumber = Double.random(in: 0...259)
                 insertCount += 1
                 sut.insert(randomNumber)
             }
@@ -64,7 +62,7 @@ class CalculatorItemQueueTests: XCTestCase {
     }
     
     func testInsertItemSucceeded() {
-        let insertItem = 6
+        let insertItem: Double = 6
         sut.insert(insertItem)
         let isSuccess = sut.front == insertItem
         XCTAssertTrue(isSuccess)
@@ -73,7 +71,7 @@ class CalculatorItemQueueTests: XCTestCase {
     func testFrontAndRearIsSameWhenQueueIsEmtyOrQueueCountIsOne() {
         XCTAssertEqual(sut.front, sut.rear)
         
-        let insertItem = 66
+        let insertItem: Double = 66
         sut.insert(insertItem)
         
         XCTAssertEqual(sut.front, sut.rear)
@@ -98,7 +96,7 @@ class CalculatorItemQueueTests: XCTestCase {
     }
     
     func testInsertAndDeleteItemSucceeded() {
-        let item = 6
+        let item: Double = 6
         sut.insert(item)
         let deleteResult = sut.delete()
         let isDeleteSuccess = (deleteResult == item)

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 extension Int: CalculateItem {}
 
-class CalculatorTests: XCTestCase {
+class CalculatorItemQueueTests: XCTestCase {
     
     var sut: CalculatorItemQueue<Int>!
     

--- a/Calculator/CalculatorTests/DivideOperatorTests.swift
+++ b/Calculator/CalculatorTests/DivideOperatorTests.swift
@@ -40,7 +40,7 @@ class DivideOperatorTests: XCTestCase {
         XCTAssertEqual(calculatedResult, firstNumber / secondNumber / thirdNumber)
     }
     
-    func testDivideUsingOne() throws {
+    func testDivideUsingZero() throws {
         let firstNumber = 36.0
         let secondNumber = 0.0
         

--- a/Calculator/CalculatorTests/DivideOperatorTests.swift
+++ b/Calculator/CalculatorTests/DivideOperatorTests.swift
@@ -21,31 +21,31 @@ class DivideOperatorTests: XCTestCase {
         sut = nil
     }
     
-    func testDivideTwoNumbers() {
+    func testDivideTwoNumbers() throws {
         let firstNumber = 3.0
         let secondNumber = 6.0
         
-        let calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        let calculatedResult = try sut.calculate(lhs: firstNumber, rhs: secondNumber)
         XCTAssertEqual(calculatedResult, firstNumber / secondNumber)
     }
     
-    func testDivideThreeNumbers() {
+    func testDivideThreeNumbers() throws {
         let firstNumber = 6.0
         let secondNumber = 9.0
         let thirdNumber = 96.0
         
-        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
-        calculatedResult = sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
+        var calculatedResult = try sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        calculatedResult = try sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
         
         XCTAssertEqual(calculatedResult, firstNumber / secondNumber / thirdNumber)
     }
     
-    func testDivideUsingOne() {
+    func testDivideUsingOne() throws {
         let firstNumber = 36.0
         let secondNumber = 0.0
         
-        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
-        
-        XCTAssertThrowsError(calculatedResult)
+        XCTAssertThrowsError(try sut.calculate(lhs: firstNumber, rhs: secondNumber)) { error in
+            XCTAssertEqual(error as? OperatorError, OperatorError.divisionByZero)
+        }
     }
 }

--- a/Calculator/CalculatorTests/DivideOperatorTests.swift
+++ b/Calculator/CalculatorTests/DivideOperatorTests.swift
@@ -1,0 +1,51 @@
+//
+//  DivideOperatorTests.swift
+//  CalculatorTests
+//
+//  Created by 김진태 on 2021/11/14.
+//
+
+import XCTest
+@testable import Calculator
+
+class DivideOperatorTests: XCTestCase {
+    var sut: Operator!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = .divide
+    }
+    
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func testDivideTwoNumbers() {
+        let firstNumber = 3.0
+        let secondNumber = 6.0
+        
+        let calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        XCTAssertEqual(calculatedResult, firstNumber / secondNumber)
+    }
+    
+    func testDivideThreeNumbers() {
+        let firstNumber = 6.0
+        let secondNumber = 9.0
+        let thirdNumber = 96.0
+        
+        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        calculatedResult = sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
+        
+        XCTAssertEqual(calculatedResult, firstNumber / secondNumber / thirdNumber)
+    }
+    
+    func testDivideUsingOne() {
+        let firstNumber = 36.0
+        let secondNumber = 0.0
+        
+        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        
+        XCTAssertThrowsError(calculatedResult)
+    }
+}

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -53,4 +53,13 @@ class ExpressionParserTests: XCTestCase {
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }
+    
+    func testInputMinusFourPlusEightMultiplyMinusThreeIsMinusTwelve() throws {
+        let input = "-4+8*-3"
+        var formula = ExpressionParser.parse(from: input)
+        let calculatedResult = try formula.result()
+        let expectedResult: Double = -12
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -45,7 +45,7 @@ class ExpressionParserTests: XCTestCase {
         XCTAssertEqual(calculatedResult, expectedResult)
     }
     
-    func testInputFourAddMinusSixIsTen() throws {
+    func testInputFourPlusMinusSixIsTen() throws {
         let input = "4 + -6"
         var formula = ExpressionParser.parse(from: input)
         let calculatedResult = try formula.result()

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -1,0 +1,20 @@
+//
+//  ExpressionParserTests.swift
+//  CalculatorTests
+//
+//  Created by 김진태 on 2021/11/16.
+//
+
+import XCTest
+@testable import Calculator
+
+class ExpressionParserTests: XCTestCase {
+    func testInputTwoPlusThreeResultIsFive() throws {
+        let input = "2+3"
+        var formula = ExpressionParser.parse(from: input)
+        let calculatedResult = try formula.result()
+        let expectedResult: Double = 5
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
+}

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -44,4 +44,13 @@ class ExpressionParserTests: XCTestCase {
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }
+    
+    func testInputFourAddMinusSixIsTen() throws {
+        let input = "4 + -6"
+        var formula = ExpressionParser.parse(from: input)
+        let calculatedResult = try formula.result()
+        let expectedResult: Double = -2
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -26,4 +26,13 @@ class ExpressionParserTests: XCTestCase {
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }
+    
+    func testInputTwoPlusThreeMinusSixIsMinusOne() throws {
+        let input = "2+3-6"
+        var formula = ExpressionParser.parse(from: input)
+        let calculatedResult = try formula.result()
+        let expectedResult: Double = -1
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -54,7 +54,7 @@ class ExpressionParserTests: XCTestCase {
         XCTAssertEqual(calculatedResult, expectedResult)
     }
     
-    func testInput() throws {
+    func testInputFourPlusSixMulutiplyThreeMinusThreeIsNineteen() throws {
         let input = "4+6*3-3"
         var formula = ExpressionParser.parse(from: input)
         let calculatedResult = try formula.result()

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -35,4 +35,13 @@ class ExpressionParserTests: XCTestCase {
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }
+    
+    func testInputFourMultiplyMinusSixIsMinusTwentyFour() throws {
+        let input = "4*-6"
+        var formula = ExpressionParser.parse(from: input)
+        let calculatedResult = try formula.result()
+        let expectedResult: Double = -24
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -53,4 +53,13 @@ class ExpressionParserTests: XCTestCase {
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }
+    
+    func testInput() throws {
+        let input = "4+6*3-3"
+        var formula = ExpressionParser.parse(from: input)
+        let calculatedResult = try formula.result()
+        let expectedResult: Double = 19
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -46,10 +46,10 @@ class ExpressionParserTests: XCTestCase {
     }
     
     func testInputFourPlusSixMulutiplyThreeMinusThreeIsNineteen() throws {
-        let input = "-4+6*3-3"
+        let input = "4+6*3-3"
         var formula = ExpressionParser.parse(from: input)
         let calculatedResult = try formula.result()
-        let expectedResult: Double = 3
+        let expectedResult: Double = 27
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -58,7 +58,7 @@ class ExpressionParserTests: XCTestCase {
         let input = "4+6*3-3"
         var formula = ExpressionParser.parse(from: input)
         let calculatedResult = try formula.result()
-        let expectedResult: Double = 19
+        let expectedResult: Double = 27
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -45,20 +45,11 @@ class ExpressionParserTests: XCTestCase {
         XCTAssertEqual(calculatedResult, expectedResult)
     }
     
-    func testInputFourPlusMinusSixIsTen() throws {
-        let input = "4 + -6"
-        var formula = ExpressionParser.parse(from: input)
-        let calculatedResult = try formula.result()
-        let expectedResult: Double = -2
-        
-        XCTAssertEqual(calculatedResult, expectedResult)
-    }
-    
     func testInputFourPlusSixMulutiplyThreeMinusThreeIsNineteen() throws {
-        let input = "4+6*3-3"
+        let input = "-4+6*3-3"
         var formula = ExpressionParser.parse(from: input)
         let calculatedResult = try formula.result()
-        let expectedResult: Double = 27
+        let expectedResult: Double = 3
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -17,4 +17,13 @@ class ExpressionParserTests: XCTestCase {
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }
+    
+    func testInputTwoPlusThreeWithEmptySpaceIsFive() throws {
+        let input = "2 + 3"
+        var formula = ExpressionParser.parse(from: input)
+        let calculatedResult = try formula.result()
+        let expectedResult: Double = 5
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -27,6 +27,15 @@ class ExpressionParserTests: XCTestCase {
         XCTAssertEqual(calculatedResult, expectedResult)
     }
     
+    func testInputMinusThreeMinusFiveIsMinusEight() throws {
+        let input = "-3-5"
+        var formula = ExpressionParser.parse(from: input)
+        let calculatedResult = try formula.result()
+        let expectedResult: Double = -8
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
+    
     func testInputTwoPlusThreeMinusSixIsMinusOne() throws {
         let input = "2+3-6"
         var formula = ExpressionParser.parse(from: input)

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -55,4 +55,19 @@ class FormulaTests: XCTestCase {
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }
+    
+    func testSixSubtractNineMultiplyMinusEightDivideThree() throws {
+        sut.operands.insert(6)
+        sut.operands.insert(9)
+        sut.operands.insert(-8)
+        sut.operands.insert(3)
+        sut.operators.insert(.subtract)
+        sut.operators.insert(.multiply)
+        sut.operators.insert(.divide)
+        
+        let calculatedResult = try sut.result()
+        let expectedResult: Double = 8
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -32,6 +32,17 @@ class FormulaTests: XCTestCase {
         XCTAssertEqual(calculatedResult, expectedResult)
     }
     
+    func testThreeMultiplyMinusSix() throws {
+        sut.operands.insert(3)
+        sut.operands.insert(-6)
+        sut.operators.insert(.multiply)
+        
+        let calculatedResult = try sut.result()
+        let expectedResult: Double = -18
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
+    
     func testSixSubtractNineMultiplyEight() throws {
         sut.operands.insert(6)
         sut.operands.insert(9)

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -70,4 +70,14 @@ class FormulaTests: XCTestCase {
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }
+    
+    func testDivideUsingZero() throws {
+        sut.operands.insert(6)
+        sut.operators.insert(.divide)
+        sut.operands.insert(0)
+        
+        XCTAssertThrowsError(try sut.result()) { error in
+            XCTAssertEqual(error as? OperatorError, OperatorError.divisionByZero)
+        }
+    }
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -31,4 +31,17 @@ class FormulaTests: XCTestCase {
         
         XCTAssertEqual(calculatedResult, expectedResult)
     }
+    
+    func testSixSubtractNineMultiplyEight() throws {
+        sut.operands.insert(6)
+        sut.operands.insert(9)
+        sut.operands.insert(8)
+        sut.operators.insert(.subtract)
+        sut.operators.insert(.multiply)
+        
+        let calculatedResult = try sut.result()
+        let expectedResult: Double = -24
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -23,8 +23,8 @@ class FormulaTests: XCTestCase {
     
     func testThreeAddSix() throws {
         sut.operands.insert(3)
-        sut.operands.insert(6)
         sut.operators.insert(.add)
+        sut.operands.insert(6)
         
         let calculatedResult = try sut.result()
         let expectedResult: Double = 9
@@ -34,8 +34,8 @@ class FormulaTests: XCTestCase {
     
     func testThreeMultiplyMinusSix() throws {
         sut.operands.insert(3)
-        sut.operands.insert(-6)
         sut.operators.insert(.multiply)
+        sut.operands.insert(-6)
         
         let calculatedResult = try sut.result()
         let expectedResult: Double = -18
@@ -45,10 +45,10 @@ class FormulaTests: XCTestCase {
     
     func testSixSubtractNineMultiplyEight() throws {
         sut.operands.insert(6)
-        sut.operands.insert(9)
-        sut.operands.insert(8)
         sut.operators.insert(.subtract)
+        sut.operands.insert(9)
         sut.operators.insert(.multiply)
+        sut.operands.insert(8)
         
         let calculatedResult = try sut.result()
         let expectedResult: Double = -24
@@ -58,12 +58,12 @@ class FormulaTests: XCTestCase {
     
     func testSixSubtractNineMultiplyMinusEightDivideThree() throws {
         sut.operands.insert(6)
-        sut.operands.insert(9)
-        sut.operands.insert(-8)
-        sut.operands.insert(3)
         sut.operators.insert(.subtract)
+        sut.operands.insert(9)
         sut.operators.insert(.multiply)
+        sut.operands.insert(-8)
         sut.operators.insert(.divide)
+        sut.operands.insert(3)
         
         let calculatedResult = try sut.result()
         let expectedResult: Double = 8

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -1,0 +1,34 @@
+//
+//  FormulaTests.swift
+//  CalculatorTests
+//
+//  Created by 김진태 on 2021/11/17.
+//
+
+import XCTest
+@testable import Calculator
+
+class FormulaTests: XCTestCase {
+    var sut: Formula!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Formula()
+    }
+    
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func testThreeAddSix() throws {
+        sut.operands.insert(3)
+        sut.operands.insert(6)
+        sut.operators.insert(.add)
+        
+        let calculatedResult = try sut.result()
+        let expectedResult: Double = 9
+        
+        XCTAssertEqual(calculatedResult, expectedResult)
+    }
+}

--- a/Calculator/CalculatorTests/MultiplyOperatorTests.swift
+++ b/Calculator/CalculatorTests/MultiplyOperatorTests.swift
@@ -1,0 +1,42 @@
+//
+//  DivideOperatorTests.swift
+//  CalculatorTests
+//
+//  Created by 김진태 on 2021/11/14.
+//
+
+import XCTest
+@testable import Calculator
+
+class MultiplyOperatorTests: XCTestCase {
+    var sut: Operator!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = .multiply
+    }
+    
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func testMultiplyTwoNumbers() {
+        let firstNumber = 3.0
+        let secondNumber = 6.0
+        
+        let calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        XCTAssertEqual(calculatedResult, firstNumber * secondNumber)
+    }
+    
+    func testMultiplyThreeNumbers() {
+        let firstNumber = 6.0
+        let secondNumber = 9.0
+        let thirdNumber = 96.0
+        
+        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        calculatedResult = sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
+        
+        XCTAssertEqual(calculatedResult, firstNumber * secondNumber * thirdNumber)
+    }
+}

--- a/Calculator/CalculatorTests/MultiplyOperatorTests.swift
+++ b/Calculator/CalculatorTests/MultiplyOperatorTests.swift
@@ -21,21 +21,21 @@ class MultiplyOperatorTests: XCTestCase {
         sut = nil
     }
     
-    func testMultiplyTwoNumbers() {
+    func testMultiplyTwoNumbers() throws {
         let firstNumber = 3.0
         let secondNumber = 6.0
         
-        let calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        let calculatedResult = try sut.calculate(lhs: firstNumber, rhs: secondNumber)
         XCTAssertEqual(calculatedResult, firstNumber * secondNumber)
     }
     
-    func testMultiplyThreeNumbers() {
+    func testMultiplyThreeNumbers() throws {
         let firstNumber = 6.0
         let secondNumber = 9.0
         let thirdNumber = 96.0
         
-        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
-        calculatedResult = sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
+        var calculatedResult = try sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        calculatedResult = try sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
         
         XCTAssertEqual(calculatedResult, firstNumber * secondNumber * thirdNumber)
     }

--- a/Calculator/CalculatorTests/SubtractOperatorTests.swift
+++ b/Calculator/CalculatorTests/SubtractOperatorTests.swift
@@ -21,21 +21,21 @@ class SubtractOperatorTests: XCTestCase {
         sut = nil
     }
     
-    func testSubtractTwoNumbers() {
+    func testSubtractTwoNumbers() throws {
         let firstNumber = 3.0
         let secondNumber = 6.0
         
-        let calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        let calculatedResult = try sut.calculate(lhs: firstNumber, rhs: secondNumber)
         XCTAssertEqual(calculatedResult, firstNumber - secondNumber)
     }
     
-    func testSubtractThreeNumbers() {
+    func testSubtractThreeNumbers() throws {
         let firstNumber = 6.0
         let secondNumber = 9.0
         let thirdNumber = 96.0
         
-        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
-        calculatedResult = sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
+        var calculatedResult = try sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        calculatedResult = try sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
         
         XCTAssertEqual(calculatedResult, firstNumber - secondNumber - thirdNumber)
     }

--- a/Calculator/CalculatorTests/SubtractOperatorTests.swift
+++ b/Calculator/CalculatorTests/SubtractOperatorTests.swift
@@ -1,0 +1,42 @@
+//
+//  SubtractOperatorTests.swift
+//  CalculatorTests
+//
+//  Created by 김진태 on 2021/11/14.
+//
+
+import XCTest
+@testable import Calculator
+
+class SubtractOperatorTests: XCTestCase {
+    var sut: Operator!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = .subtract
+    }
+    
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func testSubtractTwoNumbers() {
+        let firstNumber = 3.0
+        let secondNumber = 6.0
+        
+        let calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        XCTAssertEqual(calculatedResult, firstNumber - secondNumber)
+    }
+    
+    func testSubtractThreeNumbers() {
+        let firstNumber = 6.0
+        let secondNumber = 9.0
+        let thirdNumber = 96.0
+        
+        var calculatedResult = sut.calculate(lhs: firstNumber, rhs: secondNumber)
+        calculatedResult = sut.calculate(lhs: calculatedResult, rhs: thirdNumber)
+        
+        XCTAssertEqual(calculatedResult, firstNumber - secondNumber - thirdNumber)
+    }
+}


### PR DESCRIPTION
안녕하세요 delma! @delmaSong
코로나 백신 후유증을 앓고 있는 제이티입니다 😂

계산기 프로젝트 STEP 2 PR 올립니다! 미리 약속한 PR 기한을 번복하게 되어 죄송합니다 🥲 늦었지만 잘 부탁드립니다!

# UML

![프로젝트에서 제시한 UML 이미지](https://s3.ap-northeast-2.amazonaws.com/media.yagom-academy.kr/resources/6131c8fa2e11413823f8dd7f/6189d7537c82755a83c68a7d.jpg)

프로젝트의 UML에서 제시한 타입, 프로퍼티, 메소드 등이 어떤 의도로 제시된 것인지에 대해 고민했습니다.

- enum `Operator`

  - 각 케이스가 `Character` 타입의 `rawValue`를 갖는 것을 보고 `add`는 `"+"`, `subtract`는 `"-"`와 같이 각 케이스에 맞는 `Character`를 `rawValue`로 갖도록 의도했다 판단했습니다.
  - `calculate(lhs:rhs:)` 메소드만 `internal`이고 `add(lhs:rhs:)`, `subtract(lhs:rhs:)`, `divide(lhs:rhs:)`, `multiply(lhs:rhs:)` 메소드가 `private`인 것을 통해 `calculate(lhs:rhs:)` 메소드가 나머지 4개의 메소드를 활용하는 형태로 구현하도록 의도했다 판단했습니다.
  - `CaseIterable` 프로토콜을 채용하여 `Operator.allCases`와 같이 해당 타입 내부에 allCases 프로퍼티가 생성되도록 한 이유는 `ExpressionParser` 타입의 `componentsByOperators(from:)` 메소드에서 활용하기 위함으로 이해했습니다.

- extension `Double`

  - `Double` 타입이 `CalculateItem` 프로토콜을 채용하는 것 외에 해당 extension 코드에서 구현하는 프로퍼티, 메소드 등이 없다고 이해했습니다.
  - `Double` 타입이 `CalculateItem` 프로토콜을 채용하는 이유는 `CalculateItem` 프로토콜을 채용한 타입만 받을 수 있는 변수, 파라미터 등에 `Double` 타입의 값을 넣어줄 수 있도록 하기 위함으로 이해했습니다.

- extension `String`

  - 해당 extension에서 `split(with:)` 메소드를 작성하는 이유가 기존에 `String` 타입에 구현된 `split(separator:)`와 `components(separatedBy:)` 메소드를 활용하였을 때 `return`된 값에는 separator가 포함되어 있지 않기 때문으로 이해했습니다.
  - 제가 이해한 기존에 구현된 `split(separator:)`와 `components(separatedBy:)` 메소드를 사용한 결과와 우리가 구현해야 하는 `split(with:)` 메소드가 실행되었을 때 기대되는 결과는 다음과 같습니다.

    ```swift
      let input = "4,5,6"
      let splitSeparatorResult = input.split(separator: ",")
      let componentsSeparatedByResult = input.components(separatedBy: ",")
      let splitWithResult = input.split(with: ",")

      print("\(splitSeparatorResult)")
      // 출력 결과: ["4", "5", "6"]

      print("\(componentsSeparatedByResult)")
      // 출력 결과: ["4", "5", "6"]

      print("\(splitWithResult)")
      // 출력 결과: ["4", ",", "5", ",", "6"]
    ```

- enum `ExpressionParser`

  - `parse(from:)` 메소드는 `internal`이고 `componentsByOperators(from:)` 메소드는 `private`인 것을 보고 `parse(from:)` 메소드가 `componentsByOperators(from:)` 메소드를 활용할 것이라고 생각했습니다.
  - `parse(from:)` 메소드에서 `componentsByOperators(from:)` 메소드를 활용해 숫자와 연산자 기호를 쪼개고 return된 `[String]` 값을 이용해 Formula를 생성하여 return하는 것으로 이해했습니다.

- struct `Formula`

  - `CalculatorItemQueue` 타입 `operands`와 `operators` 프로퍼티 내부의 값을 이용해 `result()` 메소드를 구현해야 하고, `result()` 메소드를 실행하면 `operands`와 `operators` 프로퍼티 내부의 값에 변화가 생길 수 있다고 이해했습니다.
  - `operands` 프로퍼티에는 `Double` 타입의 값만 insert되고 `operators` 프로퍼티에는 `Operator` 타입의 값만 insert 되도록 의도하였다 판단했습니다.

# 고민하며 작성한 코드

## String extension의 split(with:) 메소드 구현

- `split(with:)` 메소드를 구현할 때 `String` 타입의 `components(separatedBy:)` 메소드를 사용할지 `split(separator:)` 메소드를 사용할지 고민했습니다.
  - 처음에 구현할 때에는 특별한 기준 없이 `components(separatedBy:)` 메소드를 활용해 구현했으나 구현한 후 검색을 통해 `split(with:)` 메소드가 더 성능이 좋다는 것을 알게 되었습니다.
  - 성능 이외에 `""` (empty subsequence) 처리도 `split(with:)` 메소드를 사용하는 게 적합하다는 것을 알게 되었습니다.
  - 해당 PR을 올리는 시점에서는 `components(separatedBy:)` 메소드를 활용한 상태입니다.
- `components(separatedBy:)` 메소드를 활용해 생성한 배열에 separator를 어떻게 삽입해야 할지 고민했습니다.
  - `flatMap(_:)` 메소드를 활용해 각 배열 요소 뒤에 separator를 붙여주고 `dropLast()` 메소드로 마지막 요소를 제거하는 방식으로 구현해주었습니다.
  - `filter(_:)` 메소드를 활용해 `""` (empty subsequence)를 처리해주었습니다.
  - `map(_:)` 메소드를 활용해 배열 내부에 있는 모든 값의 타입을 `String`으로 변환해주었습니다. 해당 기능을 구현한 뒤 `map(_:)` 메소드가 없어도 배열 내부의 값이 모두 `String`임을 알게 되었습니다.

```swift
extension String {
    func split(with target: Character) -> [String] {
        let targetString = String(target)
        let splittedStrings = self.components(separatedBy: targetString)
                                  .flatMap { [$0, targetString] }
                                  .dropLast()
                                  .filter { !$0.isEmpty }
                                  .map { String($0) }
        return splittedStrings
    }
}
```

## ExpressionParser 타입의 parse(from:) 메소드 구현

`parse(from:)` 메소드 내부에서 `operatorComponents`와 `operandComponents`를 나누는 방식을 어떻게 구현할지에 대해 고민했습니다.

- `operatorComponents` 추출 구현 방식에 대한 고민

  - `operatorComponents`의 값을 추출할 때에 `Character`로 형변환하는 과정에서 형변환하기 전에 해당 `String`의 `count`가 1인지 확인해야 할지 고민했습니다.

- `operandComponents` 추출 구현 방식에 대한 고민

  - 아래의 구현 코드를 보면 `operandComponents`는 `operatorComponents`가 아닌 값을 `filter(_:)` 메소드를 통해 추출하도록 구현되어 있습니다.
  - 해당 구현 방식을 사용하면 해당 메소드의 파라미터 `input`의 값이 `"4+1-!5"`와 같이 예상하지 못한 기호(여기서는 !)가 들어있으면 추출된 값이 의도한 것과 다른 값이 될 수 있습니다.
  - 해당 프로젝트에서는 사용자가 직접 `input` 값을 입력할 일이 없어 예외처리 해주지 않아도 괜찮다고 판단했습니다.

```swift
static func parse(from input: String) -> Formula {
        let components = componentsByOperators(from: input)
        let allOperatorSymbols = Operator.allCases.map { String($0.rawValue) }

        let operatorComponents = components.filter { allOperatorSymbols.contains($0) }.map { Character($0) }
        let operandComponents = components.filter { !allOperatorSymbols.contains($0) }
        var formula = Formula()

        // 나머지 코드...

        return formula
    }
```

## ExpressionParser 타입의 componentsByOperators(from:) 메소드 구현

- `componentsByOperators(from:)` 메소드를 구현할 때 부호 `"+"`, `"-"`와 연산자 `"+"`, `"-"`를 어떻게 구분해주어야 할지 고민했습니다.
  - 부호 `"+"`, `"-"`와 연산자 `"+"`, `"-"`를 구분하여 분리하는 기능을 구현하며 가독성이 떨어지고 복잡한 코드가 되진 않을까 고민했습니다.
  - 먼저 연산자와 부호가 섞인 `["*+", "*-", "/+", "/-"]`에 대해 components를 분리한 뒤 연산자의 값이 들어간 `["*", "/", "+", "-"]`에 대해 components를 한 번 더 분리하는 방식으로 구현해주었습니다.
- `components` 지역 변수를 `var`(변수)가 아닌 `let`(상수)으로 활용하는 방법이 없을지 고민했습니다.
  - `let`(상수) 키워드로 `components`를 생성하는 방법은 알고 있지만 제가 생각하는 방법을 사용하면 가독성이 오히려 떨어질 것 같아 `var`(변수)로 구현했습니다.
  - `reduce(_:)` 메소드를 `map(_:)`이나 `filter(_:)`와 같은 다른 고차함수로 대체할 수 없는지 고민했습니다. `reduce(_:)` 메소드를 활용한 코드를 개선하면 `var`(변수) 대신 `let`(상수) 키워드를 사용해 지역 변수를 생성해도 가독성에 문제가 생기지 않을 것이라 판단했습니다.
- JavaScript에서 사용되는 `...`([Spread Operator](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/Spread_syntax))와 같은 기능을 하는 연산자가 Swift에도 제공되는지 알아보았습니다. Variadic Parameter과 같이 다른 기능을 구현할 때 같은 기호를 사용하는 문법은 있었으나 아쉽게도 동일한 기능은 찾지 못했습니다.
- 해당 메소드 구현 방식에 성능적 측면에서 개선할 여지가 없는지에 대해 고민해보았습니다.

```swift
    private static func componentsByOperators(from input: String) -> [String] {
        // 나머지 코드...

        var components = multiplyDivideSymbolsWithSign.reduce([inputWithoutWhitespace]) {
            (result: [String], operatorSymbolWithSign: String) in
            guard let operatorSymbol = operatorSymbolWithSign.first else { return result }
            guard let sign = operatorSymbolWithSign.last else { return result }
            let operatorSymbolWithEmptySpaceAndSign = "\(emptySpace)\(operatorSymbol)\(emptySpace)\(sign)"

            return result
                        .map {
                            $0.replacingOccurrences(of: operatorSymbolWithSign, with: operatorSymbolWithEmptySpaceAndSign)
                        }
                        .flatMap { $0.components(separatedBy: "\(emptySpace)") }
        }

        components = allOperatorSymbols.reduce(components) {
            (result: [String], operatorSymbol: Character) in
            return result
                        .flatMap { component -> [String] in
                            let splittedComponents = component.split(with: operatorSymbol)
                            guard let firstString = splittedComponents.first, firstString.count == 1, splittedComponents.count > 1 else { return splittedComponents }
                            let firstCharacter = Character(firstString)
                            guard signs.contains(firstCharacter) else { return splittedComponents }
                            let firstOpponent = "\(firstString)\(splittedComponents[1])"
                            guard splittedComponents.count > 2 else { return [firstOpponent] }
                            return ([firstOpponent] + Array(splittedComponents[2...]))
                        }
        }

        return components
    }
```

## Formula 타입의 result() 메소드 구현

- `result()` 메소드를 구현할 때 while문을 사용하지 않고 같은 기능을 구현할 수 있는 방법이 없는지 고민했습니다.
  - `CalculatorItemQueue` 타입 내부의 `items` 프로퍼티에 외부에서 접근할 수 있도록 하는 등 기존 코드를 수정하는 방법이 떠올랐습니다.
  - `CalculatorItemQueue` 타입 내부의 `items` 프로퍼티는 의도적으로 은닉화한 것이기 때문에 해당 방법을 사용하고 싶지 않아 수정하지 않았습니다.

```swift
    mutating func result() throws -> Double {
        let zeroValue = 0.0
        guard var resultValue = operands.delete() else { return zeroValue }

        while true {
            guard let operatorInstance = operators.delete(), let operandValue = operands.delete() else {
                break
            }
            resultValue = try operatorInstance.calculate(lhs: resultValue, rhs: operandValue)
        }

        return resultValue
    }
```

# 조언을 얻고 싶은 부분

## ExpressionParser 타입의 componentsByOperators(from:) 메소드 구현 방식

1. `components` 지역 변수를 `var`가 아닌 `let` 키워드로 생성하면서 가독성을 해치지 않는 방법이 있는지 조언을 얻고 싶습니다!
2. `allOperatorSymbols`의 `reduce(_:)` 메소드를 활용하는 코드가 복잡한 것 같습니다. 해당 코드를 개선할 수 있는 방법이 없을지 조언을 얻고 싶습니다!

```swift
    private static func componentsByOperators(from input: String) -> [String] {
        // 나머지 코드...

        var components = multiplyDivideSymbolsWithSign.reduce([inputWithoutWhitespace]) {
            (result: [String], operatorSymbolWithSign: String) in
            guard let operatorSymbol = operatorSymbolWithSign.first else { return result }
            guard let sign = operatorSymbolWithSign.last else { return result }
            let operatorSymbolWithEmptySpaceAndSign = "\(emptySpace)\(operatorSymbol)\(emptySpace)\(sign)"

            return result
                        .map {
                            $0.replacingOccurrences(of: operatorSymbolWithSign, with: operatorSymbolWithEmptySpaceAndSign)
                        }
                        .flatMap { $0.components(separatedBy: "\(emptySpace)") }
        }

        // 2번 질문에 대한 코드
        components = allOperatorSymbols.reduce(components) {
            (result: [String], operatorSymbol: Character) in
            return result
                        .flatMap { component -> [String] in
                            let splittedComponents = component.split(with: operatorSymbol)
                            guard let firstString = splittedComponents.first, firstString.count == 1, splittedComponents.count > 1 else { return splittedComponents }
                            let firstCharacter = Character(firstString)
                            guard signs.contains(firstCharacter) else { return splittedComponents }
                            let firstOpponent = "\(firstString)\(splittedComponents[1])"
                            guard splittedComponents.count > 2 else { return [firstOpponent] }
                            return ([firstOpponent] + Array(splittedComponents[2...]))
                        }
        }

        return components
    }
```

## Formula 타입의 result() 메소드 구현 방식

- `result()` 메소드를 구현할 때 while문을 사용하지 않고 같은 기능을 구현할 수 있는 방법이 있는지, 있다면 어떤 방법을 사용할 수 있는지 조언을 얻고 싶습니다!

```swift
    mutating func result() throws -> Double {
        let zeroValue = 0.0
        guard var resultValue = operands.delete() else { return zeroValue }

        while true {
            guard let operatorInstance = operators.delete(), let operandValue = operands.delete() else {
                break
            }
            resultValue = try operatorInstance.calculate(lhs: resultValue, rhs: operandValue)
        }

        return resultValue
    }
```
