### PR TITLE
계산기 [STEP 2] 제인

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -17,6 +17,12 @@
 		EA9C47F1273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C47F0273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift */; };
 		EA9C47F5273A58FA001676F8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C47E8273A559D001676F8 /* CalculatorItemQueue.swift */; };
 		EA9C47F7273A725E001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C47F0273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift */; };
+		EAB0A84E273D734E00C5E80C /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A84D273D734E00C5E80C /* CalculateItem.swift */; };
+		EAB0A84F273D740200C5E80C /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A84D273D734E00C5E80C /* CalculateItem.swift */; };
+		EAB0A851273D743400C5E80C /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A850273D743400C5E80C /* Formula.swift */; };
+		EAB0A853273D744400C5E80C /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A852273D744400C5E80C /* ExpressionParser.swift */; };
+		EAB0A854273D745400C5E80C /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A852273D744400C5E80C /* ExpressionParser.swift */; };
+		EAB0A855273D745600C5E80C /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A850273D743400C5E80C /* Formula.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +37,9 @@
 		EA9C47E8273A559D001676F8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		EA9C47EE273A58EE001676F8 /* CalculatorItemQueueUnitTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueUnitTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA9C47F0273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueUnitTest.swift; sourceTree = "<group>"; };
+		EAB0A84D273D734E00C5E80C /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
+		EAB0A850273D743400C5E80C /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		EAB0A852273D744400C5E80C /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,7 +110,10 @@
 		EAB0A834273BA33700C5E80C /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				EAB0A84D273D734E00C5E80C /* CalculateItem.swift */,
 				EA9C47E8273A559D001676F8 /* CalculatorItemQueue.swift */,
+				EAB0A850273D743400C5E80C /* Formula.swift */,
+				EAB0A852273D744400C5E80C /* ExpressionParser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -215,9 +227,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				EA9C47F7273A725E001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */,
+				EAB0A851273D743400C5E80C /* Formula.swift in Sources */,
+				EAB0A84E273D734E00C5E80C /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				EA9C47E9273A559D001676F8 /* CalculatorItemQueue.swift in Sources */,
+				EAB0A853273D744400C5E80C /* ExpressionParser.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -227,6 +242,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				EA9C47F5273A58FA001676F8 /* CalculatorItemQueue.swift in Sources */,
+				EAB0A84F273D740200C5E80C /* CalculateItem.swift in Sources */,
+				EAB0A854273D745400C5E80C /* ExpressionParser.swift in Sources */,
+				EAB0A855273D745600C5E80C /* Formula.swift in Sources */,
 				EA9C47F1273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		EAB0A855273D745600C5E80C /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A850273D743400C5E80C /* Formula.swift */; };
 		EAB0A857273E0E7400C5E80C /* FormulaUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */; };
 		EAB0A858273E118400C5E80C /* FormulaUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */; };
+		EAB0A85A273E8C5B00C5E80C /* ExpressionParserUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A859273E8C5B00C5E80C /* ExpressionParserUnitTest.swift */; };
+		EAB0A85B273E8C6300C5E80C /* ExpressionParserUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A859273E8C5B00C5E80C /* ExpressionParserUnitTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -43,6 +45,7 @@
 		EAB0A850273D743400C5E80C /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		EAB0A852273D744400C5E80C /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaUnitTest.swift; sourceTree = "<group>"; };
+		EAB0A859273E8C5B00C5E80C /* ExpressionParserUnitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserUnitTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +100,7 @@
 			children = (
 				EA9C47F0273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift */,
 				EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */,
+				EAB0A859273E8C5B00C5E80C /* ExpressionParserUnitTest.swift */,
 			);
 			path = CalculatorItemQueueUnitTest;
 			sourceTree = "<group>";
@@ -232,6 +236,7 @@
 			files = (
 				EA9C47F7273A725E001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */,
 				EAB0A851273D743400C5E80C /* Formula.swift in Sources */,
+				EAB0A85B273E8C6300C5E80C /* ExpressionParserUnitTest.swift in Sources */,
 				EAB0A858273E118400C5E80C /* FormulaUnitTest.swift in Sources */,
 				EAB0A84E273D734E00C5E80C /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
@@ -246,6 +251,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EAB0A85A273E8C5B00C5E80C /* ExpressionParserUnitTest.swift in Sources */,
 				EA9C47F5273A58FA001676F8 /* CalculatorItemQueue.swift in Sources */,
 				EAB0A84F273D740200C5E80C /* CalculateItem.swift in Sources */,
 				EAB0A857273E0E7400C5E80C /* FormulaUnitTest.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,10 +13,10 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		EA91B35727437B7500394F60 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
 		EA9C47E9273A559D001676F8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C47E8273A559D001676F8 /* CalculatorItemQueue.swift */; };
 		EA9C47F1273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C47F0273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift */; };
 		EA9C47F5273A58FA001676F8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C47E8273A559D001676F8 /* CalculatorItemQueue.swift */; };
-		EA9C47F7273A725E001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C47F0273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift */; };
 		EAB0A84E273D734E00C5E80C /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A84D273D734E00C5E80C /* CalculateItem.swift */; };
 		EAB0A84F273D740200C5E80C /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A84D273D734E00C5E80C /* CalculateItem.swift */; };
 		EAB0A851273D743400C5E80C /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A850273D743400C5E80C /* Formula.swift */; };
@@ -24,9 +24,7 @@
 		EAB0A854273D745400C5E80C /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A852273D744400C5E80C /* ExpressionParser.swift */; };
 		EAB0A855273D745600C5E80C /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A850273D743400C5E80C /* Formula.swift */; };
 		EAB0A857273E0E7400C5E80C /* FormulaUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */; };
-		EAB0A858273E118400C5E80C /* FormulaUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */; };
 		EAB0A85A273E8C5B00C5E80C /* ExpressionParserUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A859273E8C5B00C5E80C /* ExpressionParserUnitTest.swift */; };
-		EAB0A85B273E8C6300C5E80C /* ExpressionParserUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A859273E8C5B00C5E80C /* ExpressionParserUnitTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -234,10 +232,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EA9C47F7273A725E001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */,
 				EAB0A851273D743400C5E80C /* Formula.swift in Sources */,
-				EAB0A85B273E8C6300C5E80C /* ExpressionParserUnitTest.swift in Sources */,
-				EAB0A858273E118400C5E80C /* FormulaUnitTest.swift in Sources */,
 				EAB0A84E273D734E00C5E80C /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
@@ -257,6 +252,7 @@
 				EAB0A857273E0E7400C5E80C /* FormulaUnitTest.swift in Sources */,
 				EAB0A854273D745400C5E80C /* ExpressionParser.swift in Sources */,
 				EAB0A855273D745600C5E80C /* Formula.swift in Sources */,
+				EA91B35727437B7500394F60 /* ViewController.swift in Sources */,
 				EA9C47F1273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -416,7 +412,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.Calculator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		EAB0A853273D744400C5E80C /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A852273D744400C5E80C /* ExpressionParser.swift */; };
 		EAB0A854273D745400C5E80C /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A852273D744400C5E80C /* ExpressionParser.swift */; };
 		EAB0A855273D745600C5E80C /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A850273D743400C5E80C /* Formula.swift */; };
+		EAB0A857273E0E7400C5E80C /* FormulaUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */; };
+		EAB0A858273E118400C5E80C /* FormulaUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +42,7 @@
 		EAB0A84D273D734E00C5E80C /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		EAB0A850273D743400C5E80C /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		EAB0A852273D744400C5E80C /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaUnitTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,6 +96,7 @@
 			isa = PBXGroup;
 			children = (
 				EA9C47F0273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift */,
+				EAB0A856273E0E7400C5E80C /* FormulaUnitTest.swift */,
 			);
 			path = CalculatorItemQueueUnitTest;
 			sourceTree = "<group>";
@@ -228,6 +232,7 @@
 			files = (
 				EA9C47F7273A725E001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */,
 				EAB0A851273D743400C5E80C /* Formula.swift in Sources */,
+				EAB0A858273E118400C5E80C /* FormulaUnitTest.swift in Sources */,
 				EAB0A84E273D734E00C5E80C /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
@@ -243,6 +248,7 @@
 			files = (
 				EA9C47F5273A58FA001676F8 /* CalculatorItemQueue.swift in Sources */,
 				EAB0A84F273D740200C5E80C /* CalculateItem.swift in Sources */,
+				EAB0A857273E0E7400C5E80C /* FormulaUnitTest.swift in Sources */,
 				EAB0A854273D745400C5E80C /* ExpressionParser.swift in Sources */,
 				EAB0A855273D745600C5E80C /* Formula.swift in Sources */,
 				EA9C47F1273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		EA003F002744F41A00E0B9D8 /* OperatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA003EFF2744F41A00E0B9D8 /* OperatorError.swift */; };
 		EA91B35727437B7500394F60 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
 		EA9C47E9273A559D001676F8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C47E8273A559D001676F8 /* CalculatorItemQueue.swift */; };
 		EA9C47F1273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C47F0273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift */; };
@@ -36,6 +37,7 @@
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EA003EFF2744F41A00E0B9D8 /* OperatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorError.swift; sourceTree = "<group>"; };
 		EA9C47E8273A559D001676F8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		EA9C47EE273A58EE001676F8 /* CalculatorItemQueueUnitTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueUnitTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA9C47F0273A58EE001676F8 /* CalculatorItemQueueUnitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueUnitTest.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				EAB0A84D273D734E00C5E80C /* CalculateItem.swift */,
+				EA003EFF2744F41A00E0B9D8 /* OperatorError.swift */,
 				EA9C47E8273A559D001676F8 /* CalculatorItemQueue.swift */,
 				EAB0A850273D743400C5E80C /* Formula.swift */,
 				EAB0A852273D744400C5E80C /* ExpressionParser.swift */,
