### PR TITLE
ios-calculator-app [STEP 3] nicholas

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		8992CFB4273A2E78006BCE5E /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8D7B1273A174300F4150A /* LinkedList.swift */; };
 		89E8D7B2273A174300F4150A /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8D7B1273A174300F4150A /* LinkedList.swift */; };
 		89E8D7B4273A179300F4150A /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8D7B3273A179300F4150A /* LinkedListTests.swift */; };
+		89FC284A2744482900ADC4C1 /* CalculatorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FC28492744482900ADC4C1 /* CalculatorController.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
@@ -54,6 +55,7 @@
 		890976FA273E68AD00E4BDE5 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		89E8D7B1273A174300F4150A /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		89E8D7B3273A179300F4150A /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
+		89FC28492744482900ADC4C1 /* CalculatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorController.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */,
+				89FC28492744482900ADC4C1 /* CalculatorController.swift */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
 			);
@@ -294,6 +297,7 @@
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				890976F2273E3A1200E4BDE5 /* StringExtension.swift in Sources */,
 				890976ED273E377500E4BDE5 /* Operator.swift in Sources */,
+				89FC284A2744482900ADC4C1 /* CalculatorController.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				890976F4273E3BC300E4BDE5 /* Formula.swift in Sources */,
 				890976F9273E685A00E4BDE5 /* ExpressionParser.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		8992CFB4273A2E78006BCE5E /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8D7B1273A174300F4150A /* LinkedList.swift */; };
 		89E8D7B2273A174300F4150A /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8D7B1273A174300F4150A /* LinkedList.swift */; };
 		89E8D7B4273A179300F4150A /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8D7B3273A179300F4150A /* LinkedListTests.swift */; };
+		89F09C01274776AE00986EFF /* calculatorHistoryUILbel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F09C00274776AE00986EFF /* calculatorHistoryUILbel.swift */; };
 		89FC284A2744482900ADC4C1 /* CalculatorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FC28492744482900ADC4C1 /* CalculatorController.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
@@ -55,6 +56,7 @@
 		890976FA273E68AD00E4BDE5 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		89E8D7B1273A174300F4150A /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		89E8D7B3273A179300F4150A /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
+		89F09C00274776AE00986EFF /* calculatorHistoryUILbel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = calculatorHistoryUILbel.swift; sourceTree = "<group>"; };
 		89FC28492744482900ADC4C1 /* CalculatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorController.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -98,6 +100,7 @@
 			isa = PBXGroup;
 			children = (
 				C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */,
+				89F09C00274776AE00986EFF /* calculatorHistoryUILbel.swift */,
 				89FC28492744482900ADC4C1 /* CalculatorController.swift */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
@@ -295,6 +298,7 @@
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				8904A643273977BF004BCF06 /* CalculatorItemQueue.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				89F09C01274776AE00986EFF /* calculatorHistoryUILbel.swift in Sources */,
 				890976F2273E3A1200E4BDE5 /* StringExtension.swift in Sources */,
 				890976ED273E377500E4BDE5 /* Operator.swift in Sources */,
 				89FC284A2744482900ADC4C1 /* CalculatorController.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		89E8D7B4273A179300F4150A /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E8D7B3273A179300F4150A /* LinkedListTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
-		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
+		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
@@ -57,7 +57,7 @@
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C713D9452570E5EB001C3AFC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorViewController.swift; sourceTree = "<group>"; };
 		C713D9482570E5EB001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -95,9 +95,9 @@
 		8904A63B2739749F004BCF06 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
+				C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
-				C713D9452570E5EB001C3AFC /* ViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -289,7 +289,7 @@
 			files = (
 				890976F0273E383D00E4BDE5 /* DoubleExtension.swift in Sources */,
 				89E8D7B2273A174300F4150A /* LinkedList.swift in Sources */,
-				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				8904A643273977BF004BCF06 /* CalculatorItemQueue.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				890976F2273E3A1200E4BDE5 /* StringExtension.swift in Sources */,

--- a/Calculator/Calculator/Controller/AppDelegate.swift
+++ b/Calculator/Calculator/Controller/AppDelegate.swift
@@ -9,8 +9,6 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true

