### PR TITLE
계산기 [STEP 3] 제인

### DIFF
--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -6,7 +6,7 @@ class ViewController: UIViewController {
     @IBOutlet private weak var operatorLabel: UILabel!
     @IBOutlet private weak var mainStackView: UIStackView!
     
-    var inputString: String = ""
+    private var inputString: String = ""
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -14,14 +14,14 @@ class ViewController: UIViewController {
         operatorLabel.text = ""
     }
     
-    func makeLabel(text: String?) -> UILabel {
+    private func makeLabel(text: String?) -> UILabel {
         let label = UILabel()
         label.textColor = .white
         label.text = text
         return label
     }
     
-    func makeStackView(with subviews: UIView...) -> UIStackView {
+    private func makeStackView(with subviews: UIView...) -> UIStackView {
         let stackView = UIStackView()
         
         stackView.axis = .horizontal
@@ -33,7 +33,7 @@ class ViewController: UIViewController {
         return stackView
     }
     
-    func makeExpressionStackView() {
+    private func makeExpressionStackView() {
         let operandLabel = makeLabel(text: self.operandsLabel.text)
         let operatorLabel = makeLabel(text: self.operatorLabel.text)
         let smallStackview = makeStackView(with: operatorLabel, operandLabel)
@@ -41,16 +41,7 @@ class ViewController: UIViewController {
         mainStackView.addArrangedSubview(smallStackview)
     }
     
-    @IBAction func touchUpOperandButton(_ sender: UIButton) {
-        guard let newInput = sender.currentTitle else {return}
-        
-        changeOperandsLabelText(newInput: newInput)
-        inputString.append(newInput)
-        print(inputString)
-
-    }
-    
-    func changeOperandsLabelText(newInput: String) {
+    private func changeOperandsLabelText(newInput: String) {
         guard let currentText = operandsLabel.text else {return}
         if currentText == "0" {
             operandsLabel.text = newInput
@@ -65,17 +56,27 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpOperatorButton(_ sender: UIButton) {
+    @IBAction private func touchUpOperandButton(_ sender: UIButton) {
+        guard let newInput = sender.currentTitle else {return}
+        
+        changeOperandsLabelText(newInput: newInput)
+        inputString.append(newInput)
+        print(inputString)
+
+    }
+    
+    @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle else {return}
         guard operandsLabel.text != "0" else { return }
         guard operandsLabel.text?.isEmpty == false else {return}
         makeExpressionStackView()
-        inputString.append(`operator`)
         operandsLabel.text = "0"
         operatorLabel.text = `operator`
+        
+        inputString.append(`operator`)
     }
     
-    @IBAction func touchUpACButton(_ sender: UIButton) {
+    @IBAction private func touchUpACButton(_ sender: UIButton) {
         operandsLabel.text = "0"
         operatorLabel.text = ""
         inputString = ""
@@ -85,7 +86,7 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpCEButton(_ sender: UIButton) {
+    @IBAction private func touchUpCEButton(_ sender: UIButton) {
         if operandsLabel.text?.isEmpty == false {
             operandsLabel.text?.removeLast()
         }
@@ -96,7 +97,7 @@ class ViewController: UIViewController {
         
     }
     
-    @IBAction func touchUpPlusMinusButton(_ sender: UIButton) {
+    @IBAction private func touchUpPlusMinusButton(_ sender: UIButton) {
         guard let operandsLabelText = operandsLabel.text else {return}
         
         if operandsLabelText.contains("-") {
@@ -107,14 +108,14 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpDotButton(_ sender: UIButton) {
+    @IBAction private func touchUpDotButton(_ sender: UIButton) {
         guard let newInput = sender.currentTitle, let operandsLabelText = operandsLabel.text else {return}
         
         operandsLabel.text = operandsLabelText + newInput
         inputString.append(newInput)
     }
     
-    @IBAction func touchUpResultButton(_ sender: UIButton) {
+    @IBAction private func touchUpResultButton(_ sender: UIButton) {
         guard operandsLabel.text != "0" else { return }
         guard operandsLabel.text?.isEmpty == false else {return}
         makeExpressionStackView()

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class ViewController: UIViewController {
 
-    @IBOutlet private weak var inputLabel: UILabel!
+    @IBOutlet private weak var operandsLabel: UILabel!
     @IBOutlet private weak var operatorLabel: UILabel!
     @IBOutlet private weak var mainStackView: UIStackView!
     
@@ -10,7 +10,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        inputLabel.text = "0"
+        operandsLabel.text = "0"
         operatorLabel.text = ""
     }
     
@@ -33,8 +33,8 @@ class ViewController: UIViewController {
         return stackView
     }
     
-    func makeSmallStackView() {
-        let operandLabel = makeLabel(text: self.inputLabel.text)
+    func makeExpressionStackView() {
+        let operandLabel = makeLabel(text: self.operandsLabel.text)
         let operatorLabel = makeLabel(text: self.operatorLabel.text)
         let smallStackview = makeStackView(with: operatorLabel, operandLabel)
         
@@ -42,17 +42,17 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpOperandButton(_ sender: UIButton) {
-        guard let newInput = sender.currentTitle, let currentInput = inputLabel.text else {return}
+        guard let newInput = sender.currentTitle, let operandsLabelText = operandsLabel.text else {return}
         
-        if currentInput == "0" {
-            inputLabel.text = newInput
+        if operandsLabelText == "0" {
+            operandsLabel.text = newInput
         } else {
-            inputLabel.text = currentInput + newInput
+            operandsLabel.text = operandsLabelText + newInput
         }
-        
+
         if newInput == "00" {
-            if currentInput == "0" || currentInput == "" {
-                inputLabel.text = "0"
+            if operandsLabelText == "0" || operandsLabelText == "" {
+                operandsLabel.text = "0"
             }
         }
         
@@ -63,16 +63,16 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle else {return}
-        guard inputLabel.text != "0" else { return }
-        guard inputLabel.text?.isEmpty == false else {return}
-        makeSmallStackView()
+        guard operandsLabel.text != "0" else { return }
+        guard operandsLabel.text?.isEmpty == false else {return}
+        makeExpressionStackView()
         inputString.append(`operator`)
-        inputLabel.text = ""
+        operandsLabel.text = ""
         operatorLabel.text = `operator`
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
-        inputLabel.text = "0"
+        operandsLabel.text = "0"
         operatorLabel.text = ""
         inputString = ""
         for i in mainStackView.arrangedSubviews {
@@ -82,8 +82,8 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpCEButton(_ sender: UIButton) {
-        if inputLabel.text?.isEmpty == false {
-            inputLabel.text?.removeLast()
+        if operandsLabel.text?.isEmpty == false {
+            operandsLabel.text?.removeLast()
         }
         
         if inputString.isEmpty == false {
@@ -93,27 +93,27 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpPlusMinusButton(_ sender: UIButton) {
-        guard let currentInput = inputLabel.text else {return}
+        guard let operandsLabelText = operandsLabel.text else {return}
         
-        if currentInput.contains("-") {
-            inputLabel.text = currentInput.replacingOccurrences(of: "-", with: "")
+        if operandsLabelText.contains("-") {
+            operandsLabel.text = operandsLabelText.replacingOccurrences(of: "-", with: "")
         }
         else {
-            inputLabel.text = "-" + currentInput
+            operandsLabel.text = "-" + operandsLabelText
         }
     }
     
     @IBAction func touchUpDotButton(_ sender: UIButton) {
-        guard let newInput = sender.currentTitle, let currentInput = inputLabel.text else {return}
+        guard let newInput = sender.currentTitle, let operandsLabelText = operandsLabel.text else {return}
         
-        inputLabel.text = currentInput + newInput
+        operandsLabel.text = operandsLabelText + newInput
         inputString.append(newInput)
     }
     
     @IBAction func touchUpResultButton(_ sender: UIButton) {
-        guard inputLabel.text != "0" else { return }
-        guard inputLabel.text?.isEmpty == false else {return}
-        makeSmallStackView()
+        guard operandsLabel.text != "0" else { return }
+        guard operandsLabel.text?.isEmpty == false else {return}
+        makeExpressionStackView()
         
         var formula: Formula = ExpressionParser.parse(from: inputString)
         print(inputString)
@@ -121,7 +121,7 @@ class ViewController: UIViewController {
         print(formula.operators)
         let result = formula.result()
         print(result)
-        inputLabel.text = result.description
+        operandsLabel.text = result.description
         operatorLabel.text = ""
         
     }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -85,6 +85,11 @@ class ViewController: UIViewController {
         if inputLabel.text?.isEmpty == false {
             inputLabel.text?.removeLast()
         }
+        
+        if inputString.isEmpty == false {
+            inputString.removeLast()
+        }
+        
     }
     
     @IBAction func touchUpPlusMinusButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -61,6 +61,10 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
         inputLabel.text = "0"
+        for i in mainStackView.arrangedSubviews {
+            mainStackView.removeArrangedSubview(i)
+            i.removeFromSuperview()
+        }
     }
     
     @IBAction func touchUpCEButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -2,9 +2,9 @@ import UIKit
 
 class ViewController: UIViewController {
 
-    @IBOutlet weak var inputLabel: UILabel!
-    @IBOutlet weak var operatorLabel: UILabel!
-    @IBOutlet weak var mainStackView: UIStackView!
+    @IBOutlet private weak var inputLabel: UILabel!
+    @IBOutlet private weak var operatorLabel: UILabel!
+    @IBOutlet private weak var mainStackView: UIStackView!
     
     var inputString: String = ""
     

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -10,6 +10,10 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        initializeView()
+    }
+    
+    func initializeView() {
         operandsLabel.text = "0"
         operatorLabel.text = ""
     }
@@ -21,7 +25,7 @@ class ViewController: UIViewController {
         return label
     }
     
-    private func makeStackView(with subviews: UIView...) -> UIStackView {
+    private func makeStackView(with subviews: [UIView]) -> UIStackView {
         let stackView = UIStackView()
         
         stackView.axis = .horizontal
@@ -36,9 +40,9 @@ class ViewController: UIViewController {
     private func makeExpressionStackView() {
         let operandLabel = makeLabel(text: self.operandsLabel.text)
         let operatorLabel = makeLabel(text: self.operatorLabel.text)
-        let smallStackview = makeStackView(with: operatorLabel, operandLabel)
+        let expressionStackview = makeStackView(with: [operatorLabel, operandLabel])
         
-        mainStackView.addArrangedSubview(smallStackview)
+        mainStackView.addArrangedSubview(expressionStackview)
     }
     
     private func changeOperandsLabelText(newInput: String) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -42,15 +42,11 @@ class ViewController: UIViewController {
     @IBAction func touchUpOperandButton(_ sender: UIButton) {
         guard let newInput = sender.currentTitle, let currentInput = inputLabel.text else {return}
         
-        if newInput == "0" {
-            inputLabel.text = "0"
-        }
-        else {
-            inputLabel.text = currentInput + newInput
-        }
         if currentInput == "0" {
             inputLabel.text = newInput
         }
+        
+        inputLabel.text = currentInput + newInput
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -2,13 +2,13 @@ import UIKit
 
 class ViewController: UIViewController {
 
-    @IBOutlet weak var resultLabel: UILabel!
+    @IBOutlet weak var inputLabel: UILabel!
     @IBOutlet weak var operatorLabel: UILabel!
-    @IBOutlet weak var stackView: UIStackView!
+    @IBOutlet weak var mainStackView: UIStackView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        resultLabel.text = "0"
+        inputLabel.text = "0"
     }
     
     func makeLabel(text: String?) -> UILabel {
@@ -33,44 +33,44 @@ class ViewController: UIViewController {
     }
     
     func makeSmallStackView() {
-        let operandLabel = makeLabel(text: self.resultLabel.text)
+        let operandLabel = makeLabel(text: self.inputLabel.text)
         let operatorLabel = makeLabel(text: self.operatorLabel.text)
         let smallStackview = makeStackView(with: operatorLabel,operandLabel)
         
-        stackView.addArrangedSubview(smallStackview)
+        mainStackView.addArrangedSubview(smallStackview)
     }
     
-    @IBAction func operandButtonTapped(_ sender: UIButton) {
+    @IBAction func touchUpOperandButton(_ sender: UIButton) {
         guard let operand = sender.currentTitle else {return}
-        resultLabel.text?.append(contentsOf: operand)
+        inputLabel.text?.append(contentsOf: operand)
     }
     
-    @IBAction func operatorButtonTapped(_ sender: UIButton) {
+    @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle else {return}
         operatorLabel.text = `operator`
         makeSmallStackView()
-        resultLabel.text = ""
+        inputLabel.text = ""
     }
     
-    @IBAction func ACButtonTapped(_ sender: UIButton) {
-        resultLabel.text = "0"
+    @IBAction func touchUpACButton(_ sender: UIButton) {
+        inputLabel.text = "0"
     }
     
-    @IBAction func CEButtonTapped(_ sender: UIButton) {
-        if resultLabel.text?.isEmpty == false {
-            resultLabel.text?.removeLast()
+    @IBAction func touchUpCEButton(_ sender: UIButton) {
+        if inputLabel.text?.isEmpty == false {
+            inputLabel.text?.removeLast()
         }
     }
     
-    @IBAction func plusMinusButtonTapped(_ sender: UIButton) {
+    @IBAction func touchUpPlusMinusButton(_ sender: UIButton) {
         
     }
     
-    @IBAction func dotButtonTapped(_ sender: UIButton) {
+    @IBAction func touchUpDotButton(_ sender: UIButton) {
         
     }
     
-    @IBAction func resultButtonTapped(_ sender: UIButton) {
+    @IBAction func touchUpResultButton(_ sender: UIButton) {
         
     }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -6,6 +6,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var operatorLabel: UILabel!
     @IBOutlet weak var mainStackView: UIStackView!
     
+    var inputString: String = ""
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         inputLabel.text = "0"
@@ -53,6 +55,9 @@ class ViewController: UIViewController {
                 inputLabel.text = "0"
             }
         }
+        
+        inputString.append(newInput)
+        print(inputString)
 
     }
     
@@ -61,6 +66,7 @@ class ViewController: UIViewController {
         guard inputLabel.text != "0" else { return }
         guard inputLabel.text?.isEmpty == false else {return}
         makeSmallStackView()
+        inputString.append(`operator`)
         inputLabel.text = ""
         operatorLabel.text = `operator`
     }
@@ -68,6 +74,7 @@ class ViewController: UIViewController {
     @IBAction func touchUpACButton(_ sender: UIButton) {
         inputLabel.text = "0"
         operatorLabel.text = ""
+        inputString = ""
         for i in mainStackView.arrangedSubviews {
             mainStackView.removeArrangedSubview(i)
             i.removeFromSuperview()
@@ -95,9 +102,22 @@ class ViewController: UIViewController {
         guard let newInput = sender.currentTitle, let currentInput = inputLabel.text else {return}
         
         inputLabel.text = currentInput + newInput
+        inputString.append(newInput)
     }
     
     @IBAction func touchUpResultButton(_ sender: UIButton) {
+        guard inputLabel.text != "0" else { return }
+        guard inputLabel.text?.isEmpty == false else {return}
+        makeSmallStackView()
+        
+        var formula: Formula = ExpressionParser.parse(from: inputString)
+        print(inputString)
+        print(formula.operands)
+        print(formula.operators)
+        let result = formula.result()
+        print(result)
+        inputLabel.text = result.description
+        operatorLabel.text = ""
         
     }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -6,9 +6,34 @@ class ViewController: UIViewController {
     @IBOutlet weak var operatorLabel: UILabel!
     @IBOutlet weak var UIScrollView: UIScrollView!
     
+    var leftOperatorLabel: UILabel {
+        let label = UILabel()
+        return label
+    }
+    
+    var rightOperandLabel: UILabel {
+        let label = UILabel()
+        return label
+    }
+    
+    var stackView: UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 20.0
+        stackView.alignment = .fill
+        stackView.distribution = .fillEqually
+        
+        UIScrollView.addSubview(stackView)
+        stackView.addSubview(leftOperatorLabel)
+        stackView.addSubview(rightOperandLabel)
+
+        return stackView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         resultLabel.text = "0"
+
         
     }
 
@@ -19,8 +44,9 @@ class ViewController: UIViewController {
     
     @IBAction func operatorButtonTapped(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle else {return}
-        resultLabel.text?.append(contentsOf: `operator`)
         operatorLabel.text = `operator`
+        rightOperandLabel.text = resultLabel.text
+        resultLabel.text = ""
     }
     
     @IBAction func ACButtonTapped(_ sender: UIButton) {
@@ -33,7 +59,7 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func plusMinusButtonChanged(_ sender: UIButton) {
+    @IBAction func plusMinusButtonTapped(_ sender: UIButton) {
         
     }
     
@@ -44,6 +70,7 @@ class ViewController: UIViewController {
     @IBAction func resultButtonTapped(_ sender: UIButton) {
         
     }
+
     
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -17,7 +17,10 @@ class ViewController: UIViewController {
         operandsLabel.text = "0"
         operatorLabel.text = ""
     }
-    
+}
+
+// MARK: - Method
+extension ViewController {
     private func makeLabel(text: String?) -> UILabel {
         let label = UILabel()
         label.textColor = .white
@@ -119,6 +122,10 @@ class ViewController: UIViewController {
         return result
     }
     
+}
+
+// MARK: - Button Event
+extension ViewController {
     @IBAction private func touchUpOperandButton(_ sender: UIButton) {
         guard let newInput = sender.currentTitle else {return}
         changeOperandsLabelText(newInput: newInput)
@@ -168,4 +175,3 @@ class ViewController: UIViewController {
         initializeOpertorLabel()
     }
 }
-

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -42,23 +42,27 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpOperandButton(_ sender: UIButton) {
-        guard let newInput = sender.currentTitle, let operandsLabelText = operandsLabel.text else {return}
+        guard let newInput = sender.currentTitle else {return}
         
-        if operandsLabelText == "0" {
-            operandsLabel.text = newInput
-        } else {
-            operandsLabel.text = operandsLabelText + newInput
-        }
-
-        if newInput == "00" {
-            if operandsLabelText == "0" || operandsLabelText == "" {
-                operandsLabel.text = "0"
-            }
-        }
-        
+        changeOperandsLabelText(newInput: newInput)
         inputString.append(newInput)
         print(inputString)
 
+    }
+    
+    func changeOperandsLabelText(newInput: String) {
+        guard let currentText = operandsLabel.text else {return}
+        if currentText == "0" {
+            operandsLabel.text = newInput
+        } else {
+            operandsLabel.text = currentText + newInput
+        }
+
+        if newInput == "00" {
+            if currentText == "0" || currentText == "" {
+                operandsLabel.text = "0"
+            }
+        }
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
@@ -67,7 +71,7 @@ class ViewController: UIViewController {
         guard operandsLabel.text?.isEmpty == false else {return}
         makeExpressionStackView()
         inputString.append(`operator`)
-        operandsLabel.text = ""
+        operandsLabel.text = "0"
         operatorLabel.text = `operator`
     }
     

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -60,71 +60,50 @@ class ViewController: UIViewController {
         }
     }
     
-    func initializeOperandsLabel() {
+    private func initializeOperandsLabel() {
         operandsLabel.text = "0"
     }
     
-    func initializeOpertorLabel() {
+    private func initializeOpertorLabel() {
         operatorLabel.text = ""
     }
     
-    func initializeInputString() {
+    private func initializeInputString() {
         inputString = ""
     }
     
-    func updateOperandsLabel(text operands: String) {
+    private func updateOperandsLabel(text operands: String) {
         operandsLabel.text = operands
     }
     
-    func updateOperatorLabel(text operator: String) {
+    private func updateOperatorLabel(text operator: String) {
         operatorLabel.text = `operator`
     }
     
-    func appendInputString(text input: String) {
+    private func appendInputString(text input: String) {
         inputString.append(input)
     }
     
-    @IBAction private func touchUpOperandButton(_ sender: UIButton) {
-        guard let newInput = sender.currentTitle else {return}
-        changeOperandsLabelText(newInput: newInput)
-        
-        appendInputString(text: newInput)
+    private func removeTextFromInputString() {
+        if inputString.isEmpty == false {
+            inputString.removeLast()
+        }
     }
     
-    @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
-        guard let `operator` = sender.currentTitle else {return}
-        guard operandsLabel.text != "0" else {return}
-        guard operandsLabel.text?.isEmpty == false else {return}
-        makeExpressionStackView()
-        initializeOperandsLabel()
-        updateOperatorLabel(text: `operator`)
-        
-        appendInputString(text: `operator`)
+    private func removeTextFromOperandsLabel() {
+        if operandsLabel.text?.isEmpty == false {
+            operandsLabel.text?.removeLast()
+        }
     }
     
-    @IBAction private func touchUpACButton(_ sender: UIButton) {
-        initializeOperandsLabel()
-        initializeOpertorLabel()
-        initializeInputString()
-        
+    private func removeSubviewsFromStackView() {
         for i in mainStackView.arrangedSubviews {
             mainStackView.removeArrangedSubview(i)
             i.removeFromSuperview()
         }
     }
     
-    @IBAction private func touchUpCEButton(_ sender: UIButton) {
-        if operandsLabel.text?.isEmpty == false {
-            operandsLabel.text?.removeLast()
-        }
-        
-        if inputString.isEmpty == false {
-            inputString.removeLast()
-        }
-        
-    }
-    
-    @IBAction private func touchUpPlusMinusButton(_ sender: UIButton) {
+    private func changePlusMinus() {
         guard let operandsLabelText = operandsLabel.text else {return}
         
         if operandsLabelText.contains("-") {
@@ -134,22 +113,58 @@ class ViewController: UIViewController {
         }
     }
     
+    private func parseExpression() -> Double {
+        var formula: Formula = ExpressionParser.parse(from: inputString)
+        let result = formula.result()
+        return result
+    }
+    
+    @IBAction private func touchUpOperandButton(_ sender: UIButton) {
+        guard let newInput = sender.currentTitle else {return}
+        changeOperandsLabelText(newInput: newInput)
+        appendInputString(text: newInput)
+    }
+    
+    @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
+        guard let `operator` = sender.currentTitle else {return}
+        guard operandsLabel.text != "0" else {return}
+        guard operandsLabel.text?.isEmpty == false else {return}
+        
+        makeExpressionStackView()
+        initializeOperandsLabel()
+        updateOperatorLabel(text: `operator`)
+        appendInputString(text: `operator`)
+    }
+    
+    @IBAction private func touchUpACButton(_ sender: UIButton) {
+        initializeOperandsLabel()
+        initializeOpertorLabel()
+        initializeInputString()
+        removeSubviewsFromStackView()
+    }
+    
+    @IBAction private func touchUpCEButton(_ sender: UIButton) {
+        removeTextFromOperandsLabel()
+        removeTextFromInputString()
+    }
+    
+    @IBAction private func touchUpPlusMinusButton(_ sender: UIButton) {
+        changePlusMinus()
+    }
+    
     @IBAction private func touchUpDotButton(_ sender: UIButton) {
         guard let newInput = sender.currentTitle, let operandsLabelText = operandsLabel.text else {return}
         
         updateOperandsLabel(text: operandsLabelText + newInput)
-        updateOperatorLabel(text: newInput)
+        appendInputString(text: newInput)
     }
     
     @IBAction private func touchUpResultButton(_ sender: UIButton) {
         guard operandsLabel.text != "0" else { return }
         guard operandsLabel.text?.isEmpty == false else {return}
+        
         makeExpressionStackView()
-        
-        var formula: Formula = ExpressionParser.parse(from: inputString)
-        let result = formula.result()
-        
-        updateOperandsLabel(text: result.description)
+        updateOperandsLabel(text: parseExpression().description)
         initializeOpertorLabel()
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -58,7 +58,8 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle else {return}
-    
+        guard inputLabel.text != "0" else { return }
+        guard inputLabel.text?.isEmpty == false else {return}
         makeSmallStackView()
         inputLabel.text = ""
         operatorLabel.text = `operator`

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -60,30 +60,53 @@ class ViewController: UIViewController {
         }
     }
     
+    func initializeOperandsLabel() {
+        operandsLabel.text = "0"
+    }
+    
+    func initializeOpertorLabel() {
+        operatorLabel.text = ""
+    }
+    
+    func initializeInputString() {
+        inputString = ""
+    }
+    
+    func updateOperandsLabel(text operands: String) {
+        operandsLabel.text = operands
+    }
+    
+    func updateOperatorLabel(text operator: String) {
+        operatorLabel.text = `operator`
+    }
+    
+    func appendInputString(text input: String) {
+        inputString.append(input)
+    }
+    
     @IBAction private func touchUpOperandButton(_ sender: UIButton) {
         guard let newInput = sender.currentTitle else {return}
-        
         changeOperandsLabelText(newInput: newInput)
-        inputString.append(newInput)
-        print(inputString)
-
+        
+        appendInputString(text: newInput)
     }
     
     @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle else {return}
-        guard operandsLabel.text != "0" else { return }
+        guard operandsLabel.text != "0" else {return}
         guard operandsLabel.text?.isEmpty == false else {return}
         makeExpressionStackView()
-        operandsLabel.text = "0"
-        operatorLabel.text = `operator`
+        initializeOperandsLabel()
+        updateOperatorLabel(text: `operator`)
         
-        inputString.append(`operator`)
+        appendInputString(text: `operator`)
     }
     
     @IBAction private func touchUpACButton(_ sender: UIButton) {
-        operandsLabel.text = "0"
-        operatorLabel.text = ""
-        inputString = ""
+        initializeOperandsLabel()
+        initializeOpertorLabel()
+        initializeInputString()
+        
         for i in mainStackView.arrangedSubviews {
             mainStackView.removeArrangedSubview(i)
             i.removeFromSuperview()
@@ -106,8 +129,7 @@ class ViewController: UIViewController {
         
         if operandsLabelText.contains("-") {
             operandsLabel.text = operandsLabelText.replacingOccurrences(of: "-", with: "")
-        }
-        else {
+        } else {
             operandsLabel.text = "-" + operandsLabelText
         }
     }
@@ -115,8 +137,8 @@ class ViewController: UIViewController {
     @IBAction private func touchUpDotButton(_ sender: UIButton) {
         guard let newInput = sender.currentTitle, let operandsLabelText = operandsLabel.text else {return}
         
-        operandsLabel.text = operandsLabelText + newInput
-        inputString.append(newInput)
+        updateOperandsLabel(text: operandsLabelText + newInput)
+        updateOperatorLabel(text: newInput)
     }
     
     @IBAction private func touchUpResultButton(_ sender: UIButton) {
@@ -125,16 +147,10 @@ class ViewController: UIViewController {
         makeExpressionStackView()
         
         var formula: Formula = ExpressionParser.parse(from: inputString)
-        print(inputString)
-        print(formula.operands)
-        print(formula.operators)
         let result = formula.result()
-        print(result)
-        operandsLabel.text = result.description
-        operatorLabel.text = ""
         
+        updateOperandsLabel(text: result.description)
+        initializeOpertorLabel()
     }
-
-    
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -25,9 +25,7 @@ class ViewController: UIViewController {
         stackView.spacing = 2.0
         stackView.alignment = .fill
         
-        for i in subviews {
-            stackView.addArrangedSubview(i)
-        }
+        subviews.forEach {stackView.addArrangedSubview($0)}
         
         return stackView
     }
@@ -41,8 +39,17 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpOperandButton(_ sender: UIButton) {
-        guard let operand = sender.currentTitle else {return}
-        inputLabel.text?.append(contentsOf: operand)
+        guard let newInput = sender.currentTitle, let currentInput = inputLabel.text else {return}
+        
+        if newInput == "0" {
+            inputLabel.text = "0"
+        }
+        else {
+            inputLabel.text = currentInput + newInput
+        }
+        if currentInput == "0" {
+            inputLabel.text = newInput
+        }
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -9,6 +9,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         inputLabel.text = "0"
+        operatorLabel.text = ""
     }
     
     func makeLabel(text: String?) -> UILabel {
@@ -33,7 +34,7 @@ class ViewController: UIViewController {
     func makeSmallStackView() {
         let operandLabel = makeLabel(text: self.inputLabel.text)
         let operatorLabel = makeLabel(text: self.operatorLabel.text)
-        let smallStackview = makeStackView(with: operatorLabel,operandLabel)
+        let smallStackview = makeStackView(with: operatorLabel, operandLabel)
         
         mainStackView.addArrangedSubview(smallStackview)
     }
@@ -54,13 +55,15 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle else {return}
-        operatorLabel.text = `operator`
+    
         makeSmallStackView()
         inputLabel.text = ""
+        operatorLabel.text = `operator`
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
         inputLabel.text = "0"
+        operatorLabel.text = ""
         for i in mainStackView.arrangedSubviews {
             mainStackView.removeArrangedSubview(i)
             i.removeFromSuperview()

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -44,9 +44,16 @@ class ViewController: UIViewController {
         
         if currentInput == "0" {
             inputLabel.text = newInput
+        } else {
+            inputLabel.text = currentInput + newInput
         }
         
-        inputLabel.text = currentInput + newInput
+        if newInput == "00" {
+            if currentInput == "0" || currentInput == "" {
+                inputLabel.text = "0"
+            }
+        }
+
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -113,7 +113,7 @@ class ViewController: UIViewController {
         }
     }
     
-    private func parseExpression() -> Double {
+    private func drawResultFromExpression() -> Double {
         var formula: Formula = ExpressionParser.parse(from: inputString)
         let result = formula.result()
         return result
@@ -164,7 +164,7 @@ class ViewController: UIViewController {
         guard operandsLabel.text?.isEmpty == false else {return}
         
         makeExpressionStackView()
-        updateOperandsLabel(text: parseExpression().description)
+        updateOperandsLabel(text: drawResultFromExpression().description)
         initializeOpertorLabel()
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -81,7 +81,14 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpPlusMinusButton(_ sender: UIButton) {
+        guard let currentInput = inputLabel.text else {return}
         
+        if currentInput.contains("-") {
+            inputLabel.text = currentInput.replacingOccurrences(of: "-", with: "")
+        }
+        else {
+            inputLabel.text = "-" + currentInput
+        }
     }
     
     @IBAction func touchUpDotButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -85,7 +85,9 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpDotButton(_ sender: UIButton) {
+        guard let newInput = sender.currentTitle, let currentInput = inputLabel.text else {return}
         
+        inputLabel.text = currentInput + newInput
     }
     
     @IBAction func touchUpResultButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -4,39 +4,42 @@ class ViewController: UIViewController {
 
     @IBOutlet weak var resultLabel: UILabel!
     @IBOutlet weak var operatorLabel: UILabel!
-    @IBOutlet weak var UIScrollView: UIScrollView!
-    
-    var leftOperatorLabel: UILabel {
-        let label = UILabel()
-        return label
-    }
-    
-    var rightOperandLabel: UILabel {
-        let label = UILabel()
-        return label
-    }
-    
-    var stackView: UIStackView {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.spacing = 20.0
-        stackView.alignment = .fill
-        stackView.distribution = .fillEqually
-        
-        UIScrollView.addSubview(stackView)
-        stackView.addSubview(leftOperatorLabel)
-        stackView.addSubview(rightOperandLabel)
-
-        return stackView
-    }
+    @IBOutlet weak var stackView: UIStackView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         resultLabel.text = "0"
-
-        
     }
-
+    
+    func makeLabel(text: String?) -> UILabel {
+        let label = UILabel()
+        label.textColor = .white
+        label.text = text
+        return label
+    }
+    
+    func makeStackView(with subviews: UIView...) -> UIStackView {
+        let stackView = UIStackView()
+        
+        stackView.axis = .horizontal
+        stackView.spacing = 2.0
+        stackView.alignment = .fill
+        
+        for i in subviews {
+            stackView.addArrangedSubview(i)
+        }
+        
+        return stackView
+    }
+    
+    func makeSmallStackView() {
+        let operandLabel = makeLabel(text: self.resultLabel.text)
+        let operatorLabel = makeLabel(text: self.operatorLabel.text)
+        let smallStackview = makeStackView(with: operatorLabel,operandLabel)
+        
+        stackView.addArrangedSubview(smallStackview)
+    }
+    
     @IBAction func operandButtonTapped(_ sender: UIButton) {
         guard let operand = sender.currentTitle else {return}
         resultLabel.text?.append(contentsOf: operand)
@@ -45,7 +48,7 @@ class ViewController: UIViewController {
     @IBAction func operatorButtonTapped(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle else {return}
         operatorLabel.text = `operator`
-        rightOperandLabel.text = resultLabel.text
+        makeSmallStackView()
         resultLabel.text = ""
     }
     

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -37,7 +37,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
     
     private func divide(lhs: Double, rhs: Double) throws -> Double {
         if rhs == 0 {
-            throw OperatorError.divideByZero
+//            throw OperatorError.divideByZero
         }
         return lhs / rhs
     }

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -37,7 +37,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
     
     private func divide(lhs: Double, rhs: Double) throws -> Double {
         if rhs == 0 {
-//            throw OperatorError.divideByZero
+            throw OperatorError.divideByZero
         }
         return lhs / rhs
     }

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -10,9 +10,9 @@ extension Double: CalculateItem {
 
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
-    case subtract = "_"
-    case divide = "/"
-    case multiply = "*"
+    case subtract = "−"
+    case divide = "÷"
+    case multiply = "×"
     
     func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -9,9 +9,10 @@ extension String {
 
 enum ExpressionParser {
     static func parse(from inputString: String) -> Formula {
+        print(inputString)
         let inputArrayInString = inputString.map {String($0)}
         let operandArray = componentsByOperators(from: inputString).compactMap{Double($0)}
-        let operatorArray = inputArrayInString.filter{Operator(rawValue: Character($0)) != nil}.compactMap{Operator(rawValue: Character($0))}
+        let operatorArray = [.add] + inputArrayInString.filter{Operator(rawValue: Character($0)) != nil}.compactMap{Operator(rawValue: Character($0))}
         
         let operands = CalculatorItemQueue<Double>(calculatorItems: operandArray)
         let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArray)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -12,7 +12,7 @@ enum ExpressionParser {
         print(inputString)
         let inputArrayInString = inputString.map {String($0)}
         let operandArray = componentsByOperators(from: inputString).compactMap{Double($0)}
-        let operatorArray = [.add] + inputArrayInString.filter{Operator(rawValue: Character($0)) != nil}.compactMap{Operator(rawValue: Character($0))}
+        let operatorArray = [.add] + inputArrayInString.compactMap{Operator(rawValue: Character($0))}
         
         let operands = CalculatorItemQueue<Double>(calculatorItems: operandArray)
         let operators = CalculatorItemQueue<Operator>(calculatorItems: operatorArray)

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -15,10 +15,10 @@ struct Formula {
             let lhs = result
             guard let rhs = operands.dequeue() else { return 0 }
             
-            let `operator` = operators.dequeue()
+            guard let `operator` = operators.dequeue() else {return 0}
             do {
-                let calculateResult = try `operator`?.calculate(lhs: lhs, rhs: rhs)
-                result = calculateResult ?? 0
+                let calculateResult = try `operator`.calculate(lhs: lhs, rhs: rhs)
+                result = calculateResult
             } catch {
                 print("0으로 나눌 수 없음")
             }

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -17,10 +17,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="245" width="382" height="41"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
+                                    <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
@@ -61,7 +61,7 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="BOT-7g-vxv" secondAttribute="height" priority="100" id="82c-Ko-nh3"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="BOT-7g-vxv" secondAttribute="height" id="1z4-Jq-fyY"/>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="width" secondItem="BOT-7g-vxv" secondAttribute="width" id="9hO-gT-uzB"/>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="gA2-7M-FxF" secondAttribute="height" priority="1" id="PfX-qG-S4s"/>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="leading" secondItem="K6N-nC-kaV" secondAttribute="leading" id="WTo-5t-Xde"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -364,8 +364,8 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="inputLabel" destination="Lwz-OF-XHD" id="vrH-QW-w3K"/>
                         <outlet property="mainStackView" destination="XRe-QE-UJf" id="IS0-Kj-3NT"/>
+                        <outlet property="operandsLabel" destination="Lwz-OF-XHD" id="oTw-8h-BwP"/>
                         <outlet property="operatorLabel" destination="HPC-iy-qdm" id="wkW-NX-n9A"/>
                     </connections>
                 </viewController>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -18,39 +18,39 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
+                                <rect key="frame" x="16" y="285.5" width="382" height="0.0"/>
                                 <subviews>
-                                    <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="0.0"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
+                                            <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
+                                                <rect key="frame" x="0.0" y="0.0" width="115" height="0.0"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6qF-b3-Psy">
-                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
+                                            <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6qF-b3-Psy">
+                                                <rect key="frame" x="0.0" y="0.0" width="115" height="0.0"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Z3H-3J-pqF">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U8o-Rm-zLb">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -109,6 +109,7 @@
                                                 </state>
                                                 <connections>
                                                     <action selector="plusMinusButtonChanged:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YAQ-X9-bZb"/>
+                                                    <action selector="plusMinusButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="SgJ-lY-Azc"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
@@ -364,9 +365,9 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="UIScrollView" destination="BOT-7g-vxv" id="Pyh-nK-JAF"/>
                         <outlet property="operatorLabel" destination="HPC-iy-qdm" id="wkW-NX-n9A"/>
                         <outlet property="resultLabel" destination="Lwz-OF-XHD" id="J5o-Vb-B86"/>
+                        <outlet property="stackView" destination="XRe-QE-UJf" id="aOO-kv-JCY"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -86,7 +86,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="ACButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bgW-RR-dSY"/>
+                                                    <action selector="touchUpACButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dgh-FN-Hvk"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
@@ -97,7 +97,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="CEButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="oyw-uw-pB4"/>
+                                                    <action selector="touchUpCEButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ewz-7m-a3P"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
@@ -108,8 +108,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="plusMinusButtonChanged:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YAQ-X9-bZb"/>
-                                                    <action selector="plusMinusButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="SgJ-lY-Azc"/>
+                                                    <action selector="touchUpPlusMinusButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wGe-SP-cJx"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
@@ -120,7 +119,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="suy-pI-MUJ"/>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8nE-pq-9ts"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -136,7 +135,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cgh-yd-swR"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="voR-w5-Dnz"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
@@ -147,7 +146,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ImS-Sg-hUI"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="P25-0f-gyV"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
@@ -158,7 +157,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Adx-uL-kuX"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2UK-Qx-ale"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
@@ -169,7 +168,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pYl-fh-6iW"/>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="o0P-ur-iXF"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -185,7 +184,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ezn-7O-Aeo"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8zv-HZ-kVN"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
@@ -196,7 +195,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vg2-2s-HE7"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Rbg-E4-ttF"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
@@ -207,7 +206,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uqs-0F-g9Y"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sEr-7t-HF4"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
@@ -218,7 +217,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gQE-XZ-zLT"/>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vef-8z-6mp"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -234,7 +233,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="otV-iO-BzN"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ORK-uS-IgG"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
@@ -245,7 +244,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="NTq-bg-uh7"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="co7-oS-jPY"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
@@ -256,7 +255,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="67M-MC-eB0"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ufT-IK-N1A"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
@@ -267,7 +266,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="XZQ-jt-J4m"/>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qg5-S1-lEP"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -283,7 +282,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kol-Yf-as1"/>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aqd-Bs-4iA"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
@@ -293,9 +292,6 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
-                                                <connections>
-                                                    <action selector="operandButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="S4C-vv-Wfv"/>
-                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -305,7 +301,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="dotButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LaI-11-wdS"/>
+                                                    <action selector="touchUpDotButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="F2q-Tt-4X7"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
@@ -319,7 +315,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="resultButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cds-Ir-uSW"/>
+                                                    <action selector="touchUpResultButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1FU-zJ-RBV"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -365,9 +361,9 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="inputLabel" destination="Lwz-OF-XHD" id="vrH-QW-w3K"/>
+                        <outlet property="mainStackView" destination="XRe-QE-UJf" id="IS0-Kj-3NT"/>
                         <outlet property="operatorLabel" destination="HPC-iy-qdm" id="wkW-NX-n9A"/>
-                        <outlet property="resultLabel" destination="Lwz-OF-XHD" id="J5o-Vb-B86"/>
-                        <outlet property="stackView" destination="XRe-QE-UJf" id="aOO-kv-JCY"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -292,6 +292,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="riz-hx-xZs"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -61,7 +61,7 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="BOT-7g-vxv" secondAttribute="height" id="1z4-Jq-fyY"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="BOT-7g-vxv" secondAttribute="height" priority="100" id="1z4-Jq-fyY"/>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="width" secondItem="BOT-7g-vxv" secondAttribute="width" id="9hO-gT-uzB"/>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="gA2-7M-FxF" secondAttribute="height" priority="1" id="PfX-qG-S4s"/>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="leading" secondItem="K6N-nC-kaV" secondAttribute="leading" id="WTo-5t-Xde"/>


### PR DESCRIPTION
 # 계산기 프로젝트 STEP 3 PR
안녕하세요, 콘 @protocorn93 😁
제인입니다!

계산기 프로젝트 STEP 3 PR 보냅니다...😄
요구사항을 전부 다 구현하지는 못했고 너무 부족한 코드이지만 할 수 있는만큼 열심히 해보았습니다...😭 피드백 주시는 내용 반영해서 수정하겠습니다! 이번에도 잘 부탁드립니다 😁
 
 ## 고민한 부분
 
**1. UIStackView를 코드로 생성**
 처음 기본 화면에는 UIScrollView안에 UIStackView가 있고, 그 UIStackView 안에 두개의 UIStackView가 있었습니다. 그러나 스택뷰에 스택이 몇 개 들어올 지 모르는 상황에서, UI에 스택의 개수를 지정해 줄 수 없기 때문에, 코드를 이용하여 스택뷰를 생성했습니다. 

스택이 생성될때마다 mainStackView에 서브뷰로 추가해주는 방식을 사용했습니다.
 
 ![](https://i.imgur.com/RyPEwDL.png)

 ![](https://i.imgur.com/idA3j5l.png)

```swift
 func makeLabel(text: String?) -> UILabel {
        let label = UILabel()
        label.textColor = .white
        label.text = text
        return label
    }
    
    func makeStackView(with subviews: UIView...) -> UIStackView {
        let stackView = UIStackView()
        
        stackView.axis = .horizontal
        stackView.spacing = 2.0
        stackView.alignment = .fill
        
        subviews.forEach {stackView.addArrangedSubview($0)}
        
        return stackView
    }
    
    func makeSmallStackView() {
        let operandLabel = makeLabel(text: self.inputLabel.text)
        let operatorLabel = makeLabel(text: self.operatorLabel.text)
        let smallStackview = makeStackView(with: operatorLabel, operandLabel)
        
        mainStackView.addArrangedSubview(smallStackview)
    }
```
연산자와 피연산자 레이블을 각각 만들어 준 후, 두 레이블을 담는 smallStackView를 만들어서 레이블을 서브뷰로 넣어준 뒤에 smallStackView를 mainStackView의 서브뷰로 넣어주는 방식을 사용했습니다. 연산자버튼을 누르거나, =버튼을 누를 때 makeSmallStackView() 메서드가 실행되도록 하였습니다. 

**2. 스택뷰에 존재하는 모든 서브뷰를 제거**
AC버튼을 눌렀을 때, 위에 표시된 연산 과정을 모두 지우고 싶었습니다. 따라서 removeArrangedSubview()를 통해 지우려했지만 실패하였는데 그 이유로는, stackView는 두가지 배열 subViews 와 arrangedSubViews를 가지고 있습니다. `.addArrangedSubview()` 를 통해서 arrangedSubViews에 서브뷰를 추가하면, 자동으로 subViews에도 추가되지만, subViews에 서브뷰를 추가하면 arrangedSubViews에는 추가되지 않습니다. 

따라서 arrangedSubViews의 서브뷰를 삭제하려고 removeArrangedSubview()해도 arrangedSubviews에만 삭제되고 subview에선 삭제가 되지 않아 뷰가 화면에 남아있습니다. 

따라서 removeFromSuperview() 를 호출하여 뷰를 제거하는 방식으로 해결하였습니다. 
```swift
@IBAction func touchUpACButton(_ sender: UIButton) {
    inputLabel.text = "0"
    operatorLabel.text = ""
    inputString = ""
    for i in mainStackView.arrangedSubviews {
    mainStackView.removeArrangedSubview(i)
        i.removeFromSuperview()
    }
}
```
**3. 연산자를 맨 처음 입력한 숫자 앞에는 나오게 하지 않고, 그 다음 숫자 앞에 나오게하는 방법**
`55 - 1 +` 을 할 때 

55
-1
이 나와야 하는데

-55
+1
이 나오는 현상이 발생하였습니다.

이 문제를 해결하기 위한 첫번째 시도로는 연산자와 피연산자를 묶어서 스택뷰에 넣을때 현재 연산자가 있는지 없는지 검사하고, 없으면 숫자만 있는 스택뷰를 따로 만드는 메서드를 호출하려고 했습니다. -> 실패

```swift
func makeSmallStackViewForFirst() {
    let operandLabel = makeLabel(text: self.inputLabel.text)
    let smallStackview = makeStackView(with: operandLabel)
        mainStackView.addArrangedSubview(smallStackview)
    }
```

두번째 시도로는 연산자 버튼을 누를 때 누르기 전의 연산자레이블과 숫자레이블을 스택뷰로 만들어서 서브뷰에 넣어주고, 넣어준 후에 현재 누른 연산자를 연산자레이블에 할당해주는 방법을 사용했습니다. -> 성공

```swift
@IBAction func touchUpOperatorButton(_ sender: UIButton) {
    guard let `operator` = sender.currentTitle else {return}
    guard inputLabel.text != "0" else { return }
    guard inputLabel.text?.isEmpty == false else {return}
    makeSmallStackView()
    inputString.append(`operator`)
    inputLabel.text = ""
    operatorLabel.text = `operator`
}
```

 ## 질문드리고 싶은 부분
**= 버튼 눌렀을 때 연산하는 방법**

연산하기 버튼을 눌렀을 때 입력한 값들을 모아서 연산을 하는 방법에 대해 두가지 방법으로 시도해보았습니다. 

첫번째로 생각한 방법은 스택뷰의 서브뷰들을 다 꺼내서 ExpressionParser의 parse를 통해 Formula 형태로 반환하고, Formula의 result 메서드를 통해 연산하는 방법이었습니다. 그래서 서브뷰를 꺼내는 방법에 대해 고민해보았는데 스택뷰안의 서브뷰들에 접근하여 레이블의 text를 가져오고 싶었습니다. 

아래는 서브뷰에 접근할 수 있는지 시도해본 코드입니다.
```swift
    var formula: [String?] = []
    let a = mainStackView.arrangedSubviews[2] as? UIStackView
    let operatorLabel = a?.arrangedSubviews[0] as? UILabel
    let operandLabel = a?.arrangedSubviews[1] as? UILabel
        
    let operatorLabelText = operatorLabel?.text
    let operandLabelText = operandLabel?.text
    formula.append(operandLabelText)
    formula.append(operandLabelText)
```
 그러나.. 이렇게 스택뷰 안의 스택뷰 안의 레이블에 접근하여 값을 가져오기 위해서는 이중으로 for문을 사용해야 할 것 같아서 시간복잡도가 엄청 커질 것 같아서 다른 방법을 선택했습니다.
 
뷰에서 스택뷰에 추가할 때 동시에 문자열 변수에 값을 append하여 그 문자열을 사용하는 방법을 선택했습니다. 

```swift
@IBAction func touchUpResultButton(_ sender: UIButton) {
    guard inputLabel.text != "0" else { return }
    guard inputLabel.text?.isEmpty == false else {return}
    makeSmallStackView()

    var formula: Formula = ExpressionParser.parse(from: inputString)
    let result = formula.result()
    inputLabel.text = result.description
    operatorLabel.text = ""
}
```

제가 시도해본 첫번째 방법인 뷰를 먼저 그리고 뷰에 있는 정보를 가져와서 연산을 하는 방법은 보통 사용하지 않는지 궁금합니다!



계산기에서 지켜야하는 제약사항이 많은데 전부 다 반영하지 못했습니다... ㅜㅜ 전체적으로 코드가 깔끔하지 않고 지저분한데 피드백 기반으로 수정하겠습니다! 😭