@@ -236,6 +239,7 @@
 				EAB0A84E273D734E00C5E80C /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				EA003F002744F41A00E0B9D8 /* OperatorError.swift in Sources */,
 				EA9C47E9273A559D001676F8 /* CalculatorItemQueue.swift in Sources */,
 				EAB0A853273D744400C5E80C /* ExpressionParser.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/CalculatorItemQueueUnitTest.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/CalculatorItemQueueUnitTest.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EA9C47ED273A58EE001676F8"
+               BuildableName = "CalculatorItemQueueUnitTest.xctest"
+               BlueprintName = "CalculatorItemQueueUnitTest"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/CalculatorItemQueueUnitTest.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/CalculatorItemQueueUnitTest.xcscheme
@@ -34,6 +34,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -41,6 +51,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -1,18 +1,49 @@
-//
-//  Calculator - ViewController.swift
-//  Created by yagom. 
-//  Copyright © yagom. All rights reserved.
-// 
-
 import UIKit
 
 class ViewController: UIViewController {
 
+    @IBOutlet weak var resultLabel: UILabel!
+    @IBOutlet weak var operatorLabel: UILabel!
+    @IBOutlet weak var UIScrollView: UIScrollView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        resultLabel.text = "0"
+        
     }
 
-
+    @IBAction func operandButtonTapped(_ sender: UIButton) {
+        guard let operand = sender.currentTitle else {return}
+        resultLabel.text?.append(contentsOf: operand)
+    }
+    
+    @IBAction func operatorButtonTapped(_ sender: UIButton) {
+        guard let `operator` = sender.currentTitle else {return}
+        resultLabel.text?.append(contentsOf: `operator`)
+        operatorLabel.text = `operator`
+    }
+    
+    @IBAction func ACButtonTapped(_ sender: UIButton) {
+        resultLabel.text = "0"
+    }
+    
+    @IBAction func CEButtonTapped(_ sender: UIButton) {
+        if resultLabel.text?.isEmpty == false {
+            resultLabel.text?.removeLast()
+        }
+    }
+    
+    @IBAction func plusMinusButtonChanged(_ sender: UIButton) {
+        
+    }
+    
+    @IBAction func dotButtonTapped(_ sender: UIButton) {
+        
+    }
+    
+    @IBAction func resultButtonTapped(_ sender: UIButton) {
+        
+    }
+    
 }
 

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -14,23 +14,33 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "/"
     case multiply = "*"
     
-    func calculate() -> Double {
-        return 0.1
+    //연산 케이스에 따라 두 숫자를 받아서 함수를 실행하는 함수
+    func calculate(lhs: Double, rhs: Double) -> Double {
+        switch self {
+        case .add:
+            return add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            return subtract(lhs: lhs, rhs: rhs)
+        case .divide:
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
+        }
     }
     
-    func add() -> Double {
-        return 0.1
+    func add(lhs: Double, rhs: Double) -> Double {
+        return lhs + rhs
     }
     
-    func subtract() -> Double {
-        return 0.1
+    func subtract(lhs: Double, rhs: Double) -> Double {
+        return lhs - rhs
     }
     
-    func divide() -> Double {
-        return 0.1
+    func divide(lhs: Double, rhs: Double) -> Double {
+        return lhs / rhs
     }
     
-    func multiply() -> Double {
-        return 0.1
+    func multiply(lhs: Double, rhs: Double) -> Double {
+        return lhs * rhs
     }
 }

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -31,22 +31,22 @@ enum Operator: Character, CaseIterable, CalculateItem {
         }
     }
     
-    func add(lhs: Double, rhs: Double) -> Double {
+    private func add(lhs: Double, rhs: Double) -> Double {
         return lhs + rhs
     }
     
-    func subtract(lhs: Double, rhs: Double) -> Double {
+    private func subtract(lhs: Double, rhs: Double) -> Double {
         return lhs - rhs
     }
     
-    func divide(lhs: Double, rhs: Double) throws -> Double {
+    private func divide(lhs: Double, rhs: Double) throws -> Double {
         if rhs == 0 {
             throw OperatorError.divideError
         }
         return lhs / rhs
     }
     
-    func multiply(lhs: Double, rhs: Double) -> Double {
+    private func multiply(lhs: Double, rhs: Double) -> Double {
         return lhs * rhs
     }
 }

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum OperatorError: Error {
-    case divideError
+    case divideByZero
 }
 
 protocol CalculateItem {
@@ -41,7 +41,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
     
     private func divide(lhs: Double, rhs: Double) throws -> Double {
         if rhs == 0 {
-            throw OperatorError.divideError
+            throw OperatorError.divideByZero
         }
         return lhs / rhs
     }

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-enum OperatorError: Error {
-    case divideByZero
-}
-
 protocol CalculateItem {
     
 }

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -14,7 +14,7 @@ extension Double: CalculateItem {
 
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
-    case subtract = "-"
+    case subtract = "_"
     case divide = "/"
     case multiply = "*"
     

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -18,7 +18,6 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "/"
     case multiply = "*"
     
-    //연산 케이스에 따라 두 숫자를 받아서 함수를 실행하는 함수
     func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {
         case .add:

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+enum OperatorError: Error {
+    case divideError
+}
+
 protocol CalculateItem {
     
 }
@@ -15,14 +19,14 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case multiply = "*"
     
     //연산 케이스에 따라 두 숫자를 받아서 함수를 실행하는 함수
-    func calculate(lhs: Double, rhs: Double) -> Double {
+    func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {
         case .add:
             return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            return divide(lhs: lhs, rhs: rhs)
+            return try divide(lhs: lhs, rhs: rhs)
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
         }
@@ -36,7 +40,10 @@ enum Operator: Character, CaseIterable, CalculateItem {
         return lhs - rhs
     }
     
-    func divide(lhs: Double, rhs: Double) -> Double {
+    func divide(lhs: Double, rhs: Double) throws -> Double {
+        if rhs == 0 {
+            throw OperatorError.divideError
+        }
         return lhs / rhs
     }
     

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -4,6 +4,33 @@ protocol CalculateItem {
     
 }
 
-extension Character: CalculateItem {
+extension Double: CalculateItem {
     
+}
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+"
+    case subtract = "-"
+    case divide = "/"
+    case multiply = "*"
+    
+    func calculate() -> Double {
+        return 0.1
+    }
+    
+    func add() -> Double {
+        return 0.1
+    }
+    
+    func subtract() -> Double {
+        return 0.1
+    }
+    
+    func divide() -> Double {
+        return 0.1
+    }
+    
+    func multiply() -> Double {
+        return 0.1
+    }
 }

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol CalculateItem {
+    
+}
+
+extension Character: CalculateItem {
+    
+}

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -15,14 +15,14 @@ extension Character: CalculateItem {
     
 }
 
-class CalculatorItemQueue<T: CalculateItem> {
+struct CalculatorItemQueue<T: CalculateItem> {
     private var calculatorItems = [T]()
     
-    func enqueue(_ item: T) {
+    mutating func enqueue(_ item: T) {
         calculatorItems.append(item)
     }
     
-    func dequeue() -> T? {
+    mutating func dequeue() -> T? {
         guard calculatorItems.isEmpty == false else {
             return nil
         }
@@ -35,7 +35,7 @@ class CalculatorItemQueue<T: CalculateItem> {
         return firstItem
     }
     
-    func removeAll() {
+    mutating func removeAll() {
         calculatorItems.removeAll()
     }
 }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct CalculatorItemQueue<T: CalculateItem> {
-    private var calculatorItems = [T]()
+    var calculatorItems: [T]
     
     mutating func enqueue(_ item: T) {
         calculatorItems.append(item)

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -24,7 +24,7 @@ struct CalculatorItemQueue<T: CalculateItem> {
         calculatorItems.removeAll()
     }
     
-    func countItems() -> Int {
+    var countItems: Int {
         return calculatorItems.count
     }
 }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -23,4 +23,8 @@ struct CalculatorItemQueue<T: CalculateItem> {
     mutating func removeAll() {
         calculatorItems.removeAll()
     }
+    
+    func countItems() -> Int {
+        return calculatorItems.count
+    }
 }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -24,7 +24,7 @@ struct CalculatorItemQueue<T: CalculateItem> {
         calculatorItems.removeAll()
     }
     
-    var countItems: Int {
+    var numberOfItems: Int {
         return calculatorItems.count
     }
 }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -1,19 +1,4 @@
-//
-//  CalculatorItemQueue.swift
-//  Calculator
-//
-//  Created by si won kim on 2021/11/09.
-//
-
 import Foundation
-
-protocol CalculateItem {
-    
-}
-
-extension Character: CalculateItem {
-    
-}
 
 struct CalculatorItemQueue<T: CalculateItem> {
     private var calculatorItems = [T]()

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -16,7 +16,7 @@ extension Character: CalculateItem {
 }
 
 class CalculatorItemQueue<T: CalculateItem> {
-    var calculatorItems = [T]()
+    private var calculatorItems = [T]()
     
     func enqueue(_ item: T) {
         calculatorItems.append(item)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -10,30 +10,36 @@ extension String {
 
 enum ExpressionParser {
     //숫자 배열을 가지고 input에서 다시 연산자 거르는애 -> 형식에맞게 둘다 리턴
-    static func parse(from input: String) -> [String] {
+    static func parse(from inputString: String) -> Formula {
         //[1,2,3,4]
-        let numberResultArray = componentsByOperators(from: input)
+        let numberArrayInString = componentsByOperators(from: inputString)
         
         //문자열 input를 배열로 변경: [1,+,2,-,3,/,4]
-        var inputArray = input.map { String($0) }
+        var inputArrayInString = inputString.map { String($0) }
         
         //배열을 숫자만있는배열을 이용해 숫자를제거해 연산자만 배열에담음
-        inputArray = inputArray.filter {!numberResultArray.contains($0)}
+        inputArrayInString = inputArrayInString.filter {!numberArrayInString.contains($0)}
         
+        let numberArrayInDouble = numberArrayInString.map {Double($0) ?? 0 }
+        let operatorArrayInOperator = inputArrayInString.map {Operator(rawValue: Character($0))!}
         
-        return inputArray
+        let operands = CalculatorItemQueue<Double>(calculatorItems: numberArrayInDouble)
+        let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)
+        let formula = Formula(operands: operands, operators: operators)
+
+        return formula
     }
     //숫자만 걸러서 리턴하는애
     static func componentsByOperators(from input: String) -> [String] {
-        var numberResult = input
+        var numberString = input
         
         Operator.allCases.forEach {
-            guard let tempNumberResult = numberResult.split(with: $0.rawValue).first else {return}
-            numberResult = tempNumberResult
+            guard let numberArrayWithBlank = numberString.split(with: $0.rawValue).first else {return}
+            numberString = numberArrayWithBlank
         }
         
-        let numberResultArray = numberResult.components(separatedBy: " ")
+        let numberArray = numberString.components(separatedBy: " ")
         
-        return numberResultArray
+        return numberArray
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -21,6 +21,9 @@ enum ExpressionParser {
             guard let tempNumberResult = numberResult.split(with: $0.rawValue).first else {return}
             numberResult = tempNumberResult
         }
-        return [numberResult]
+        
+        let numberResultInArray = numberResult.components(separatedBy: " ")
+        
+        return numberResultInArray
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,10 +1,11 @@
 import Foundation
 
 extension String {
-    //연산자 기준으로 나눈 String을 배열에 append해줌
+    //연산자를 빈칸으로 바꾼 문자열을 배열에 담아서 리턴 -> 이걸 4번하면 되겠지
     func split(with target: Character) -> [String] {
-        let splitedArray = self.components(separatedBy: target.description)
-        return splitedArray
+        let splitedArray = self.replacingOccurrences(of: target.description, with: " ")
+        return [splitedArray]
+        
     }
 }
 
@@ -13,8 +14,13 @@ enum ExpressionParser {
         return Formula()
     }
     
-    func componentsByOperators(from input: String) -> [String] {
-        return ["aa"]
+    static func componentsByOperators(from input: String) -> [String] {
+        var numberResult = input
+        
+        Operator.allCases.forEach {
+            guard let tempNumberResult = numberResult.split(with: $0.rawValue).first else {return}
+            numberResult = tempNumberResult
+        }
+        return [numberResult]
     }
 }
-

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -19,7 +19,6 @@ enum ExpressionParser {
         
         let operands = CalculatorItemQueue<Double>(calculatorItems: numberArrayInDouble)
         var operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)
-//        operators.enqueue(.add)
         
         let formula = Formula(operands: operands, operators: operators)
 

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -4,7 +4,6 @@ extension String {
     func split(with target: Character) -> [String] {
         let splitedArray = self.replacingOccurrences(of: target.description, with: " ")
         return [splitedArray]
-        
     }
 }
 
@@ -15,7 +14,7 @@ enum ExpressionParser {
         
         inputArrayInString = inputArrayInString.filter {!numberArrayInString.contains($0)}
         
-        let numberArrayInDouble = numberArrayInString.map {Double($0) ?? 0 }
+        let numberArrayInDouble = numberArrayInString.map {Double($0) ?? 0}
         let operatorArrayInOperator = inputArrayInString.compactMap {Operator(rawValue: Character($0))}
         
         let operands = CalculatorItemQueue<Double>(calculatorItems: numberArrayInDouble)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -9,15 +9,10 @@ extension String {
 }
 
 enum ExpressionParser {
-    //숫자 배열을 가지고 input에서 다시 연산자 거르는애 -> 형식에맞게 둘다 리턴
     static func parse(from inputString: String) -> Formula {
-        //[1,2,3,4]
         let numberArrayInString = componentsByOperators(from: inputString)
-        
-        //문자열 input를 배열로 변경: [1,+,2,-,3,/,4]
         var inputArrayInString = inputString.map { String($0) }
         
-        //배열을 숫자만있는배열을 이용해 숫자를제거해 연산자만 배열에담음
         inputArrayInString = inputArrayInString.filter {!numberArrayInString.contains($0)}
         
         let numberArrayInDouble = numberArrayInString.map {Double($0) ?? 0 }
@@ -29,7 +24,7 @@ enum ExpressionParser {
 
         return formula
     }
-    //숫자만 걸러서 리턴하는애
+
     static func componentsByOperators(from input: String) -> [String] {
         var numberString = input
         

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -18,7 +18,9 @@ enum ExpressionParser {
         let operatorArrayInOperator = operatorArrayInString.compactMap {Operator(rawValue: Character($0))}
         
         let operands = CalculatorItemQueue<Double>(calculatorItems: numberArrayInDouble)
-        let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)
+        var operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)
+//        operators.enqueue(.add)
+        
         let formula = Formula(operands: operands, operators: operators)
 
         return formula

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -10,12 +10,12 @@ extension String {
 enum ExpressionParser {
     static func parse(from inputString: String) -> Formula {
         let numberArrayInString = componentsByOperators(from: inputString)
-        var inputArrayInString = inputString.map { String($0) }
+        let inputArrayInString = inputString.map { String($0) }
         
-        inputArrayInString = inputArrayInString.filter {!numberArrayInString.contains($0)}
+        let operatorArrayInString = inputArrayInString.filter {!numberArrayInString.contains($0)}
         
         let numberArrayInDouble = numberArrayInString.map {Double($0) ?? 0}
-        let operatorArrayInOperator = inputArrayInString.compactMap {Operator(rawValue: Character($0))}
+        let operatorArrayInOperator = operatorArrayInString.compactMap {Operator(rawValue: Character($0))}
         
         let operands = CalculatorItemQueue<Double>(calculatorItems: numberArrayInDouble)
         let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -25,7 +25,7 @@ enum ExpressionParser {
         return formula
     }
 
-    static func componentsByOperators(from input: String) -> [String] {
+    private static func componentsByOperators(from input: String) -> [String] {
         var numberString = input
         
         Operator.allCases.forEach {

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,1 +1,12 @@
 import Foundation
+
+enum ExpressionParser {
+    func parse(from input: String) -> Formula {
+        return Formula()
+    }
+    
+    func componentsByOperators(from input: String) -> [String] {
+        return ["aa"]
+    }
+}
+

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+extension String {
+    //연산자 기준으로 나눈 String을 배열에 append해줌
+    func split(with target: Character) -> [String] {
+        let splitedArray = self.components(separatedBy: target.description)
+        return splitedArray
+    }
+}
+
 enum ExpressionParser {
     func parse(from input: String) -> Formula {
         return Formula()

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 extension String {
-    //연산자를 빈칸으로 바꾼 문자열을 배열에 담아서 리턴 -> 이걸 4번하면 되겠지
     func split(with target: Character) -> [String] {
         let splitedArray = self.replacingOccurrences(of: target.description, with: " ")
         return [splitedArray]
@@ -10,10 +9,21 @@ extension String {
 }
 
 enum ExpressionParser {
-    func parse(from input: String) -> Formula {
-        return Formula()
+    //숫자 배열을 가지고 input에서 다시 연산자 거르는애 -> 형식에맞게 둘다 리턴
+    static func parse(from input: String) -> [String] {
+        //[1,2,3,4]
+        let numberResultArray = componentsByOperators(from: input)
+        
+        //문자열 input를 배열로 변경: [1,+,2,-,3,/,4]
+        var inputArray = input.map { String($0) }
+        
+        //배열을 숫자만있는배열을 이용해 숫자를제거해 연산자만 배열에담음
+        inputArray = inputArray.filter {!numberResultArray.contains($0)}
+        
+        
+        return inputArray
     }
-    
+    //숫자만 걸러서 리턴하는애
     static func componentsByOperators(from input: String) -> [String] {
         var numberResult = input
         
@@ -22,8 +32,8 @@ enum ExpressionParser {
             numberResult = tempNumberResult
         }
         
-        let numberResultInArray = numberResult.components(separatedBy: " ")
+        let numberResultArray = numberResult.components(separatedBy: " ")
         
-        return numberResultInArray
+        return numberResultArray
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -9,16 +9,12 @@ extension String {
 
 enum ExpressionParser {
     static func parse(from inputString: String) -> Formula {
-        let numberArrayInString = componentsByOperators(from: inputString)
-        let inputArrayInString = inputString.map { String($0) }
+        let inputArrayInString = inputString.map {String($0)}
+        let operandArray = componentsByOperators(from: inputString).compactMap{Double($0)}
+        let operatorArray = inputArrayInString.filter{Operator(rawValue: Character($0)) != nil}.compactMap{Operator(rawValue: Character($0))}
         
-        let operatorArrayInString = inputArrayInString.filter {!numberArrayInString.contains($0)}
-        
-        let numberArrayInDouble = numberArrayInString.map {Double($0) ?? 0}
-        let operatorArrayInOperator = operatorArrayInString.compactMap {Operator(rawValue: Character($0))}
-        
-        let operands = CalculatorItemQueue<Double>(calculatorItems: numberArrayInDouble)
-        let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)
+        let operands = CalculatorItemQueue<Double>(calculatorItems: operandArray)
+        let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArray)
         
         let formula = Formula(operands: operands, operators: operators)
 

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -16,7 +16,7 @@ enum ExpressionParser {
         inputArrayInString = inputArrayInString.filter {!numberArrayInString.contains($0)}
         
         let numberArrayInDouble = numberArrayInString.map {Double($0) ?? 0 }
-        let operatorArrayInOperator = inputArrayInString.map {Operator(rawValue: Character($0))!}
+        let operatorArrayInOperator = inputArrayInString.compactMap {Operator(rawValue: Character($0))}
         
         let operands = CalculatorItemQueue<Double>(calculatorItems: numberArrayInDouble)
         let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -18,7 +18,7 @@ enum ExpressionParser {
         let operatorArrayInOperator = operatorArrayInString.compactMap {Operator(rawValue: Character($0))}
         
         let operands = CalculatorItemQueue<Double>(calculatorItems: numberArrayInDouble)
-        var operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)
+        let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)
         
         let formula = Formula(operands: operands, operators: operators)
 

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -9,11 +9,11 @@ struct Formula {
         self.operators = operators
     }
     
-    mutating func result() -> Double? {
+    mutating func result() -> Double {
         var result: Double = 0
-        for _ in 0...operands.countItems()-1 {
+        for _ in 0...operands.countItems-1 {
             let lhs = result
-            guard let rhs = operands.dequeue() else { return nil }
+            guard let rhs = operands.dequeue() else { return 0 }
             
             let `operator` = operators.dequeue()
             do {

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -4,7 +4,7 @@ struct Formula {
     var operands: CalculatorItemQueue<Double>
     var operators: CalculatorItemQueue<Operator>
     
-    init(operands:CalculatorItemQueue<Double> = CalculatorItemQueue<Double>(calculatorItems: []), operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>(calculatorItems: [])) {
+    init(operands:CalculatorItemQueue<Double> = CalculatorItemQueue<Double>(calculatorItems: []), operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>(calculatorItems: [.add])) {
         self.operands = operands
         self.operators = operators
     }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -11,7 +11,7 @@ struct Formula {
     
     mutating func result() -> Double? {
         var result: Double = 0
-        for _ in 0...`operands`.countItems()-1 {
+        for _ in 0...operands.countItems()-1 {
             let lhs = result
             guard let rhs = operands.dequeue() else { return nil }
             

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -5,6 +5,7 @@ struct Formula {
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
     
     func result() -> Double {
-        return 0.1
+        //Operator의 연산자 함수들을 사용하여 계산결과 도출하기
+        return 9
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -11,7 +11,7 @@ struct Formula {
     
     mutating func result() -> Double {
         var result: Double = 0
-        for _ in 0...operands.countItems-1 {
+        while operands.countItems > 0 {
             let lhs = result
             guard let rhs = operands.dequeue() else { return 0 }
             

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,1 +1,10 @@
 import Foundation
+
+struct Formula {
+    var operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>()
+    var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
+    
+    func result() -> Double {
+        return 0.1
+    }
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-struct Formula {
-    var operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>()
-    var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
+struct Formula: {
+    var operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>(calculatorItems: [])
+    var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>(calculatorItems: [])
     
     mutating func result() -> Double? {
         var result: Double = 0

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -17,7 +17,7 @@ struct Formula {
             
             let `operator` = operators.dequeue()
             do {
-                let calculateResult =  try `operator`?.calculate(lhs: lhs, rhs: rhs)
+                let calculateResult = try `operator`?.calculate(lhs: lhs, rhs: rhs)
                 result = calculateResult ?? 0
             } catch {
                 print("0으로 나눌 수 없음")

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Formula: {
+struct Formula {
     var operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>(calculatorItems: [])
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>(calculatorItems: [])
     
@@ -11,8 +11,14 @@ struct Formula: {
             guard let rhs = operands.dequeue() else { return nil }
             
             let `operator` = operators.dequeue()
-            guard let calculateResult = `operator`?.calculate(lhs: lhs, rhs: rhs) else { return nil }
-            result = calculateResult
+            do {
+                let calculateResult =  try `operator`?.calculate(lhs: lhs, rhs: rhs)
+                result = calculateResult ?? 0
+            } catch {
+                print("0으로 나눌 수 없음")
+            }
+           
+            
         }
         
         print(result)

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -11,7 +11,7 @@ struct Formula {
     
     mutating func result() -> Double {
         var result: Double = 0
-        while operands.countItems > 0 {
+        while operands.numberOfItems > 0 {
             let lhs = result
             guard let rhs = operands.dequeue() else { return 0 }
             

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -26,8 +26,4 @@ struct Formula {
         
         return result
     }
-    
-    func countOperands() -> Int {
-        return operands.calculatorItems.count
-    }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -6,11 +6,20 @@ struct Formula {
     
     mutating func result() -> Double? {
         //Operator의 연산자 함수들을 사용하여 계산결과 도출하기
-        guard let lhs = operands.dequeue() else { return nil }
-        guard let rhs = operands.dequeue() else { return nil }
-        let `operator` = operators.dequeue()
-        let calculateResult = `operator`?.calculate(lhs: lhs, rhs: rhs)
         
-        return calculateResult
+        for i in 0...operands.countItems()-2 {
+            guard let lhs = operands.dequeue() else { return nil }
+            guard let rhs = operands.dequeue() else { return nil }
+            
+            let `operator` = operators.dequeue()
+            guard let calculateResult = `operator`?.calculate(lhs: lhs, rhs: rhs) else { return nil }
+            
+            operands.enqueue(calculateResult)
+        }
+        
+        let result = operands.dequeue()
+        
+        
+        return result
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,8 +1,13 @@
 import Foundation
 
 struct Formula {
-    var operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>(calculatorItems: [])
-    var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>(calculatorItems: [])
+    var operands: CalculatorItemQueue<Double>
+    var operators: CalculatorItemQueue<Operator>
+    
+    init(operands:CalculatorItemQueue<Double> = CalculatorItemQueue<Double>(calculatorItems: []), operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>(calculatorItems: [])) {
+        self.operands = operands
+        self.operators = operators
+    }
     
     mutating func result() -> Double? {
         var result: Double = 0
@@ -20,5 +25,9 @@ struct Formula {
         }
         
         return result
+    }
+    
+    func countOperands() -> Int {
+        return operands.calculatorItems.count
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -17,11 +17,8 @@ struct Formula {
             } catch {
                 print("0으로 나눌 수 없음")
             }
-           
-            
         }
         
-        print(result)
         return result
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -4,7 +4,13 @@ struct Formula {
     var operands: CalculatorItemQueue<Double> = CalculatorItemQueue<Double>()
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
     
-    func result() -> Double {
-        return 9
+    mutating func result() -> Double? {
+        //Operator의 연산자 함수들을 사용하여 계산결과 도출하기
+        guard let lhs = operands.dequeue() else { return nil }
+        guard let rhs = operands.dequeue() else { return nil }
+        let `operator` = operators.dequeue()
+        let calculateResult = `operator`?.calculate(lhs: lhs, rhs: rhs)
+        
+        return calculateResult
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -5,21 +5,17 @@ struct Formula {
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
     
     mutating func result() -> Double? {
-        //Operator의 연산자 함수들을 사용하여 계산결과 도출하기
-        
-        for i in 0...operands.countItems()-2 {
-            guard let lhs = operands.dequeue() else { return nil }
+        var result: Double = 0
+        for _ in 0...`operands`.countItems()-1 {
+            let lhs = result
             guard let rhs = operands.dequeue() else { return nil }
             
             let `operator` = operators.dequeue()
             guard let calculateResult = `operator`?.calculate(lhs: lhs, rhs: rhs) else { return nil }
-            
-            operands.enqueue(calculateResult)
+            result = calculateResult
         }
         
-        let result = operands.dequeue()
-        
-        
+        print(result)
         return result
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -5,7 +5,6 @@ struct Formula {
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue<Operator>()
     
     func result() -> Double {
-        //Operator의 연산자 함수들을 사용하여 계산결과 도출하기
         return 9
     }
 }

--- a/Calculator/Calculator/Model/OperatorError.swift
+++ b/Calculator/Calculator/Model/OperatorError.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum OperatorError: Error {
+    case divideByZero
+}

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,40 +17,40 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                                <rect key="frame" x="16" y="245" width="382" height="41"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6qF-b3-Psy">
+                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Z3H-3J-pqF">
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U8o-Rm-zLb">
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -84,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="ACButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bgW-RR-dSY"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -92,6 +96,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="CEButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="oyw-uw-pB4"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -100,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="plusMinusButtonChanged:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YAQ-X9-bZb"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -108,6 +118,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="suy-pI-MUJ"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -121,6 +134,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cgh-yd-swR"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -129,6 +145,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ImS-Sg-hUI"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -137,6 +156,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Adx-uL-kuX"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -145,6 +167,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pYl-fh-6iW"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -158,6 +183,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ezn-7O-Aeo"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -166,6 +194,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vg2-2s-HE7"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -174,6 +205,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uqs-0F-g9Y"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -182,6 +216,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gQE-XZ-zLT"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -195,6 +232,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="otV-iO-BzN"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -203,6 +243,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="NTq-bg-uh7"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -211,6 +254,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="67M-MC-eB0"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -219,6 +265,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="XZQ-jt-J4m"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -232,6 +281,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kol-Yf-as1"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -240,6 +292,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="S4C-vv-Wfv"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -248,6 +303,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="dotButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LaI-11-wdS"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -259,25 +317,28 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="resultButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cds-Ir-uSW"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -302,6 +363,11 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="UIScrollView" destination="BOT-7g-vxv" id="Pyh-nK-JAF"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="wkW-NX-n9A"/>
+                        <outlet property="resultLabel" destination="Lwz-OF-XHD" id="J5o-Vb-B86"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/CalculatorItemQueueUnitTest/CalculatorItemQueueUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/CalculatorItemQueueUnitTest.swift
@@ -7,8 +7,8 @@ class CalculatorItemQueueUnitTest: XCTestCase {
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        sut = CalculatorItemQueue<Double>()
-        sut2 = CalculatorItemQueue<Operator>()
+        sut = CalculatorItemQueue<Double>(calculatorItems: [])
+        sut2 = CalculatorItemQueue<Operator>(calculatorItems: [])
     }
 
     override func tearDownWithError() throws {

--- a/Calculator/CalculatorItemQueueUnitTest/CalculatorItemQueueUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/CalculatorItemQueueUnitTest.swift
@@ -2,34 +2,37 @@
 import XCTest
 
 class CalculatorItemQueueUnitTest: XCTestCase {
-    var sut: CalculatorItemQueue<Character>!
+    var sut: CalculatorItemQueue<Double>!
+    var sut2: CalculatorItemQueue<Operator>!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        sut = CalculatorItemQueue<Character>()
+        sut = CalculatorItemQueue<Double>()
+        sut2 = CalculatorItemQueue<Operator>()
     }
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         sut = nil
+        sut2 = nil
     }
 
     func test_빈_큐에_1을_enqueue하면_1이_남는다() {
         //given
-        let input: Character = "1"
+        let input: Double = 1
         
         //when
         sut.enqueue(input)
         guard let result = sut.dequeue() else { return }
         
         //then
-        XCTAssertEqual(result, "1")
+        XCTAssertEqual(result, 1)
     }
     
     func test_빈_큐에_1과_2를_enqueue하면_1과_2가_남는다() {
         //given
-        let firstInput: Character = "1"
-        let secondInput: Character = "2"
+        let firstInput: Double = 1
+        let secondInput: Double = 2
         
         //when
         sut.enqueue(firstInput)
@@ -38,27 +41,27 @@ class CalculatorItemQueueUnitTest: XCTestCase {
         guard let secondResult = sut.dequeue() else { return }
         
         //then
-        XCTAssertEqual(firstResult, "1")
-        XCTAssertEqual(secondResult, "2")
+        XCTAssertEqual(firstResult, 1)
+        XCTAssertEqual(secondResult, 2)
     }
     
     func test_빈_큐에_더하기를_enqueue하면_더하기가_남는다() {
         //given
-        let input: Character = "+"
+        let input: Operator = .add
         
         //when
-        sut.enqueue(input)
-        guard let result = sut.dequeue() else { return }
+        sut2.enqueue(input)
+        guard let result = sut2.dequeue() else { return }
         
         //then
-        XCTAssertEqual(result, "+")
+        XCTAssertEqual(result, .add)
     }
     
     func test_1과_2와_3이_있는_큐를_dequeue하면_1이_나온다() {
         //given
-        let firstInput: Character = "1"
-        let secondInput: Character = "2"
-        let thirdInput: Character = "3"
+        let firstInput: Double = 1
+        let secondInput: Double = 2
+        let thirdInput: Double = 3
         
         //when
         sut.enqueue(firstInput)
@@ -67,7 +70,7 @@ class CalculatorItemQueueUnitTest: XCTestCase {
         guard let result = sut.dequeue() else { return }
         
         //then
-        XCTAssertEqual(result, "1")
+        XCTAssertEqual(result, 1)
     }
     
     func test_빈_큐에_dequeue을_하면_에러가_난다() {

--- a/Calculator/CalculatorItemQueueUnitTest/CalculatorItemQueueUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/CalculatorItemQueueUnitTest.swift
@@ -1,9 +1,3 @@
-//
-//  CalculatorItemQueueUnitTest.swift
-//  CalculatorItemQueueUnitTest
-//
-//  Created by si won kim on 2021/11/09.
-//
 
 import XCTest
 

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -1,6 +1,7 @@
 import XCTest
 
 class ExpressionParserUnitTest: XCTestCase {
+    var sut: ExpressionParser.Type! = ExpressionParser.self
     
     override func setUpWithError() throws {
         

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+class ExpressionParserUnitTest: XCTestCase {
+    
+    override func setUpWithError() throws {
+        
+    }
+
+    override func tearDownWithError() throws {
+        
+    }
+    
+    func test_더하기_연산자_기준으로_잘_나눠지는지() {
+        let splitedArray = "1+2+3".split(with: "+")
+
+        XCTAssertEqual(splitedArray, ["1","2","3"])
+    }
+    
+    func test_더하기_빼기가_있는_문자열이_더하기로_잘_나눠지는지() {
+        let splitedArray = "1+2-3".split(with: "+")
+
+        XCTAssertEqual(splitedArray, ["1","2-3"])
+    }
+}

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -1,15 +1,6 @@
 import XCTest
 
 class ExpressionParserUnitTest: XCTestCase {
-    var sut: ExpressionParser.Type! = ExpressionParser.self
-    
-    override func setUpWithError() throws {
-        
-    }
-
-    override func tearDownWithError() throws {
-        
-    }
     
     func test_더하기_연산자_기준으로_잘_나눠지는지() {
         let splitedArray = "1+2+3".split(with: "+")

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -37,11 +37,12 @@ class ExpressionParserUnitTest: XCTestCase {
         XCTAssertEqual(result, (["1","2","-3","4","5"]))
     }
     
-//    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_연산자만_뽑아지는지() {
-//        let inputString = "1+2-3*4/5"
-//        let result = ExpressionParser.parse(from: inputString)
-//
-//        XCTAssertEqual(result, Formula(operands: CalculatorItemQueue<Double>(calculatorItems: [1,2,3,4,5]), operators: CalculatorItemQueue<Operator>(calculatorItems: [.add,.subtract,.multiply,.divide])))
-//    }
+    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_연산자만_뽑아지는지() {
+        let inputString = "1+2-3*4/5"
+        let result = ExpressionParser.parse(from: inputString)
+        
+        let resultCount = result.countOperands()
+        XCTAssertEqual(resultCount, 5)
+    }
 
 }

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -29,10 +29,11 @@ class ExpressionParserUnitTest: XCTestCase {
         XCTAssertEqual(result, (["1","2","3","4","5"]))
     }
     
-    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_연산자만_뽑아지는지() {
-        let inputString = "1+2-3*4/5"
-        let result = ExpressionParser.parse(from: inputString)
-        
-        XCTAssertEqual(result, (["+","-","*","/"]))
-    }
+//    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_연산자만_뽑아지는지() {
+//        let inputString = "1+2-3*4/5"
+//        let result = ExpressionParser.parse(from: inputString)
+//
+//        XCTAssertEqual(result, Formula(operands: CalculatorItemQueue<Double>(calculatorItems: [1,2,3,4,5]), operators: CalculatorItemQueue<Operator>(calculatorItems: [.add,.subtract,.multiply,.divide])))
+//    }
+
 }

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -38,7 +38,7 @@ class ExpressionParserUnitTest: XCTestCase {
     }
     
     func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_연산자만_뽑아지는지() {
-        let inputString = "1+2-3*4/5"
+        let inputString = "1+2_3*4/5"
         let result = ExpressionParser.parse(from: inputString)
         
         let resultCount = result.countOperands()

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -14,19 +14,19 @@ class ExpressionParserUnitTest: XCTestCase {
         XCTAssertEqual(splitedArray, ["1 2-3"])
     }
     
-    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_숫자만_뽑아지는지() {
-        let inputString = "1+2_3*4/5"
-        let result = ExpressionParser.componentsByOperators(from: inputString)
-        
-        XCTAssertEqual(result, (["1","2","3","4","5"]))
-    }
-    
-    func test_빼기와_음수가_있는_문자열에서_숫자만_뽑아지는지() {
-        let inputString = "1+2_-3*4/5"
-        let result = ExpressionParser.componentsByOperators(from: inputString)
-        
-        XCTAssertEqual(result, (["1","2","-3","4","5"]))
-    }
+//    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_숫자만_뽑아지는지() {
+//        let inputString = "1+2_3*4/5"
+//        let result = ExpressionParser.componentsByOperators(from: inputString)
+//
+//        XCTAssertEqual(result, (["1","2","3","4","5"]))
+//    }
+//    
+//    func test_빼기와_음수가_있는_문자열에서_숫자만_뽑아지는지() {
+//        let inputString = "1+2_-3*4/5"
+//        let result = ExpressionParser.componentsByOperators(from: inputString)
+//
+//        XCTAssertEqual(result, (["1","2","-3","4","5"]))
+//    }
     
     func test_더하기_빼기_곱하기_나누기가_있는_문자열이_연산자와_피연산자_배열로_나눠지는지() {
         let inputString = "1+2_3*4/5"

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -37,12 +37,16 @@ class ExpressionParserUnitTest: XCTestCase {
         XCTAssertEqual(result, (["1","2","-3","4","5"]))
     }
     
-    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_연산자만_뽑아지는지() {
+    func test_더하기_빼기_곱하기_나누기가_있는_문자열이_연산자와_피연산자_배열로_나눠지는지() {
         let inputString = "1+2_3*4/5"
-        let result = ExpressionParser.parse(from: inputString)
+        var result = ExpressionParser.parse(from: inputString)
         
-        let resultCount = result.countOperands()
-        XCTAssertEqual(resultCount, 5)
+        [1,2,3,4,5].forEach { element in
+            XCTAssertEqual(element, result.operands.dequeue())
+        }
+        
+        [.add, .subtract, .multiply, .divide].forEach { element in
+            XCTAssertEqual(element, result.operators.dequeue())
+        }
     }
-
 }

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -24,10 +24,17 @@ class ExpressionParserUnitTest: XCTestCase {
     }
     
     func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_숫자만_뽑아지는지() {
-        let inputString = "1+2-3*4/5"
+        let inputString = "1+2_3*4/5"
         let result = ExpressionParser.componentsByOperators(from: inputString)
         
         XCTAssertEqual(result, (["1","2","3","4","5"]))
+    }
+    
+    func test_빼기와_음수가_있는_문자열에서_숫자만_뽑아지는지() {
+        let inputString = "1+2_-3*4/5"
+        let result = ExpressionParser.componentsByOperators(from: inputString)
+        
+        XCTAssertEqual(result, (["1","2","-3","4","5"]))
     }
     
 //    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_연산자만_뽑아지는지() {

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -26,6 +26,6 @@ class ExpressionParserUnitTest: XCTestCase {
         let inputString = "1+2-3*4/5"
         let result = ExpressionParser.componentsByOperators(from: inputString)
         
-        XCTAssertEqual(result, ["1 2 3 4 5"])
+        XCTAssertEqual(result, ["1","2","3","4","5"])
     }
 }

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -13,12 +13,19 @@ class ExpressionParserUnitTest: XCTestCase {
     func test_더하기_연산자_기준으로_잘_나눠지는지() {
         let splitedArray = "1+2+3".split(with: "+")
 
-        XCTAssertEqual(splitedArray, ["1","2","3"])
+        XCTAssertEqual(splitedArray, ["1 2 3"])
     }
     
     func test_더하기_빼기가_있는_문자열이_더하기로_잘_나눠지는지() {
         let splitedArray = "1+2-3".split(with: "+")
 
-        XCTAssertEqual(splitedArray, ["1","2-3"])
+        XCTAssertEqual(splitedArray, ["1 2-3"])
+    }
+    
+    func test_더하기_빼기_곱하기_나누기가_모두_빈칸으로_잘바뀌는지() {
+        let inputString = "1+2-3*4/5"
+        let result = ExpressionParser.componentsByOperators(from: inputString)
+        
+        XCTAssertEqual(result, ["1 2 3 4 5"])
     }
 }

--- a/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/ExpressionParserUnitTest.swift
@@ -22,10 +22,17 @@ class ExpressionParserUnitTest: XCTestCase {
         XCTAssertEqual(splitedArray, ["1 2-3"])
     }
     
-    func test_더하기_빼기_곱하기_나누기가_모두_빈칸으로_잘바뀌는지() {
+    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_숫자만_뽑아지는지() {
         let inputString = "1+2-3*4/5"
         let result = ExpressionParser.componentsByOperators(from: inputString)
         
-        XCTAssertEqual(result, ["1","2","3","4","5"])
+        XCTAssertEqual(result, (["1","2","3","4","5"]))
+    }
+    
+    func test_더하기_빼기_곱하기_나누기가_있는_문자열에서_연산자만_뽑아지는지() {
+        let inputString = "1+2-3*4/5"
+        let result = ExpressionParser.parse(from: inputString)
+        
+        XCTAssertEqual(result, (["+","-","*","/"]))
     }
 }

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -93,6 +93,7 @@ class FormulaUnitTest: XCTestCase {
     }
     
     func test_2더하기_3곱하기_4빼기_5의_결과는_15가_나온다() {
+        //given
         numbers.enqueue(2)
         numbers.enqueue(3)
         numbers.enqueue(4)
@@ -111,7 +112,25 @@ class FormulaUnitTest: XCTestCase {
         //then
         XCTAssertEqual(result, 15)
     }
-
+    
+    func test_2더하기_3나누기_0은_에러가_난다() {
+        //given
+        numbers.enqueue(2)
+        numbers.enqueue(3)
+        numbers.enqueue(0)
+        
+        operators.enqueue(.add)
+        operators.enqueue(.add)
+        operators.enqueue(.divide)
+        
+        var formula = Formula(operands: numbers, operators: operators)
+        
+        //when
+        let result = formula.result()
+        
+        //then
+        XCTAssertNoThrow(result)
+    }
 }
 
 

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -10,14 +10,13 @@ class FormulaUnitTest: XCTestCase {
         sut = nil
     }
 
-    func test_2더하기_3더하기_4의_결과는_9가_나온다() {
+    func test_2더하기_3의_결과는_5가_나온다() {
         //given
         var numbers = CalculatorItemQueue<Double>()
         var operators = CalculatorItemQueue<Operator>()
         numbers.enqueue(2)
         numbers.enqueue(3)
-        numbers.enqueue(4)
-        operators.enqueue(.add)
+
         operators.enqueue(.add)
         
         var firstFormula = Formula(operands: numbers, operators: operators)
@@ -26,7 +25,7 @@ class FormulaUnitTest: XCTestCase {
         let result = firstFormula.result()
         
         //then
-        XCTAssertEqual(result, 9)
+        XCTAssertEqual(result, 5)
     }
 
 }

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -6,8 +6,8 @@ class FormulaUnitTest: XCTestCase {
 //    var formula: Formula!
     
     override func setUpWithError() throws {
-        numbers = CalculatorItemQueue<Double>()
-        operators = CalculatorItemQueue<Operator>()
+        numbers = CalculatorItemQueue<Double>(calculatorItems: [])
+        operators = CalculatorItemQueue<Operator>(calculatorItems: [])
 //        formula = Formula(operands: numbers, operators: operators)
     }
 

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -19,7 +19,6 @@ class FormulaUnitTest: XCTestCase {
         formula.operators.enqueue(.add)
         formula.operators.enqueue(.add)
 
-
         //when
         let result = formula.result()
 
@@ -37,8 +36,6 @@ class FormulaUnitTest: XCTestCase {
         formula.operators.enqueue(.add)
         formula.operators.enqueue(.add)
 
-//        var formula = Formula(operands: numbers, operators: operators)
-
         //when
         let result = formula.result()
 
@@ -55,10 +52,7 @@ class FormulaUnitTest: XCTestCase {
 
         formula.operators.enqueue(.add)
         formula.operators.enqueue(.add)
-        formula.operators.enqueue(.add)
         formula.operators.enqueue(.subtract)
-
-//        var formula = Formula(operands: numbers, operators: operators)
 
         //when
         let result = formula.result()
@@ -74,10 +68,7 @@ class FormulaUnitTest: XCTestCase {
         formula.operands.enqueue(4)
 
         formula.operators.enqueue(.add)
-        formula.operators.enqueue(.add)
         formula.operators.enqueue(.multiply)
-
-//        var formula = Formula(operands: numbers, operators: operators)
 
         //when
         let result = formula.result()
@@ -94,11 +85,8 @@ class FormulaUnitTest: XCTestCase {
         formula.operands.enqueue(5)
 
         formula.operators.enqueue(.add)
-        formula.operators.enqueue(.add)
         formula.operators.enqueue(.multiply)
         formula.operators.enqueue(.subtract)
-
-//        var formula = Formula(operands: numbers, operators: operators)
 
         //when
         let result = formula.result()
@@ -114,10 +102,7 @@ class FormulaUnitTest: XCTestCase {
         formula.operands.enqueue(0)
 
         formula.operators.enqueue(.add)
-        formula.operators.enqueue(.add)
         formula.operators.enqueue(.divide)
-
-//        var formula = Formula(operands: numbers, operators: operators)
 
         //when
         let result = formula.result()

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -1,19 +1,21 @@
 import XCTest
 
 class FormulaUnitTest: XCTestCase {
-    var sut: Formula!
+    var numbers: CalculatorItemQueue<Double>!
+    var operators: CalculatorItemQueue<Operator>!
+    
     override func setUpWithError() throws {
-        sut = Formula()
+        numbers = CalculatorItemQueue<Double>()
+        operators = CalculatorItemQueue<Operator>()
     }
 
     override func tearDownWithError() throws {
-        sut = nil
+        numbers = nil
+        operators = nil
     }
 
     func test_2더하기_3의_결과는_5가_나온다() {
         //given
-        var numbers = CalculatorItemQueue<Double>()
-        var operators = CalculatorItemQueue<Operator>()
         numbers.enqueue(2)
         numbers.enqueue(3)
 
@@ -27,6 +29,25 @@ class FormulaUnitTest: XCTestCase {
         //then
         XCTAssertEqual(result, 5)
     }
+    
+    func test_2더하기_3더하기_4의_결과는_9가_나온다() {
+        //given
+        numbers.enqueue(2)
+        numbers.enqueue(3)
+        numbers.enqueue(4)
+        
+        operators.enqueue(.add)
+        operators.enqueue(.add)
+        
+        var secondFormula = Formula(operands: numbers, operators: operators)
+        
+        //when
+        let result = secondFormula.result()
+        
+        //then
+        XCTAssertEqual(result, 9)
+    }
+    
 
 }
 

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -1,30 +1,24 @@
 import XCTest
 
 class FormulaUnitTest: XCTestCase {
-    var numbers: CalculatorItemQueue<Double>!
-    var operators: CalculatorItemQueue<Operator>!
-//    var formula: Formula!
+    var formula: Formula!
     
     override func setUpWithError() throws {
-        numbers = CalculatorItemQueue<Double>(calculatorItems: [])
-        operators = CalculatorItemQueue<Operator>(calculatorItems: [])
-//        formula = Formula(operands: numbers, operators: operators)
+        formula = Formula()
     }
 
     override func tearDownWithError() throws {
-        numbers = nil
-        operators = nil
+        formula = nil
     }
 
     func test_2더하기_3의_결과는_5가_나온다() {
         //given
-        numbers.enqueue(2)
-        numbers.enqueue(3)
+        formula.operands.enqueue(2)
+        formula.operands.enqueue(3)
 
-        operators.enqueue(.add)
-        operators.enqueue(.add)
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.add)
 
-        var formula = Formula(operands: numbers, operators: operators)
 
         //when
         let result = formula.result()
@@ -35,15 +29,15 @@ class FormulaUnitTest: XCTestCase {
 
     func test_2더하기_3더하기_4의_결과는_9가_나온다() {
         //given
-        numbers.enqueue(2)
-        numbers.enqueue(3)
-        numbers.enqueue(4)
+        formula.operands.enqueue(2)
+        formula.operands.enqueue(3)
+        formula.operands.enqueue(4)
 
-        operators.enqueue(.add)
-        operators.enqueue(.add)
-        operators.enqueue(.add)
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.add)
 
-        var formula = Formula(operands: numbers, operators: operators)
+//        var formula = Formula(operands: numbers, operators: operators)
 
         //when
         let result = formula.result()
@@ -54,17 +48,17 @@ class FormulaUnitTest: XCTestCase {
 
     func test_2더하기_3더하기_4빼기_3의_결과는_6이_나온다() {
         //given
-        numbers.enqueue(2)
-        numbers.enqueue(3)
-        numbers.enqueue(4)
-        numbers.enqueue(3)
-        
-        operators.enqueue(.add)
-        operators.enqueue(.add)
-        operators.enqueue(.add)
-        operators.enqueue(.subtract)
+        formula.operands.enqueue(2)
+        formula.operands.enqueue(3)
+        formula.operands.enqueue(4)
+        formula.operands.enqueue(3)
 
-        var formula = Formula(operands: numbers, operators: operators)
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.subtract)
+
+//        var formula = Formula(operands: numbers, operators: operators)
 
         //when
         let result = formula.result()
@@ -73,61 +67,61 @@ class FormulaUnitTest: XCTestCase {
         XCTAssertEqual(result, 6)
 
     }
-    
+
     func test_2더하기_3곱하기_4의_결과는_9가_나온다() {
-        numbers.enqueue(2)
-        numbers.enqueue(3)
-        numbers.enqueue(4)
-        
-        operators.enqueue(.add)
-        operators.enqueue(.add)
-        operators.enqueue(.multiply)
-        
-        var formula = Formula(operands: numbers, operators: operators)
-        
+        formula.operands.enqueue(2)
+        formula.operands.enqueue(3)
+        formula.operands.enqueue(4)
+
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.multiply)
+
+//        var formula = Formula(operands: numbers, operators: operators)
+
         //when
         let result = formula.result()
 
         //then
         XCTAssertEqual(result, 20)
     }
-    
+
     func test_2더하기_3곱하기_4빼기_5의_결과는_15가_나온다() {
         //given
-        numbers.enqueue(2)
-        numbers.enqueue(3)
-        numbers.enqueue(4)
-        numbers.enqueue(5)
-        
-        operators.enqueue(.add)
-        operators.enqueue(.add)
-        operators.enqueue(.multiply)
-        operators.enqueue(.subtract)
-        
-        var formula = Formula(operands: numbers, operators: operators)
-        
+        formula.operands.enqueue(2)
+        formula.operands.enqueue(3)
+        formula.operands.enqueue(4)
+        formula.operands.enqueue(5)
+
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.multiply)
+        formula.operators.enqueue(.subtract)
+
+//        var formula = Formula(operands: numbers, operators: operators)
+
         //when
         let result = formula.result()
 
         //then
         XCTAssertEqual(result, 15)
     }
-    
+
     func test_2더하기_3나누기_0은_에러가_난다() {
         //given
-        numbers.enqueue(2)
-        numbers.enqueue(3)
-        numbers.enqueue(0)
-        
-        operators.enqueue(.add)
-        operators.enqueue(.add)
-        operators.enqueue(.divide)
-        
-        var formula = Formula(operands: numbers, operators: operators)
-        
+        formula.operands.enqueue(2)
+        formula.operands.enqueue(3)
+        formula.operands.enqueue(0)
+
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.add)
+        formula.operators.enqueue(.divide)
+
+//        var formula = Formula(operands: numbers, operators: operators)
+
         //when
         let result = formula.result()
-        
+
         //then
         XCTAssertNoThrow(result)
     }

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -20,7 +20,7 @@ class FormulaUnitTest: XCTestCase {
         operators.enqueue(.add)
         operators.enqueue(.add)
         
-        let firstFormula = Formula(operands: numbers, operators: operators)
+        var firstFormula = Formula(operands: numbers, operators: operators)
         
         //when
         let result = firstFormula.result()

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+class FormulaUnitTest: XCTestCase {
+    var sut: Formula!
+    override func setUpWithError() throws {
+        sut = Formula()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+
+    func test_2더하기_3더하기_4의_결과는_9가_나온다() {
+        //given
+        var numbers = CalculatorItemQueue<Double>()
+        var operators = CalculatorItemQueue<Operator>()
+        numbers.enqueue(2)
+        numbers.enqueue(3)
+        numbers.enqueue(4)
+        operators.enqueue(.add)
+        operators.enqueue(.add)
+        
+        let firstFormula = Formula(operands: numbers, operators: operators)
+        
+        //when
+        let result = firstFormula.result()
+        
+        //then
+        XCTAssertEqual(result, 9)
+    }
+
+}
+
+

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -3,10 +3,12 @@ import XCTest
 class FormulaUnitTest: XCTestCase {
     var numbers: CalculatorItemQueue<Double>!
     var operators: CalculatorItemQueue<Operator>!
+//    var formula: Formula!
     
     override func setUpWithError() throws {
         numbers = CalculatorItemQueue<Double>()
         operators = CalculatorItemQueue<Operator>()
+//        formula = Formula(operands: numbers, operators: operators)
     }
 
     override func tearDownWithError() throws {
@@ -22,10 +24,10 @@ class FormulaUnitTest: XCTestCase {
         operators.enqueue(.add)
         operators.enqueue(.add)
 
-        var firstFormula = Formula(operands: numbers, operators: operators)
+        var formula = Formula(operands: numbers, operators: operators)
 
         //when
-        let result = firstFormula.result()
+        let result = formula.result()
 
         //then
         XCTAssertEqual(result, 5)
@@ -41,10 +43,10 @@ class FormulaUnitTest: XCTestCase {
         operators.enqueue(.add)
         operators.enqueue(.add)
 
-        var secondFormula = Formula(operands: numbers, operators: operators)
+        var formula = Formula(operands: numbers, operators: operators)
 
         //when
-        let result = secondFormula.result()
+        let result = formula.result()
 
         //then
         XCTAssertEqual(result, 9)
@@ -62,14 +64,52 @@ class FormulaUnitTest: XCTestCase {
         operators.enqueue(.add)
         operators.enqueue(.subtract)
 
-        var thirdFormula = Formula(operands: numbers, operators: operators)
+        var formula = Formula(operands: numbers, operators: operators)
 
         //when
-        let result = thirdFormula.result()
+        let result = formula.result()
 
         //then
         XCTAssertEqual(result, 6)
 
+    }
+    
+    func test_2더하기_3곱하기_4의_결과는_9가_나온다() {
+        numbers.enqueue(2)
+        numbers.enqueue(3)
+        numbers.enqueue(4)
+        
+        operators.enqueue(.add)
+        operators.enqueue(.add)
+        operators.enqueue(.multiply)
+        
+        var formula = Formula(operands: numbers, operators: operators)
+        
+        //when
+        let result = formula.result()
+
+        //then
+        XCTAssertEqual(result, 20)
+    }
+    
+    func test_2더하기_3곱하기_4빼기_5의_결과는_15가_나온다() {
+        numbers.enqueue(2)
+        numbers.enqueue(3)
+        numbers.enqueue(4)
+        numbers.enqueue(5)
+        
+        operators.enqueue(.add)
+        operators.enqueue(.add)
+        operators.enqueue(.multiply)
+        operators.enqueue(.subtract)
+        
+        var formula = Formula(operands: numbers, operators: operators)
+        
+        //when
+        let result = formula.result()
+
+        //then
+        XCTAssertEqual(result, 15)
     }
 
 }

--- a/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
+++ b/Calculator/CalculatorItemQueueUnitTest/FormulaUnitTest.swift
@@ -20,34 +20,57 @@ class FormulaUnitTest: XCTestCase {
         numbers.enqueue(3)
 
         operators.enqueue(.add)
-        
+        operators.enqueue(.add)
+
         var firstFormula = Formula(operands: numbers, operators: operators)
-        
+
         //when
         let result = firstFormula.result()
-        
+
         //then
         XCTAssertEqual(result, 5)
     }
-    
+
     func test_2더하기_3더하기_4의_결과는_9가_나온다() {
         //given
         numbers.enqueue(2)
         numbers.enqueue(3)
         numbers.enqueue(4)
-        
+
         operators.enqueue(.add)
         operators.enqueue(.add)
-        
+        operators.enqueue(.add)
+
         var secondFormula = Formula(operands: numbers, operators: operators)
-        
+
         //when
         let result = secondFormula.result()
-        
+
         //then
         XCTAssertEqual(result, 9)
     }
-    
+
+    func test_2더하기_3더하기_4빼기_3의_결과는_6이_나온다() {
+        //given
+        numbers.enqueue(2)
+        numbers.enqueue(3)
+        numbers.enqueue(4)
+        numbers.enqueue(3)
+        
+        operators.enqueue(.add)
+        operators.enqueue(.add)
+        operators.enqueue(.add)
+        operators.enqueue(.subtract)
+
+        var thirdFormula = Formula(operands: numbers, operators: operators)
+
+        //when
+        let result = thirdFormula.result()
+
+        //then
+        XCTAssertEqual(result, 6)
+
+    }
 
 }
 


### PR DESCRIPTION
# 계산기 프로젝트 STEP 2 PR

안녕하세요, 콘 @protocorn93 😁
제인입니다!

계산기 프로젝트 STEP 2 PR 보냅니다!!
이번에는 STEP 1보다 구현 내용이 복잡해져서 구현 내용을 글로 정리해보았습니다! 부족하지만 잘 부탁드립니다 😄

## UML
![](https://i.imgur.com/1BX9RWj.png)

## 구현 내용
- **Operator 열거형**
Character 타입을 원시값으로 가지고, CaseIterable과 CalculateItem 프로토콜을 채택한 열거형이다.
연산자들을 case로 가지고 있고, `add(), subtract(), multiply(), divide()` 메서드들과 이 메서드들을 관리하는 메서드인 `calculate()` 메서드를 통해 각 case에 따른 메서드를 실행하여 계산한다.

- **CalculatorItemQueue 구조체**
큐 방식으로 계산기에 필요한 연산자나 피연산자를 관리하는 구조체이다. 요소들을 담고 있는 calculatorItems 프로퍼티와 요소들을 넣거나 빼는 `enqueue(), dequeue(), removeAll()` 메서드들이 존재한다.

- **Formula 구조체**
연산자와 피연산자들의 모임을 한번에 세트로 관리하는 구조체이다. 연산자와 피연산자를 각각 담고있는 큐를 가진 `operands, operators` 프로퍼티와 연산자 피연산자를 가지고 연산을 하는 result() 메서드가 존재한다. 
    - operands: `Double` 타입의 자료를 담고있는 CalculatorItemQueue 구조체
    - operators: `Operator` 타입의 자료를 담고있는 CalculatorItemQueue 구조체
    - result(): 피연산자의 수만큼 반복문을 돌려서 피연산자와 연산자를 하나씩 dequeue하여 계산한다. 이때 Operator 열거형의 calculate() 메서드를 사용하여 Operator의 케이스에 맞는 연산하는 메서드를 불러온다. 
    
- **String 익스텐션**
    - split(with:): String 타입을 확장하여 매개변수로 받는 target을 빈칸으로 바꾼다. (-> 실행부분에서 forEach를 이용해 Operator의 rawValue인 `+*_/` 를 모두 빈칸으로 바꾼다.)

- **ExpressionParser 열거형**
연산자와 피연산자를 순차적으로 입력받는 사용자 입력을 연산자와 피연산자로 각각 나누어서 Formula 구조체의 형태로 반환하는 역할을 하는 메서드들을 담고있는 열거형이다.
    - parse(from:): componentsByOperators(from:)에서 리턴한 문자열 피연산자 배열을 다시 사용자 입력인 input에서 빼서 연산자 배열을 가져온다. 각각의 배열을 Double, Operator 타입으로 변환한 후 Formula 구조체에 넣어서 리턴한다. 
    - componentsByOperators(from: ): 사용자입력인 input에 대해 문자열의 split() 메서드를 사용하여 연산자들을 공백으로 모두 변경하고 남은 피연산자들을 String타입으로 배열에 담아 리턴하는 메서드이다. 


## 고민했던 부분
**1. 파일 나누기**

성격이 비슷한 타입끼리 묶어서 파일을 분리해보았습니다.

- `CalculateItem.swift`
: CalculateItem 프로토콜을 따르는 타입끼리 모아놓기 위해 프로토콜과, Operator 열거형과 Double 익스텐션을 한 파일에 놓았습니다. 
- `CalculatorItemQueue.swift`
- `Formula.swift`
- `ExpressionParser.swift`
: ExpressionParser는 String 익스텐션의 `split()`메서드와 밀접하게 연관되어있다고 생각하여 ExpressionParser 파일에 String 익스텐션도 넣어주었습니다. 

다른 분들의 코드를 참고해보니 프로토콜, 익스텐션, 구조체별로 나누어주신 분도 있고, 타입별로 모두 파일을 분리하신 분도있던데... 그렇게 많이 분리하면 보기가 불편하지 않을까..? 라는 생각도 들어서,, 어떤 기준으로 파일을 나누는 것이 좋은 방법인지 궁금합니다!

**2. Formula 구조체의 `result()` 메서드 구현 방법**

`operands.countItems > 0` 을 조건으로 반복하게 하여
지역변수 result 를 두고 초깃값 = 0으로 설정하였고, 큐에서 숫자를 하나씩 꺼내서 처음엔 result = 0 에 더해주고 나서 결과값은 lhs에, 새로 연산할 값은 또 큐에서 꺼내서 rhs에 넣어서 연산하는 방식으로 구현하였습니다. 

이 방법을 사용하려면, 연산자 큐에 맨 처음에 자동으로 + 가 할당되어야 하기 때문에 Formula 이니셜라이저 기본값으로 operands 프로퍼티를 [.add]로 설정했습니다.


**3. 빼기 연산자와 음수표시에 대한 표현**

"-" 와 "_" 기호의 분리를 통해 해결하였습니다. 

```swift
enum Operator: Character, CaseIterable, CalculateItem {
    case add = "+"
    case subtract = "_"
    case divide = "/"
    case multiply = "*"
```
빼기 연산자를 언더바(_)로 설정해준 이유는 아래 `split()` 메서드에서 연산자를 빈칸으로 먼저 바꿔주는데, 연산자를 빈칸으로 바꾸고 난 후 숫자와 함께 남는 값이 -3과 같은 형식으로 되어야지 Double로 타입을 바꿀 때 정상적으로 바뀔 것이라고 생각했기 때문입니다.  

```string
extension String {
    func split(with target: Character) -> [String] {
        let splitedArray = self.replacingOccurrences(of: target.description, with: " ")
        return [splitedArray]
    }
}
```

**4. ExpressionParserUnitTest 의 결과값 확인방법**

`parse()`의 리턴값 Formula가 잘 나왔는지 테스트하기위해 Formula 인스턴스 값을 비교하려했습니다. 처음엔 === 으로 비교하려했는데, 클래스 인스턴스만 비교가 가능했습니다. 두번째로는 `countOperands()` 메서드 구현하여 값의 갯수만 맞는지 확인하려했습니다. 
```swift
    func countOperands() -> Int {
        return operands.calculatorItems.count
    }
```

그러나 테스트 코드를 위해서 타입에서 필요하지도 않은 값 갯수를 반환하는 메서드를 만들어야 하는 것이 좋은 방법이 아니라는 생각에, forEach를 사용하여 배열의 각 요소가 operands 를 하나씩 dequeue한 값과 같은지 비교해보는 방법으로 해결했습니다. 

```swift
[1,2,3,4,5].forEach { element in
            XCTAssertEqual(element, result.operands.dequeue())
```



## 질문사항
**1. 메서드와 연산 프로퍼티**

FormulaUnitTest를 테스트할 때 메서드와 연산 프로퍼티가 다르게 동작하는 것 같은데 정확히 어떤 차이가 있는지 궁금하여 질문드립니다.

테스트 상황을 말씀드리겠습니다. 처음에는 아래 코드와 같이 numbers, operators를 먼저 만들어주고, 거기다가 값을 enqueue해주고 나서 두 변수를 사용해 Formula 인스턴스를 초기화해주었습니다. 

```swift
class FormulaUnitTest: XCTestCase {
    var numbers: CalculatorItemQueue<Double>!
    var operators: CalculatorItemQueue<Operator>!
//    var formula: Formula!
    
    override func setUpWithError() throws {
        numbers = CalculatorItemQueue<Double>(calculatorItems: [])
        operators = CalculatorItemQueue<Operator>(calculatorItems: [])
//        formula = Formula(operands: numbers, operators: operators)
    }

    override func tearDownWithError() throws {
        numbers = nil
        operators = nil
    }

    func test_2더하기_3의_결과는_5가_나온다() {
        //given
        numbers.enqueue(2)
        numbers.enqueue(3)

        operators.enqueue(.add)
        operators.enqueue(.add)

        var formula = Formula(operands: numbers, operators: operators)

        //when
        let result = formula.result()

        //then
        XCTAssertEqual(result, 5)
    }
}
```

이렇게 하면 코드가 정상적으로 실행은 되지만, 테스트 시마다 인스턴스를 새로 만드는 것이 좋은 방법이 아니라고 생각하여 아래 코드와 같이 FormulaUnitTest의 프로퍼티로 Formula 타입을 담고, 테스트케이스가 실행될때마다 자동으로 만들어지도록 하고싶었습니다.

```swift
class FormulaUnitTest: XCTestCase {
    var formula: Formula!
    
    override func setUpWithError() throws {
        formula = Formula()
    }

    override func tearDownWithError() throws {
        formula = nil
    }

    func test_2더하기_3의_결과는_5가_나온다() {
        //given
        formula.operands.enqueue(2)
        formula.operands.enqueue(3)

        formula.operators.enqueue(.add)
        formula.operators.enqueue(.add)


        //when
        let result = formula.result()

        //then
        XCTAssertEqual(result, 5)
    }
```

하지만, 그렇게 코드를 바꾸자 `Fatal error: Range requires lowerBound <= upperBound` 에러가 떴습니다. 

Formula 구조체의 `result()` 메서드가 문제였는데, 제 생각에는 아래 코드를 보시면 3번째 줄에 for문의 범위로 배열의 요소를 세서 리턴하는 `countItems()` 메서드의 리턴값으로 0이 들어갔기 때문에 `0...-1`이 되어서 에러가 난 것 같습니다.

FormulaUnitTest에서 분명히 Formula 구조체의 인스턴스를 처음에 초기화해주고 그 뒤에 operands 와 operators에 enqueue()로 값을 넣어주고 나서 배열에 값이 있는 상태에서 `formula.result()` 를 실행하여 `result()` 함수 내에서 `operands.countItems()`가 실행이 됐을텐데 왜 0이 리턴되는지 에 대한 의문이 들었습니다. 

```swift
mutating func result() -> Double {
        var result: Double = 0
        for _ in 0...operands.countItems()-1 {
            let lhs = result
            guard let rhs = operands.dequeue() else { return 0 }
            
            let `operator` = operators.dequeue()
            do {
                let calculateResult = try `operator`?.calculate(lhs: lhs, rhs: rhs)
                result = calculateResult ?? 0
            } catch {
                print("0으로 나눌 수 없음")
            }
        }
```

```swift
    struct CalculatorItemQueue<T: CalculateItem> {
    var calculatorItems: [T]
    
    func countItems() -> Int {
        return calculatorItems.count
    }
}
```
.

캠퍼들과 이야기해보다가 `countItems()`를 연산 프로퍼티로 바꿔줬더니 문제가 해결되었습니다. 



```swift
    mutating func result() -> Double {
        var result: Double = 0
        for _ in 0...operands.countItems-1 {
            let lhs = result
            guard let rhs = operands.dequeue() else { return 0 }
            
            let `operator` = operators.dequeue()
            do {
                let calculateResult =  try `operator`?.calculate(lhs: lhs, rhs: rhs)
                result = calculateResult ?? 0
            } catch {
                print("0으로 나눌 수 없음")
            }
        }
        
        return result
    }
```

```swift
    struct CalculatorItemQueue<T: CalculateItem> {
    var calculatorItems: [T]
    
    var countItems: Int {
        return calculatorItems.count
    }
}
```

제가 생각했을때 메서드 대신 연산 프로퍼티를 사용하는 상황은 값을 세팅해주고 값을 가져오는 기능을 한번에 묶고싶을 때나, 접근자만 구현해 읽기전용 상태를 쉽게 구현할 때인것 같습니다. 

countItems는 calculatorItems의 요소의 개수만 단순히 읽어오는 기능을 하기 때문에 메서드보다는 연산 프로퍼티로 구현하는 것이 맞을 것 같긴한데, 위 테스트 상황에서 연산 프로퍼티로는 동작이되지만 메서드로는 동작이 되지 않는 이유에 대해서는 잘 모르겠습니다... 
혹시 이 부분에 대해 더 검색해볼 수 있는 키워드가 있는지 궁금합니다..! 

**2. parse() 메서드 안의 기능을 함수로 따로 분리**

제 코드에서 parse 메서드가 하는 일이 두가지가 있습니다. 
- 숫자만있는 배열을 이용해서 연산자만 거르는 일
- 숫자배열, 연산자배열을 각각 Formula에 담아서 리턴하는 일

→ 첫번째 기능을 따로 빼서 메서드로 만들어도되는지 궁금합니다.
아래 코드에서 볼 수 있듯이, `componentsByOperators(from:)` 메서드에서는 빈칸으로 나누어진 숫자배열을 빈칸을 기준으로 나눠서 반환하는 기능을 가지고 있어서 이 메서드처럼 연산자배열을 반환하는 메서드를 따로 만들어주면 어떨지 여쭤보고 싶습니다! 

```swift
enum ExpressionParser {
    static func parse(from inputString: String) -> Formula {
        let numberArrayInString = componentsByOperators(from: inputString)
        let inputArrayInString = inputString.map { String($0) }
        
        let operatorArrayInString = inputArrayInString.filter {!numberArrayInString.contains($0)}
        
        let numberArrayInDouble = numberArrayInString.map {Double($0) ?? 0}
        let operatorArrayInOperator = operatorArrayInString.compactMap {Operator(rawValue: Character($0))}
        
        let operands = CalculatorItemQueue<Double>(calculatorItems: numberArrayInDouble)
        let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArrayInOperator)
        
        let formula = Formula(operands: operands, operators: operators)

        return formula
    }

    static func componentsByOperators(from input: String) -> [String] {
        var numberString = input
        
        Operator.allCases.forEach {
            guard let numberArrayWithBlank = numberString.split(with: $0.rawValue).first else {return}
            numberString = numberArrayWithBlank
        }
        
        let numberArray = numberString.components(separatedBy: " ")
        
        return numberArray
    }
}
```