--- a/Calculator/Calculator/Controller/CalculatorController.swift
+++ b/Calculator/Calculator/Controller/CalculatorController.swift
@@ -13,7 +13,6 @@ class CalculatorController {
     func insertFormula(`operator`: String, operand: String) {
         formula = formula + `operator` + String(ExpressionParser.separator)
                             + operand + String(ExpressionParser.separator)
-        print(formula)
     }
     
     func resetFormula() {

--- a/Calculator/Calculator/Controller/CalculatorController.swift
+++ b/Calculator/Calculator/Controller/CalculatorController.swift
@@ -8,15 +8,15 @@
 import Foundation
 
 class CalculatorController {
-    private var formula = ""
+    private var storedOperandAndOperator = ""
     
     func insertFormula(`operator`: String, operand: String) {
-        formula = formula + `operator` + String(ExpressionParser.separator)
+        storedOperandAndOperator = storedOperandAndOperator + `operator` + String(ExpressionParser.separator)
                             + operand + String(ExpressionParser.separator)
     }
     
     func resetFormula() {
-        formula = ""
+        storedOperandAndOperator = ""
     }
     
     func calculate() -> String {
@@ -28,7 +28,7 @@ class CalculatorController {
         var calculatedResult = 0.0
         
         do {
-            calculatedResult = try ExpressionParser.parse(from: formula).result()
+            calculatedResult = try ExpressionParser.parse(from: storedOperandAndOperator).result()
         } catch {
             return Formula.FormulaError.NaN.description
         }

--- a/Calculator/Calculator/Controller/CalculatorController.swift
+++ b/Calculator/Calculator/Controller/CalculatorController.swift
@@ -8,5 +8,37 @@
 import Foundation
 
 class CalculatorController {
-    let formula = ExpressionParser.parse(from: "   ")
+    private var formula = ""
+    
+    func insertFormula(`operator`: String, operand: String) {
+        formula = formula + `operator` + String(ExpressionParser.separator)
+                            + operand + String(ExpressionParser.separator)
+        print(formula)
+    }
+    
+    func resetFormula() {
+        formula = ""
+    }
+    
+    func calculate() -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = 20
+        numberFormatter.roundingMode = .halfUp
+        
+        var calculatedResult = 0.0
+        
+        do {
+            calculatedResult = try ExpressionParser.parse(from: formula).result()
+        } catch {
+            return Formula.FormulaError.NaN.description
+        }
+        print(calculatedResult.description)
+        print(calculatedResult)
+        
+        guard let result = numberFormatter.string(from: NSNumber(value: calculatedResult)) else {
+            return ""
+        }
+        return result
+    }
 }

--- a/Calculator/Calculator/Controller/CalculatorController.swift
+++ b/Calculator/Calculator/Controller/CalculatorController.swift
@@ -8,15 +8,15 @@
 import Foundation
 
 class CalculatorController {
-    private var storedOperandAndOperator = ""
+    private var numericalExpression = ""
     
     func insertFormula(`operator`: String, operand: String) {
-        storedOperandAndOperator = storedOperandAndOperator + `operator` + String(ExpressionParser.separator)
+        numericalExpression = numericalExpression + `operator` + String(ExpressionParser.separator)
                             + operand + String(ExpressionParser.separator)
     }
     
     func resetFormula() {
-        storedOperandAndOperator = ""
+        numericalExpression = ""
     }
     
     func calculate() -> String {
@@ -28,7 +28,7 @@ class CalculatorController {
         var calculatedResult = 0.0
         
         do {
-            calculatedResult = try ExpressionParser.parse(from: storedOperandAndOperator).result()
+            calculatedResult = try ExpressionParser.parse(from: numericalExpression).result()
         } catch {
             return Formula.FormulaError.NaN.description
         }

--- a/Calculator/Calculator/Controller/CalculatorController.swift
+++ b/Calculator/Calculator/Controller/CalculatorController.swift
@@ -33,9 +33,7 @@ class CalculatorController {
         } catch {
             return Formula.FormulaError.NaN.description
         }
-        print(calculatedResult.description)
-        print(calculatedResult)
-        
+
         guard let result = numberFormatter.string(from: NSNumber(value: calculatedResult)) else {
             return ""
         }

--- a/Calculator/Calculator/Controller/CalculatorController.swift
+++ b/Calculator/Calculator/Controller/CalculatorController.swift
@@ -1,0 +1,12 @@
+//
+//  CalculatorController.swift
+//  Calculator
+//
+//  Created by Eunsoo KIM on 2021/11/17.
+//
+
+import Foundation
+
+class CalculatorController {
+    let formula = ExpressionParser.parse(from: "   ")
+}

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -20,6 +20,8 @@ class CalculatorViewController: UIViewController {
     func reset() {
         operandLabel.text = "0"
         operatorLabel.text = ""
+        allClear()
+    }
     }
     
     @IBAction func touchUpNumberPadButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class CalculatorViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -49,6 +49,19 @@ class CalculatorViewController: UIViewController {
         operatorLabel.text = sender.titleLabel?.text
         operandLabel.text = "0"
     }
+    @IBAction func touchUpTogglePlusMinusButton(_ sender: UIButton) {
+        if var operand = operandLabel.text {
+            if operand == "0" {
+                return
+            }
+            if operand.contains("-") {
+                operand.remove(at: operand.startIndex)
+            } else {
+                operand.insert("-", at: operand.startIndex)
+            }
+            operandLabel.text = operand
+        }
+    }
     
     @IBAction func touchUpAllClear(_ sender: UIButton) {
         reset()

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -13,13 +13,22 @@ class CalculatorViewController: UIViewController {
     @IBOutlet weak var calculationHistoryStackView: UIStackView!
     @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
     
+    var inputedOperand = "0"
+    var invalidCheckInputedOperand: Bool {
+        if inputedOperand.count <= 15 {
+            return true
+        } else {
+            return false
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         reset()
     }
     
     @IBAction func touchUpNumberPadButton(_ sender: UIButton) {
-        guard let operandLabelText = operandLabel.text else {
+        guard invalidCheckInputedOperand else {
             return
         }
         
@@ -27,32 +36,35 @@ class CalculatorViewController: UIViewController {
             return
         }
         
-        if operandLabelText == "0" {
+        if inputedOperand == "0" {
             if tapedNumber == "0" || tapedNumber == "00" {
                 return
             } else {
-                operandLabel.text = tapedNumber
+                inputedOperand = tapedNumber
+                operandLabel.text = inputedOperand
                 return
             }
         }
         
-        operandLabel.text = operandLabelText + tapedNumber
+        inputedOperand = inputedOperand + tapedNumber
+        operandLabel.text = changeNumberFormatter(target: inputedOperand)
+        
+        if tapedNumber == "0" {
+            operandLabel.text = inputedOperand
+        }
     }
     
     @IBAction func touchUpDecimalPointButton(_ sender: UIButton) {
-        guard let operand = operandLabel.text else {
+        guard !inputedOperand.contains(".") else {
             return
         }
         
-        guard !operand.contains(".") else {
-            return
-        }
-        
-        operandLabel.text = operand + "."
+        inputedOperand = inputedOperand + "."
+        operandLabel.text = inputedOperand
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
-        
+        inputedOperand = "0"
         if operandLabel.text == "0" {
             operatorLabel.text = sender.titleLabel?.text
             return
@@ -87,7 +99,8 @@ class CalculatorViewController: UIViewController {
     }
     
     func reset() {
-        operandLabel.text = "0"
+        inputedOperand = "0"
+        operandLabel.text = inputedOperand
         operatorLabel.text = ""
         allClear()
     }
@@ -126,7 +139,8 @@ class CalculatorViewController: UIViewController {
     }
     
     func clearEntry() {
-        operandLabel.text = "0"
+        inputedOperand = "0"
+        operandLabel.text = inputedOperand
     }
     
     func autoScrollDown() {
@@ -139,6 +153,18 @@ class CalculatorViewController: UIViewController {
                                             height: self.calculationHistoryScrollView.bounds.size.height),
                                      animated: true)
         }
+    }
+    
+    func changeNumberFormatter(target: String) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = 15
+
+        guard let number = Double(target),
+              let result = numberFormatter.string(for: number) else {
+            return ""
+        }
+        return result
     }
     
 }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -44,5 +44,30 @@ class CalculatorViewController: UIViewController {
         operatorLabel.text = ""
         allClear()
     }
+    
+    func addFormula() {
+        let stackView = UIStackView()
+        
+        if let `operator` = operatorLabel.text {
+            let insultingoperatingLable = UILabel()
+            insultingoperatingLable.textColor = UIColor.white
+            insultingoperatingLable.text = `operator`
+            
+            stackView.addArrangedSubview(insultingoperatingLable)
+        }
+        
+        guard let operand = operandLabel.text else {
+            return
+        }
+        
+        let insultinOperandLabel = UILabel()
+        insultinOperandLabel.textColor = UIColor.white
+        insultinOperandLabel.text = operand
+        
+        
+        stackView.addArrangedSubview(insultinOperandLabel)
+        
+        calculationHistoryStackView.addArrangedSubview(stackView)
+    }
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -38,13 +38,13 @@ class CalculatorViewController: UIViewController {
         }
         
         if inputedOperand == "0" {
-            if number == "0" || number == "00" {
-                return
-            } else {
-                inputedOperand = number
-                operandLabel.text = inputedOperand
+            guard number != "0" || number != "00" else {
                 return
             }
+            
+            inputedOperand = number
+            operandLabel.text = inputedOperand
+            return
         }
         
         inputedOperand = inputedOperand + number

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -106,27 +106,21 @@ class CalculatorViewController: UIViewController {
     func addFormula() {
         let stackView = UIStackView()
         
-        guard let `operator` = operatorLabel.text else {
+        guard let `operator` = operatorLabel.text,
+                let operand = operandLabel.text  else {
             return
         }
         
-        let insertingOperatingLabel = UILabel()
-        insertingOperatingLabel.textColor = UIColor.white
-        insertingOperatingLabel.text = `operator`
-        insertingOperatingLabel.font = UIFont.preferredFont(forTextStyle: .title3)
+        labelFormat(textValue: `operator`)
+        labelFormat(textValue: operand)
         
-        stackView.addArrangedSubview(insertingOperatingLabel)
-        
-        guard let operand = operandLabel.text else {
-            return
+        func labelFormat(textValue: String) {
+            let label = UILabel()
+            label.textColor = UIColor.white
+            label.text = textValue
+            label.font = UIFont.preferredFont(forTextStyle: .title3)
+            stackView.addArrangedSubview(label)
         }
-        
-        let insertingOperandLabel = UILabel()
-        insertingOperandLabel.textColor = UIColor.white
-        insertingOperandLabel.text = operand
-        insertingOperandLabel.font = UIFont.preferredFont(forTextStyle: .title3)
-        
-        stackView.addArrangedSubview(insertingOperandLabel)
         
         calculationHistoryStackView.addArrangedSubview(stackView)
         

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -36,6 +36,9 @@ class CalculatorViewController: UIViewController {
         if operandLabelText == "0" {
             if tapedNumber == "0" || tapedNumber == "00" {
                 return
+            } else {
+                operandLabel.text = tapedNumber
+                return
             }
         }
         

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -25,7 +25,7 @@ class CalculatorViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        reset()
+        resetCalcurator()
     }
     
     @IBAction func touchUpNumberPadButton(_ sender: UIButton) {
@@ -82,7 +82,7 @@ class CalculatorViewController: UIViewController {
     }
     
     @IBAction func touchUpAllClearButton(_ sender: UIButton) {
-        reset()
+        resetCalcurator()
     }
     
     @IBAction func touchUpClearEntryButton(_ sender: UIButton) {
@@ -98,7 +98,7 @@ class CalculatorViewController: UIViewController {
         operandLabel.text = calculatorController.calculate()
     }
     
-    func reset() {
+    func resetCalcurator() {
         notFormattedOperand = "0"
         operandLabel.text = notFormattedOperand
         operatorLabel.text = ""

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -8,11 +8,14 @@ import UIKit
 
 class CalculatorViewController: UIViewController {
 
+    @IBOutlet weak var operandLabel: UILabel!
+    @IBOutlet weak var operatorLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
     
-
+    @IBAction func touchUpNumberPadButton(_ sender: UIButton) {
+    }
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -38,6 +38,9 @@ class CalculatorViewController: UIViewController {
         
         operandLabel.text = operandLabelText + tapedNumber
     }
+    @IBAction func touchUpAllClear(_ sender: UIButton) {
+        reset()
+    }
     
     func reset() {
         operandLabel.text = "0"
@@ -69,5 +72,17 @@ class CalculatorViewController: UIViewController {
         
         calculationHistoryStackView.addArrangedSubview(stackView)
     }
+    
+    func allClear() {
+        for subview in calculationHistoryStackView.subviews {
+            subview.removeFromSuperview()
+        }
+    }
+    
+    func clearEntry() {
+        operandLabel.text = "0"
+    }
+    
+    
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -13,9 +13,9 @@ class CalculatorViewController: UIViewController {
     @IBOutlet weak var calculationHistoryStackView: UIStackView!
     @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
     
-    private var notFormattedOperand = "0"
+    private var rawOperand = "0"
     private var invalidCheckInputedOperand: Bool {
-        if notFormattedOperand.components(separatedBy: [",", "-"]).joined().count <= 14 {
+        if rawOperand.components(separatedBy: [",", "-"]).joined().count <= 14 {
             return true
         } else {
             return false
@@ -37,21 +37,21 @@ class CalculatorViewController: UIViewController {
             return
         }
         
-        notFormattedOperand = notFormattedOperand + number
+        rawOperand = rawOperand + number
         operandLabel.text = changeNumberFormatter(insertedNumber: number)
     }
     
     @IBAction func touchUpDecimalPointButton(_ sender: UIButton) {
-        guard !notFormattedOperand.contains(".") else {
+        guard !rawOperand.contains(".") else {
             return
         }
         
-        notFormattedOperand = notFormattedOperand + "."
-        operandLabel.text = notFormattedOperand
+        rawOperand = rawOperand + "."
+        operandLabel.text = rawOperand
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
-        notFormattedOperand = "0"
+        rawOperand = "0"
         
         guard operandLabel.text != "0" else {
             operatorLabel.text = sender.titleLabel?.text
@@ -68,17 +68,17 @@ class CalculatorViewController: UIViewController {
     }
     
     @IBAction func touchUpTogglePlusMinusButton(_ sender: UIButton) {
-        guard notFormattedOperand != "0" else {
+        guard rawOperand != "0" else {
             return
         }
         
-        if notFormattedOperand.contains("-") {
-            notFormattedOperand.remove(at: notFormattedOperand.startIndex)
+        if rawOperand.contains("-") {
+            rawOperand.remove(at: rawOperand.startIndex)
         } else {
-            notFormattedOperand.insert("-", at: notFormattedOperand.startIndex)
+            rawOperand.insert("-", at: rawOperand.startIndex)
         }
         
-        operandLabel.text = notFormattedOperand
+        operandLabel.text = rawOperand
     }
     
     @IBAction func touchUpAllClearButton(_ sender: UIButton) {
@@ -99,8 +99,8 @@ class CalculatorViewController: UIViewController {
     }
     
     func resetCalcurator() {
-        notFormattedOperand = "0"
-        operandLabel.text = notFormattedOperand
+        rawOperand = "0"
+        operandLabel.text = rawOperand
         operatorLabel.text = ""
         allClear()
     }
@@ -140,8 +140,8 @@ class CalculatorViewController: UIViewController {
     }
     
     func clearEntry() {
-        notFormattedOperand = "0"
-        operandLabel.text = notFormattedOperand
+        rawOperand = "0"
+        operandLabel.text = rawOperand
     }
     
     func autoScrollDown() {
@@ -161,14 +161,14 @@ class CalculatorViewController: UIViewController {
         numberFormatter.numberStyle = .decimal
         numberFormatter.maximumSignificantDigits = 15
 
-        guard let number = Double(notFormattedOperand),
+        guard let number = Double(rawOperand),
               let result = numberFormatter.string(from: NSNumber(value: number)) else {
             return ""
         }
         
-        if notFormattedOperand.contains(".") {
+        if rawOperand.contains(".") {
             if insertedNumber == "0" || insertedNumber == "00" {
-                return notFormattedOperand
+                return rawOperand
             }
         }
         return result

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -96,23 +96,24 @@ class CalculatorViewController: UIViewController {
         let stackView = UIStackView()
         
         if let `operator` = operatorLabel.text {
-            let insultingoperatingLable = UILabel()
-            insultingoperatingLable.textColor = UIColor.white
-            insultingoperatingLable.text = `operator`
+            let insertingOperatingLabel = UILabel()
+            insertingOperatingLabel.textColor = UIColor.white
+            insertingOperatingLabel.text = `operator`
+            insertingOperatingLabel.font = UIFont.preferredFont(forTextStyle: .title3)
             
-            stackView.addArrangedSubview(insultingoperatingLable)
+            stackView.addArrangedSubview(insertingOperatingLabel)
         }
         
         guard let operand = operandLabel.text else {
             return
         }
         
-        let insultinOperandLabel = UILabel()
-        insultinOperandLabel.textColor = UIColor.white
-        insultinOperandLabel.text = operand
+        let insertingOperandLabel = UILabel()
+        insertingOperandLabel.textColor = UIColor.white
+        insertingOperandLabel.text = operand
+        insertingOperandLabel.font = UIFont.preferredFont(forTextStyle: .title3)
         
-        
-        stackView.addArrangedSubview(insultinOperandLabel)
+        stackView.addArrangedSubview(insertingOperandLabel)
         
         calculationHistoryStackView.addArrangedSubview(stackView)
         autoScrollDown()

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -39,6 +39,18 @@ class CalculatorViewController: UIViewController {
         operandLabel.text = operandLabelText + tapedNumber
     }
     
+    @IBAction func touchUpDecimalPointButton(_ sender: UIButton) {
+        guard let operand = operandLabel.text else {
+            return
+        }
+        
+        guard !operand.contains(".") else {
+            return
+        }
+        
+        operandLabel.text = operand + "."
+    }
+    
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         
         if operandLabel.text == "0" {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -14,7 +14,7 @@ class CalculatorViewController: UIViewController {
     @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
     
     private var rawOperand = "0"
-    private var invalidCheckInputedOperand: Bool {
+    private var checkNumberOfInputs: Bool {
         if rawOperand.components(separatedBy: [",", "-"]).joined().count <= 14 {
             return true
         } else {
@@ -29,7 +29,7 @@ class CalculatorViewController: UIViewController {
     }
     
     @IBAction func touchUpNumberPadButton(_ sender: UIButton) {
-        guard invalidCheckInputedOperand else {
+        guard checkNumberOfInputs else {
             return
         }
         

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -36,7 +36,6 @@ class CalculatorViewController: UIViewController {
         }
         
         operandLabel.text = operandLabelText + tapedNumber
-        
     }
     
     func reset() {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -13,9 +13,9 @@ class CalculatorViewController: UIViewController {
     @IBOutlet weak var calculationHistoryStackView: UIStackView!
     @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
     
-    private var inputedOperand = "0"
+    private var notFormattedOperand = "0"
     private var invalidCheckInputedOperand: Bool {
-        if inputedOperand.components(separatedBy: [",", "-"]).joined().count <= 14 {
+        if notFormattedOperand.components(separatedBy: [",", "-"]).joined().count <= 14 {
             return true
         } else {
             return false
@@ -37,31 +37,31 @@ class CalculatorViewController: UIViewController {
             return
         }
         
-        if inputedOperand == "0" {
+        if notFormattedOperand == "0" {
             guard number != "0" || number != "00" else {
                 return
             }
             
-            inputedOperand = number
-            operandLabel.text = inputedOperand
+            notFormattedOperand = number
+            operandLabel.text = notFormattedOperand
             return
         }
         
-        inputedOperand = inputedOperand + number
+        notFormattedOperand = notFormattedOperand + number
         operandLabel.text = changeNumberFormatter(insertedNumber: number)
     }
     
     @IBAction func touchUpDecimalPointButton(_ sender: UIButton) {
-        guard !inputedOperand.contains(".") else {
+        guard !notFormattedOperand.contains(".") else {
             return
         }
         
-        inputedOperand = inputedOperand + "."
-        operandLabel.text = inputedOperand
+        notFormattedOperand = notFormattedOperand + "."
+        operandLabel.text = notFormattedOperand
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
-        inputedOperand = "0"
+        notFormattedOperand = "0"
         
         if operandLabel.text == "0" {
             operatorLabel.text = sender.titleLabel?.text
@@ -78,15 +78,15 @@ class CalculatorViewController: UIViewController {
     }
     
     @IBAction func touchUpTogglePlusMinusButton(_ sender: UIButton) {
-        if inputedOperand == "0" {
+        if notFormattedOperand == "0" {
             return
         }
-        if inputedOperand.contains("-") {
-            inputedOperand.remove(at: inputedOperand.startIndex)
+        if notFormattedOperand.contains("-") {
+            notFormattedOperand.remove(at: notFormattedOperand.startIndex)
         } else {
-            inputedOperand.insert("-", at: inputedOperand.startIndex)
+            notFormattedOperand.insert("-", at: notFormattedOperand.startIndex)
         }
-        operandLabel.text = inputedOperand
+        operandLabel.text = notFormattedOperand
     }
     
     @IBAction func touchUpAllClearButton(_ sender: UIButton) {
@@ -107,8 +107,8 @@ class CalculatorViewController: UIViewController {
     }
     
     func reset() {
-        inputedOperand = "0"
-        operandLabel.text = inputedOperand
+        notFormattedOperand = "0"
+        operandLabel.text = notFormattedOperand
         operatorLabel.text = ""
         allClear()
     }
@@ -153,8 +153,8 @@ class CalculatorViewController: UIViewController {
     }
     
     func clearEntry() {
-        inputedOperand = "0"
-        operandLabel.text = inputedOperand
+        notFormattedOperand = "0"
+        operandLabel.text = notFormattedOperand
     }
     
     func autoScrollDown() {
@@ -174,14 +174,14 @@ class CalculatorViewController: UIViewController {
         numberFormatter.numberStyle = .decimal
         numberFormatter.maximumSignificantDigits = 15
 
-        guard let number = Double(inputedOperand),
+        guard let number = Double(notFormattedOperand),
               let result = numberFormatter.string(from: NSNumber(value: number)) else {
             return ""
         }
         
-        if inputedOperand.contains(".") {
+        if notFormattedOperand.contains(".") {
             if insertedNumber == "0" || insertedNumber == "00" {
-                return inputedOperand
+                return notFormattedOperand
             }
         }
         return result

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -7,7 +7,8 @@
 import UIKit
 
 class CalculatorViewController: UIViewController {
-
+    //MARK: - Properties
+    
     @IBOutlet weak var operandLabel: UILabel!
     @IBOutlet weak var operatorLabel: UILabel!
     @IBOutlet weak var calculationHistoryStackView: UIStackView!
@@ -23,11 +24,16 @@ class CalculatorViewController: UIViewController {
     }
     private let calculatorController = CalculatorController()
     
+    // MARK: - Life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         resetCalcurator()
     }
-    
+}
+
+// MARK: - Actions
+
+extension CalculatorViewController {
     @IBAction func touchUpNumberPadButton(_ sender: UIButton) {
         guard checkNumberOfInputs else {
             return

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -16,6 +16,22 @@ class CalculatorViewController: UIViewController {
     }
     
     @IBAction func touchUpNumberPadButton(_ sender: UIButton) {
+        guard let txt = operandLabel.text else {
+            return
+        }
+        
+        guard let a = sender.titleLabel?.text else {
+            return
+        }
+        
+        if txt == "0" {
+            if a == "0" || a == "00" {
+                return
+            }
+        }
+        
+        operandLabel.text = txt + a
+        
     }
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -113,10 +113,10 @@ class CalculatorViewController: UIViewController {
             return
         }
         
-        insertValueToStack(textValue: `operator`)
-        insertValueToStack(textValue: operand)
+        insertValueToStackView(textValue: `operator`)
+        insertValueToStackView(textValue: operand)
         
-        func insertValueToStack(textValue: String) {
+        func insertValueToStackView(textValue: String) {
             let label = calculatorHistoryUILbel(text: textValue)
             stackView.addArrangedSubview(label)
         }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -17,13 +17,6 @@ class CalculatorViewController: UIViewController {
         reset()
     }
     
-    func reset() {
-        operandLabel.text = "0"
-        operatorLabel.text = ""
-        allClear()
-    }
-    }
-    
     @IBAction func touchUpNumberPadButton(_ sender: UIButton) {
         guard let operandLabelText = operandLabel.text else {
             return

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -65,9 +65,14 @@ class CalculatorViewController: UIViewController {
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         inputedOperand = "0"
+        
         if operandLabel.text == "0" {
             operatorLabel.text = sender.titleLabel?.text
             return
+        }
+        
+        if calculationHistoryStackView.subviews.isEmpty {
+            operatorLabel.text = ""
         }
         
         addFormula()

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -108,7 +108,7 @@ extension CalculatorViewController {
         rawOperand = "0"
         operandLabel.text = rawOperand
         operatorLabel.text = ""
-        allClear()
+        clearAll()
     }
     
     func addFormula() {
@@ -135,7 +135,7 @@ extension CalculatorViewController {
         autoScrollDown()
     }
     
-    func allClear() {
+    func clearAll() {
         for subview in calculationHistoryStackView.subviews {
             subview.removeFromSuperview()
         }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -38,6 +38,18 @@ class CalculatorViewController: UIViewController {
         
         operandLabel.text = operandLabelText + tapedNumber
     }
+    @IBAction func touchUpOperatorButton(_ sender: UIButton) {
+        
+        if operandLabel.text == "0" {
+            operatorLabel.text = sender.titleLabel?.text
+            return
+        }
+        
+        addFormula()
+        operatorLabel.text = sender.titleLabel?.text
+        operandLabel.text = "0"
+    }
+    
     @IBAction func touchUpAllClear(_ sender: UIButton) {
         reset()
     }
@@ -71,6 +83,7 @@ class CalculatorViewController: UIViewController {
         stackView.addArrangedSubview(insultinOperandLabel)
         
         calculationHistoryStackView.addArrangedSubview(stackView)
+        autoScrollDown()
     }
     
     func allClear() {
@@ -83,6 +96,17 @@ class CalculatorViewController: UIViewController {
         operandLabel.text = "0"
     }
     
+    func autoScrollDown() {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1 ) {
+            self.calculationHistoryScrollView
+                .scrollRectToVisible(CGRect(x: 0,
+                                            y: self.calculationHistoryScrollView.contentSize.height
+                                                - self.calculationHistoryScrollView.bounds.height,
+                                            width: self.calculationHistoryScrollView.bounds.size.width,
+                                            height: self.calculationHistoryScrollView.bounds.size.height),
+                                     animated: true)
+        }
+    }
     
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -54,6 +54,10 @@ class CalculatorViewController: UIViewController {
         reset()
     }
     
+    @IBAction func touchUpClearEntry(_ sender: UIButton) {
+        clearEntry()
+    }
+    
     func reset() {
         operandLabel.text = "0"
         operatorLabel.text = ""

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -56,6 +56,7 @@ class CalculatorViewController: UIViewController {
             if operand == "0" {
                 return
             }
+            
             if operand.contains("-") {
                 operand.remove(at: operand.startIndex)
             } else {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -45,5 +45,11 @@ class CalculatorViewController: UIViewController {
         operandLabel.text = operandLabelText + tapedNumber
         
     }
+    
+    func reset() {
+        operandLabel.text = "0"
+        operatorLabel.text = ""
+        allClear()
+    }
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -65,11 +65,11 @@ class CalculatorViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpAllClear(_ sender: UIButton) {
+    @IBAction func touchUpAllClearButton(_ sender: UIButton) {
         reset()
     }
     
-    @IBAction func touchUpClearEntry(_ sender: UIButton) {
+    @IBAction func touchUpClearEntryButton(_ sender: UIButton) {
         clearEntry()
     }
     

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -126,7 +126,8 @@ class CalculatorViewController: UIViewController {
         
         calculationHistoryStackView.addArrangedSubview(stackView)
         
-        calculatorController.insertFormula(operator: `operator`, operand: operand.components(separatedBy: [","]).joined())
+        calculatorController.insertFormula(operator: `operator`,
+                                           operand: operand.components(separatedBy: [","]).joined())
         
         autoScrollDown()
     }
@@ -172,5 +173,4 @@ class CalculatorViewController: UIViewController {
         }
         return result
     }
-    
 }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -37,16 +37,6 @@ class CalculatorViewController: UIViewController {
             return
         }
         
-        if notFormattedOperand == "0" {
-            guard number != "0" || number != "00" else {
-                return
-            }
-            
-            notFormattedOperand = number
-            operandLabel.text = notFormattedOperand
-            return
-        }
-        
         notFormattedOperand = notFormattedOperand + number
         operandLabel.text = changeNumberFormatter(insertedNumber: number)
     }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -68,14 +68,16 @@ class CalculatorViewController: UIViewController {
     }
     
     @IBAction func touchUpTogglePlusMinusButton(_ sender: UIButton) {
-        if notFormattedOperand == "0" {
+        guard notFormattedOperand != "0" else {
             return
         }
+        
         if notFormattedOperand.contains("-") {
             notFormattedOperand.remove(at: notFormattedOperand.startIndex)
         } else {
             notFormattedOperand.insert("-", at: notFormattedOperand.startIndex)
         }
+        
         operandLabel.text = notFormattedOperand
     }
     

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -10,27 +10,34 @@ class CalculatorViewController: UIViewController {
 
     @IBOutlet weak var operandLabel: UILabel!
     @IBOutlet weak var operatorLabel: UILabel!
+    @IBOutlet weak var calculationHistory: UIStackView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        reset()
+    }
+    
+    func reset() {
+        operandLabel.text = "0"
+        operatorLabel.text = ""
     }
     
     @IBAction func touchUpNumberPadButton(_ sender: UIButton) {
-        guard let txt = operandLabel.text else {
+        guard let operandLabelText = operandLabel.text else {
             return
         }
         
-        guard let a = sender.titleLabel?.text else {
+        guard let tapedNumber = sender.titleLabel?.text else {
             return
         }
         
-        if txt == "0" {
-            if a == "0" || a == "00" {
+        if operandLabelText == "0" {
+            if tapedNumber == "0" || tapedNumber == "00" {
                 return
             }
         }
         
-        operandLabel.text = txt + a
+        operandLabel.text = operandLabelText + tapedNumber
         
     }
 }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -53,7 +53,7 @@ class CalculatorViewController: UIViewController {
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         notFormattedOperand = "0"
         
-        if operandLabel.text == "0" {
+        guard operandLabel.text != "0" else {
             operatorLabel.text = sender.titleLabel?.text
             return
         }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -10,7 +10,8 @@ class CalculatorViewController: UIViewController {
 
     @IBOutlet weak var operandLabel: UILabel!
     @IBOutlet weak var operatorLabel: UILabel!
-    @IBOutlet weak var calculationHistory: UIStackView!
+    @IBOutlet weak var calculationHistoryStackView: UIStackView!
+    @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -38,6 +38,7 @@ class CalculatorViewController: UIViewController {
         
         operandLabel.text = operandLabelText + tapedNumber
     }
+    
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         
         if operandLabel.text == "0" {
@@ -49,6 +50,7 @@ class CalculatorViewController: UIViewController {
         operatorLabel.text = sender.titleLabel?.text
         operandLabel.text = "0"
     }
+    
     @IBAction func touchUpTogglePlusMinusButton(_ sender: UIButton) {
         if var operand = operandLabel.text {
             if operand == "0" {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -117,10 +117,7 @@ class CalculatorViewController: UIViewController {
         labelFormat(textValue: operand)
         
         func labelFormat(textValue: String) {
-            let label = UILabel()
-            label.textColor = UIColor.white
-            label.text = textValue
-            label.font = UIFont.preferredFont(forTextStyle: .title3)
+            let label = calculatorHistoryUILbel(text: textValue)
             stackView.addArrangedSubview(label)
         }
         

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -113,10 +113,10 @@ class CalculatorViewController: UIViewController {
             return
         }
         
-        labelFormat(textValue: `operator`)
-        labelFormat(textValue: operand)
+        insertValueToStack(textValue: `operator`)
+        insertValueToStack(textValue: operand)
         
-        func labelFormat(textValue: String) {
+        func insertValueToStack(textValue: String) {
             let label = calculatorHistoryUILbel(text: textValue)
             stackView.addArrangedSubview(label)
         }

--- a/Calculator/Calculator/Controller/calculatorHistoryUILbel.swift
+++ b/Calculator/Calculator/Controller/calculatorHistoryUILbel.swift
@@ -1,0 +1,27 @@
+//
+//  customUILable.swift
+//  Calculator
+//
+//  Created by Eunsoo KIM on 2021/11/19.
+//
+
+import Foundation
+import UIKit
+
+class calculatorHistoryUILbel: UILabel {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    init(text: String) {
+        super.init(frame: CGRect.zero)
+        self.text = text
+        self.textColor = UIColor.white
+        self.font = UIFont.preferredFont(forTextStyle: .title3)
+    }
+}

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -20,6 +20,10 @@ enum ExpressionParser {
             .forEach { formula.operands.enqueue($0) }
         
         separatedInput
+            .filter {
+                Operator.allCases
+                    .map { String($0.rawValue) }.contains($0)
+            }
             .compactMap { Operator(rawValue: Character($0)) }
             .forEach { formula.operators.enqueue($0) }
         

--- a/Calculator/Calculator/Model/Extension/StringExtension.swift
+++ b/Calculator/Calculator/Model/Extension/StringExtension.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension String {
-    func split(with targert: Character) -> [String] {
-        self.split(separator: targert).map { String($0) }
+    func split(with target: Character) -> [String] {
+        self.split(separator: target).map { String($0) }
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -8,7 +8,14 @@
 import Foundation
 
 struct Formula {
-    enum FormulaError: Error {
+    enum FormulaError: Error, CustomStringConvertible {
+        var description: String {
+            switch self {
+            case .NaN:
+                return "NaN"
+            }
+        }
+        
         case NaN
     }
     

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -9,9 +9,9 @@ import Foundation
 
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
-    case substract = "-"
-    case divide = "/"
-    case multiply = "*"
+    case substract = "−"
+    case divide = "÷"
+    case multiply = "×"
     
     func calculate(lhs: Double, rhs: Double) -> Double {
         switch self {

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -122,6 +122,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Agd-6n-nHY"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -130,6 +133,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mz9-cw-dHK"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -138,6 +144,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Tvn-uO-ojm"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -159,6 +168,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qOx-V4-0pZ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -167,6 +179,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LO0-sx-nS9"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -175,6 +190,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qcG-HZ-Y6c"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -196,6 +214,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="EUe-VD-GWE"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -204,6 +225,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mwi-yS-4n6"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -212,6 +236,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1sQ-Kb-Ik9"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -233,6 +260,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Yhc-z1-b2z"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -241,6 +271,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberPadButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1Oa-cw-FTl"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -303,6 +336,10 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="j80-dt-QeF"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="nVk-Ga-Wtb"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -86,7 +86,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchUpAllClear:" destination="BYZ-38-t0r" eventType="touchUpInside" id="TAb-Qc-AVN"/>
+                                                    <action selector="touchUpAllClearButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Tde-3n-j9X"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
@@ -97,7 +97,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchUpClearEntry:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5vr-9k-SBy"/>
+                                                    <action selector="touchUpClearEntryButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="b5Z-tf-Ehn"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpAllClear:" destination="BYZ-38-t0r" eventType="touchUpInside" id="TAb-Qc-AVN"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -109,6 +112,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0n9-px-a3e"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -155,6 +161,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="R8w-8i-9Iw"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -201,6 +210,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qjV-JL-g4r"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -247,6 +259,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mmW-fW-hJH"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -96,6 +96,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpClearEntry:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5vr-9k-SBy"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -337,6 +337,8 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="calculationHistoryScrollView" destination="BOT-7g-vxv" id="262-5C-gla"/>
+                        <outlet property="calculationHistoryStackView" destination="XRe-QE-UJf" id="Uhe-mU-T4k"/>
                         <outlet property="operandLabel" destination="Lwz-OF-XHD" id="j80-dt-QeF"/>
                         <outlet property="operatorLabel" destination="HPC-iy-qdm" id="nVk-Ga-Wtb"/>
                     </connections>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -317,6 +317,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUPEqualButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gmR-cU-mEg"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -1,38 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Calculator View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="CalculatorViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -40,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -265,19 +266,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -303,6 +303,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpDecimalPointButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YJY-Rz-TeZ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -107,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpTogglePlusMinusButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6kZ-lb-pBr"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -14,7 +14,7 @@ class ExpressionParserTests: XCTestCase {
         XCTAssertEqual(["a", "b"], "a b".split(with: " "))
     }
 
-    func test_1_더하기_2의_결과가_3인가() {
+    func test_13_더하기_20의_결과가_33인가() {
         
         XCTAssertEqual(33.0, try ExpressionParser.parse(from: "13 + 20").result())
     }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -16,19 +16,18 @@ class ExpressionParserTests: XCTestCase {
 
     func test_1_더하기_2의_결과가_3인가() {
         
-        XCTAssertEqual(3.0, try ExpressionParser.parse(from: "1 + 2").result())
+        XCTAssertEqual(33.0, try ExpressionParser.parse(from: "13 + 20").result())
     }
     
     func test_9_나누기_3의_결과가_3인가() {
         
-        XCTAssertEqual(3.0, try ExpressionParser.parse(from: "9 / 3").result())
+        XCTAssertEqual(3.0, try ExpressionParser.parse(from: "9.0 / 3.0").result())
     }
     
     func test_0으로_나눌경우_오류처리가_되는가() {
         XCTAssertThrowsError(try ExpressionParser.parse(from: "9 / 0").result()) { error in
             XCTAssertEqual(error as? Formula.FormulaError, Formula.FormulaError.NaN)
         }
-        
     }
 
 }


### PR DESCRIPTION
안녕하세요~! 코리!!! 😭7

마지막 스텝 PR 전송입니다!!!
스텝1, 스텝2에서의 꼼꼼한 PR 덕분에 너무나 많은걸 배웠습니다~!
이번에도 좋은 피드백 기다리고 있겠습니다!!

# ‼️ 고민한점
1. 스토리 보드에 구현된 레이블들을 제거할지, 아님 뷰가 로드되면 제거할지 고민을 했습니다.
    * 아카데미에서 포크받은 소스이기에 일단, 제거하지 않았으며 로드되면 제거가 되도록 진행했습니다.
2. 자동 스크롤 다운에 대한 고민
    * 사용자의 입력될 때마다 최근에 입력한 값을 스크롤뷰 하단으로 삽입되며 스크롤을 자동으로 내리는 제약에 대해서 많은 고민을 했습니다!
    * 경험한 현상: 사용자가 입력한 시점에 바로 스크롤 다운 되는게 아닌, 한 박자(?) 늦은 스크롤 다운
    * 디버깅하면서 이해한 점
        * view 요소들을 생성하는 함수가 종료된 이후에 실질적으로 화면에 생성이 됨
        * 스크롤 다운이 되는 시점은 실질적인 요소가 생성되기 이전이기에 위에 적은 현상이 발생됨
    * 해결 방안
        * DispatchQueue를 이용한 스크롤 다운에 대한 지연을 줌
3. ViewController의 거대화
    * 기능 요구를 충족하다보니, ViewController가 비대해 진다는걸 느꼈습니다. 이에 Model과 직접적으로 통신하는 Controller를 별도로 구현하여, 분배하였습니다.
4. notFormattedOperand 변수를 만든 이유
    * 사용자의 입력을 실시간으로 입력받는 경우 numberFormatter의 영향으로 0.01을 입력할때 소수점 이후 0을 제거함
    * 실질적인 연산을 하기 위해서는 콤마를 제거하는 과정이 존재함
    * 이러한 이유로 사용자의 입력에 대해서 numberFormatter 형식을 거치지 않는 별도의 변수 `notFormattedOperand`를 만들었습니다.
5. numberFormatter의 최대 입력할수 있는 수
    * ref: https://stackoverflow.com/questions/45520019/numberformatter-issue-for-large-number
    * 사용자가 입력한 값이 15~16자리를 초과하는 경우 입력값과 다른 값을 출력되는 현상이 있었습니다.
    * 상기 사유로 사용자가 입력할 수 있는 수의 갯수를 15개로 제한을 두었습니다.
 
---
# ⁉️ 궁금한점
1. viewContoller 내부 @IBOutlet, @IBAction 요소들에 대한 접근 제어
    * 의존모둠 스크럼을 통해 알게되었습니다! 이전까지 프로젝트를 진행하면서 저는 접근제어를 별도로 진행하지 않았으며, 이 부분에 대해서도 리뷰를 받지 못했는데요! 코리가 생각하시는 해당 요소들에 대한 접근 제어 필요 유무가 궁금합니다.
2. 고민한점 2번에 대한 질문
    * 기재한 해결 방안을 찾기 이전에는 스크롤뷰에 자동 스크롤 다운이 되는 프로퍼티나 메서드가 존재하지 않을까라는 고민을 하고 찾아봤지만 찾지 못했습니다. 혹시 제가 찾지 못한건지... 궁금합니다!. 만약 없다면! 코리라면은 어떤 방향으로 해결을 하실지 궁금합니다.
3. ViewContoroller extension에 대한 질문
    * 이번에도 의존 모둠 스크럼을 통해 알게된 사실입니다..ㅎ ViewController 파일 내부에 기능별로 ViewContoroller를 extension을 통해 구분해 놓는 컨벤션(?)을 알게 되었습니다!! 이 컨벤션이 많이 사용되는 컨벤션인지 궁금합니다


---
이상입니다~! 좋은 피드백 많이 많이 부탁드립니다!!!👏🏻