### PR TITLE
계산기(모둠) [STEP1] 고사리, Allie

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		FBFA13B1274BC3FA00E98813 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */; };
 		FBFA13B3274BC41B00E98813 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AE274BC13600E98813 /* Operator.swift */; };
 		FBFA13B4274BC43500E98813 /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D91274BC2470068931F /* CalculateError.swift */; };
+		FBFA13B8274BC66400E98813 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13B7274BC66400E98813 /* StringExtensionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 		FBFA13AC274BBD9C00E98813 /* CalculatorQueueError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorQueueError.swift; sourceTree = "<group>"; };
 		FBFA13AE274BC13600E98813 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
+		FBFA13B7274BC66400E98813 /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +104,7 @@
 			children = (
 				0DB33D83274BBEF40068931F /* CalculatorItemQueue.swift */,
 				FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */,
+				FBFA13B7274BC66400E98813 /* StringExtensionTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -268,6 +271,7 @@
 				FBFA13B3274BC41B00E98813 /* Operator.swift in Sources */,
 				0DB33D8E274BBF770068931F /* CalculatorQueueError.swift in Sources */,
 				0DB33D8F274BBF7C0068931F /* CalculateItem.swift in Sources */,
+				FBFA13B8274BC66400E98813 /* StringExtensionTests.swift in Sources */,
 				FBFA13B4274BC43500E98813 /* CalculateError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		FBFA13B3274BC41B00E98813 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AE274BC13600E98813 /* Operator.swift */; };
 		FBFA13B4274BC43500E98813 /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D91274BC2470068931F /* CalculateError.swift */; };
 		FBFA13B8274BC66400E98813 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13B7274BC66400E98813 /* StringExtensionTests.swift */; };
+		FBFA13BA274C83E300E98813 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13B9274C83E300E98813 /* Formula.swift */; };
+		FBFA13BB274C83E300E98813 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13B9274C83E300E98813 /* Formula.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +67,7 @@
 		FBFA13AE274BC13600E98813 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		FBFA13B7274BC66400E98813 /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
+		FBFA13B9274C83E300E98813 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +94,7 @@
 				0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */,
 				FBFA13AE274BC13600E98813 /* Operator.swift */,
 				0DB33D96274BC8B90068931F /* ExpressionParser.swift */,
+				FBFA13B9274C83E300E98813 /* Formula.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -269,6 +273,7 @@
 			files = (
 				0DB33D8D274BBF740068931F /* Double.swift in Sources */,
 				FBFA13B1274BC3FA00E98813 /* OperatorTests.swift in Sources */,
+				FBFA13BB274C83E300E98813 /* Formula.swift in Sources */,
 				0DB33D90274BBF800068931F /* CalcultorItemQueue.swift in Sources */,
 				0DB33D95274BC5B20068931F /* String.swift in Sources */,
 				0DB33D84274BBEF40068931F /* CalculatorItemQueue.swift in Sources */,
@@ -287,6 +292,7 @@
 			files = (
 				0DB33D7C274BBCFF0068931F /* CalculateItem.swift in Sources */,
 				0DB33D79274BBB4B0068931F /* CalcultorItemQueue.swift in Sources */,
+				FBFA13BA274C83E300E98813 /* Formula.swift in Sources */,
 				0DB33D94274BC5B20068931F /* String.swift in Sources */,
 				FBFA13AD274BBD9C00E98813 /* CalculatorQueueError.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		FBFA13AD274BBD9C00E98813 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +78,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				FBFA13AB274BBD8500E98813 /* Error */,
 				0DB33D7A274BBCEE0068931F /* Protocol */,
 				0DB33D77274BBB1C0068931F /* Model */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
@@ -87,6 +90,14 @@
 				C713D94F2570E5ED001C3AFC /* Info.plist */,
 			);
 			path = Calculator;
+			sourceTree = "<group>";
+		};
+		FBFA13AB274BBD8500E98813 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */,
+			);
+			path = Error;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -161,6 +172,7 @@
 			files = (
 				0DB33D7C274BBCFF0068931F /* CalculateItem.swift in Sources */,
 				0DB33D79274BBB4B0068931F /* CalcultorItemQueue.swift in Sources */,
+				FBFA13AD274BBD9C00E98813 /* CalculatorError.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 		FBFA13AD274BBD9C00E98813 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */; };
+		FBFA13AF274BC13600E98813 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AE274BC13600E98813 /* Operator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,7 @@
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
+		FBFA13AE274BC13600E98813 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */,
+				FBFA13AE274BC13600E98813 /* Operator.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -262,6 +265,7 @@
 				FBFA13AD274BBD9C00E98813 /* CalculatorError.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				FBFA13AF274BC13600E98813 /* Operator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				0DB33D8C274BBF610068931F /* Double.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 		FBFA13AD274BBD9C00E98813 /* CalculatorQueueError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AC274BBD9C00E98813 /* CalculatorQueueError.swift */; };
 		FBFA13AF274BC13600E98813 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AE274BC13600E98813 /* Operator.swift */; };
+		FBFA13B1274BC3FA00E98813 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */; };
+		FBFA13B3274BC41B00E98813 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AE274BC13600E98813 /* Operator.swift */; };
+		FBFA13B4274BC43500E98813 /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D91274BC2470068931F /* CalculateError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +56,7 @@
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FBFA13AC274BBD9C00E98813 /* CalculatorQueueError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorQueueError.swift; sourceTree = "<group>"; };
 		FBFA13AE274BC13600E98813 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				0DB33D83274BBEF40068931F /* CalculatorItemQueue.swift */,
+				FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -252,10 +257,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				0DB33D8D274BBF740068931F /* Double.swift in Sources */,
+				FBFA13B1274BC3FA00E98813 /* OperatorTests.swift in Sources */,
 				0DB33D90274BBF800068931F /* CalcultorItemQueue.swift in Sources */,
 				0DB33D84274BBEF40068931F /* CalculatorItemQueue.swift in Sources */,
+				FBFA13B3274BC41B00E98813 /* Operator.swift in Sources */,
 				0DB33D8E274BBF770068931F /* CalculatorQueueError.swift in Sources */,
 				0DB33D8F274BBF7C0068931F /* CalculateItem.swift in Sources */,
+				FBFA13B4274BC43500E98813 /* CalculateError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -12,16 +12,17 @@
 		0DB33D84274BBEF40068931F /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D83274BBEF40068931F /* CalculatorItemQueue.swift */; };
 		0DB33D8C274BBF610068931F /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D8B274BBF610068931F /* Double.swift */; };
 		0DB33D8D274BBF740068931F /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D8B274BBF610068931F /* Double.swift */; };
-		0DB33D8E274BBF770068931F /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */; };
+		0DB33D8E274BBF770068931F /* CalculatorQueueError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AC274BBD9C00E98813 /* CalculatorQueueError.swift */; };
 		0DB33D8F274BBF7C0068931F /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D7B274BBCFF0068931F /* CalculateItem.swift */; };
 		0DB33D90274BBF800068931F /* CalcultorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */; };
+		0DB33D92274BC2470068931F /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D91274BC2470068931F /* CalculateError.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
-		FBFA13AD274BBD9C00E98813 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */; };
+		FBFA13AD274BBD9C00E98813 /* CalculatorQueueError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AC274BBD9C00E98813 /* CalculatorQueueError.swift */; };
 		FBFA13AF274BC13600E98813 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AE274BC13600E98813 /* Operator.swift */; };
 /* End PBXBuildFile section */
 
@@ -41,6 +42,7 @@
 		0DB33D81274BBEF40068931F /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0DB33D83274BBEF40068931F /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		0DB33D8B274BBF610068931F /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
+		0DB33D91274BC2470068931F /* CalculateError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateError.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -49,7 +51,7 @@
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
+		FBFA13AC274BBD9C00E98813 /* CalculatorQueueError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorQueueError.swift; sourceTree = "<group>"; };
 		FBFA13AE274BC13600E98813 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -143,7 +145,8 @@
 		FBFA13AB274BBD8500E98813 /* Error */ = {
 			isa = PBXGroup;
 			children = (
-				FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */,
+				FBFA13AC274BBD9C00E98813 /* CalculatorQueueError.swift */,
+				0DB33D91274BC2470068931F /* CalculateError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -251,7 +254,7 @@
 				0DB33D8D274BBF740068931F /* Double.swift in Sources */,
 				0DB33D90274BBF800068931F /* CalcultorItemQueue.swift in Sources */,
 				0DB33D84274BBEF40068931F /* CalculatorItemQueue.swift in Sources */,
-				0DB33D8E274BBF770068931F /* CalculatorError.swift in Sources */,
+				0DB33D8E274BBF770068931F /* CalculatorQueueError.swift in Sources */,
 				0DB33D8F274BBF7C0068931F /* CalculateItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -262,11 +265,12 @@
 			files = (
 				0DB33D7C274BBCFF0068931F /* CalculateItem.swift in Sources */,
 				0DB33D79274BBB4B0068931F /* CalcultorItemQueue.swift in Sources */,
-				FBFA13AD274BBD9C00E98813 /* CalculatorError.swift in Sources */,
+				FBFA13AD274BBD9C00E98813 /* CalculatorQueueError.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				FBFA13AF274BC13600E98813 /* Operator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				0DB33D92274BC2470068931F /* CalculateError.swift in Sources */,
 				0DB33D8C274BBF610068931F /* Double.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		0DB33D8F274BBF7C0068931F /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D7B274BBCFF0068931F /* CalculateItem.swift */; };
 		0DB33D90274BBF800068931F /* CalcultorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */; };
 		0DB33D92274BC2470068931F /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D91274BC2470068931F /* CalculateError.swift */; };
+		0DB33D94274BC5B20068931F /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D93274BC5B20068931F /* String.swift */; };
+		0DB33D95274BC5B20068931F /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D93274BC5B20068931F /* String.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -46,6 +48,7 @@
 		0DB33D83274BBEF40068931F /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		0DB33D8B274BBF610068931F /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
 		0DB33D91274BC2470068931F /* CalculateError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateError.swift; sourceTree = "<group>"; };
+		0DB33D93274BC5B20068931F /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -107,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				0DB33D8B274BBF610068931F /* Double.swift */,
+				0DB33D93274BC5B20068931F /* String.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -259,6 +263,7 @@
 				0DB33D8D274BBF740068931F /* Double.swift in Sources */,
 				FBFA13B1274BC3FA00E98813 /* OperatorTests.swift in Sources */,
 				0DB33D90274BBF800068931F /* CalcultorItemQueue.swift in Sources */,
+				0DB33D95274BC5B20068931F /* String.swift in Sources */,
 				0DB33D84274BBEF40068931F /* CalculatorItemQueue.swift in Sources */,
 				FBFA13B3274BC41B00E98813 /* Operator.swift in Sources */,
 				0DB33D8E274BBF770068931F /* CalculatorQueueError.swift in Sources */,
@@ -273,6 +278,7 @@
 			files = (
 				0DB33D7C274BBCFF0068931F /* CalculateItem.swift in Sources */,
 				0DB33D79274BBB4B0068931F /* CalcultorItemQueue.swift in Sources */,
+				0DB33D94274BC5B20068931F /* String.swift in Sources */,
 				FBFA13AD274BBD9C00E98813 /* CalculatorQueueError.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		FBFA13B8274BC66400E98813 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13B7274BC66400E98813 /* StringExtensionTests.swift */; };
 		FBFA13BA274C83E300E98813 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13B9274C83E300E98813 /* Formula.swift */; };
 		FBFA13BB274C83E300E98813 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13B9274C83E300E98813 /* Formula.swift */; };
+		FBFA13BD274C8B7D00E98813 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13BC274C8B7D00E98813 /* FormulaTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,6 +71,7 @@
 		FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		FBFA13B7274BC66400E98813 /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		FBFA13B9274C83E300E98813 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		FBFA13BC274C8B7D00E98813 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 				FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */,
 				FBFA13B7274BC66400E98813 /* StringExtensionTests.swift */,
 				0DB33D99274C88340068931F /* ExpressionParserTests.swift */,
+				FBFA13BC274C8B7D00E98813 /* FormulaTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -274,6 +277,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FBFA13BD274C8B7D00E98813 /* FormulaTests.swift in Sources */,
 				0DB33D8D274BBF740068931F /* Double.swift in Sources */,
 				FBFA13B1274BC3FA00E98813 /* OperatorTests.swift in Sources */,
 				FBFA13BB274C83E300E98813 /* Formula.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -9,6 +9,12 @@
 /* Begin PBXBuildFile section */
 		0DB33D79274BBB4B0068931F /* CalcultorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */; };
 		0DB33D7C274BBCFF0068931F /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D7B274BBCFF0068931F /* CalculateItem.swift */; };
+		0DB33D84274BBEF40068931F /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D83274BBEF40068931F /* CalculatorItemQueue.swift */; };
+		0DB33D8C274BBF610068931F /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D8B274BBF610068931F /* Double.swift */; };
+		0DB33D8D274BBF740068931F /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D8B274BBF610068931F /* Double.swift */; };
+		0DB33D8E274BBF770068931F /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */; };
+		0DB33D8F274BBF7C0068931F /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D7B274BBCFF0068931F /* CalculateItem.swift */; };
+		0DB33D90274BBF800068931F /* CalcultorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -18,9 +24,22 @@
 		FBFA13AD274BBD9C00E98813 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA13AC274BBD9C00E98813 /* CalculatorError.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		0DB33D85274BBEF40068931F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcultorItemQueue.swift; sourceTree = "<group>"; };
 		0DB33D7B274BBCFF0068931F /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
+		0DB33D81274BBEF40068931F /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0DB33D83274BBEF40068931F /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
+		0DB33D8B274BBF610068931F /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -33,6 +52,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0DB33D7E274BBEF40068931F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93B2570E5EB001C3AFC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -59,10 +85,27 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		0DB33D82274BBEF40068931F /* CalculatorTests */ = {
+			isa = PBXGroup;
+			children = (
+				0DB33D83274BBEF40068931F /* CalculatorItemQueue.swift */,
+			);
+			path = CalculatorTests;
+			sourceTree = "<group>";
+		};
+		0DB33D8A274BBF520068931F /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				0DB33D8B274BBF610068931F /* Double.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
+				0DB33D82274BBEF40068931F /* CalculatorTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -71,6 +114,7 @@
 			isa = PBXGroup;
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
+				0DB33D81274BBEF40068931F /* CalculatorTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -78,6 +122,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				0DB33D8A274BBF520068931F /* Extension */,
 				FBFA13AB274BBD8500E98813 /* Error */,
 				0DB33D7A274BBCEE0068931F /* Protocol */,
 				0DB33D77274BBB1C0068931F /* Model */,
@@ -103,6 +148,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0DB33D80274BBEF40068931F /* CalculatorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0DB33D89274BBEF40068931F /* Build configuration list for PBXNativeTarget "CalculatorTests" */;
+			buildPhases = (
+				0DB33D7D274BBEF40068931F /* Sources */,
+				0DB33D7E274BBEF40068931F /* Frameworks */,
+				0DB33D7F274BBEF40068931F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0DB33D86274BBEF40068931F /* PBXTargetDependency */,
+			);
+			name = CalculatorTests;
+			productName = CalculatorTests;
+			productReference = 0DB33D81274BBEF40068931F /* CalculatorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -126,9 +189,13 @@
 		C713D9362570E5EB001C3AFC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1310;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					0DB33D80274BBEF40068931F = {
+						CreatedOnToolsVersion = 13.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -148,11 +215,19 @@
 			projectRoot = "";
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
+				0DB33D80274BBEF40068931F /* CalculatorTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0DB33D7F274BBEF40068931F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93C2570E5EB001C3AFC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -166,6 +241,18 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0DB33D7D274BBEF40068931F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0DB33D8D274BBF740068931F /* Double.swift in Sources */,
+				0DB33D90274BBF800068931F /* CalcultorItemQueue.swift in Sources */,
+				0DB33D84274BBEF40068931F /* CalculatorItemQueue.swift in Sources */,
+				0DB33D8E274BBF770068931F /* CalculatorError.swift in Sources */,
+				0DB33D8F274BBF7C0068931F /* CalculateItem.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -176,10 +263,19 @@
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				0DB33D8C274BBF610068931F /* Double.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0DB33D86274BBEF40068931F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 0DB33D85274BBEF40068931F /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C713D9472570E5EB001C3AFC /* Main.storyboard */ = {
@@ -201,6 +297,55 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		0DB33D87274BBEF40068931F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = gosari.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		0DB33D88274BBEF40068931F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = gosari.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
 		C713D9502570E5ED001C3AFC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -363,6 +508,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0DB33D89274BBEF40068931F /* Build configuration list for PBXNativeTarget "CalculatorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0DB33D87274BBEF40068931F /* Debug */,
+				0DB33D88274BBEF40068931F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C713D9392570E5EB001C3AFC /* Build configuration list for PBXProject "Calculator" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		0DB33D92274BC2470068931F /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D91274BC2470068931F /* CalculateError.swift */; };
 		0DB33D94274BC5B20068931F /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D93274BC5B20068931F /* String.swift */; };
 		0DB33D95274BC5B20068931F /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D93274BC5B20068931F /* String.swift */; };
+		0DB33D97274BC8B90068931F /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D96274BC8B90068931F /* ExpressionParser.swift */; };
+		0DB33D98274BC8B90068931F /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D96274BC8B90068931F /* ExpressionParser.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -50,6 +52,7 @@
 		0DB33D8B274BBF610068931F /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
 		0DB33D91274BC2470068931F /* CalculateError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateError.swift; sourceTree = "<group>"; };
 		0DB33D93274BC5B20068931F /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		0DB33D96274BC8B90068931F /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -87,6 +90,7 @@
 			children = (
 				0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */,
 				FBFA13AE274BC13600E98813 /* Operator.swift */,
+				0DB33D96274BC8B90068931F /* ExpressionParser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -272,6 +276,7 @@
 				0DB33D8E274BBF770068931F /* CalculatorQueueError.swift in Sources */,
 				0DB33D8F274BBF7C0068931F /* CalculateItem.swift in Sources */,
 				FBFA13B8274BC66400E98813 /* StringExtensionTests.swift in Sources */,
+				0DB33D98274BC8B90068931F /* ExpressionParser.swift in Sources */,
 				FBFA13B4274BC43500E98813 /* CalculateError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -289,6 +294,7 @@
 				FBFA13AF274BC13600E98813 /* Operator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				0DB33D92274BC2470068931F /* CalculateError.swift in Sources */,
+				0DB33D97274BC8B90068931F /* ExpressionParser.swift in Sources */,
 				0DB33D8C274BBF610068931F /* Double.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0DB33D79274BBB4B0068931F /* CalcultorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */; };
+		0DB33D7C274BBCFF0068931F /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D7B274BBCFF0068931F /* CalculateItem.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -18,6 +19,7 @@
 
 /* Begin PBXFileReference section */
 		0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcultorItemQueue.swift; sourceTree = "<group>"; };
+		0DB33D7B274BBCFF0068931F /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -47,6 +49,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		0DB33D7A274BBCEE0068931F /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				0DB33D7B274BBCFF0068931F /* CalculateItem.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
@@ -66,6 +76,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				0DB33D7A274BBCEE0068931F /* Protocol */,
 				0DB33D77274BBB1C0068931F /* Model */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
@@ -148,6 +159,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0DB33D7C274BBCFF0068931F /* CalculateItem.swift in Sources */,
 				0DB33D79274BBB4B0068931F /* CalcultorItemQueue.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0DB33D79274BBB4B0068931F /* CalcultorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalcultorItemQueue.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -37,6 +39,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0DB33D77274BBB1C0068931F /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				0DB33D78274BBB4B0068931F /* CalcultorItemQueue.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
@@ -56,6 +66,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				0DB33D77274BBB1C0068931F /* Model */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
 				C713D9452570E5EB001C3AFC /* ViewController.swift */,
@@ -137,6 +148,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0DB33D79274BBB4B0068931F /* CalcultorItemQueue.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0DB33D95274BC5B20068931F /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D93274BC5B20068931F /* String.swift */; };
 		0DB33D97274BC8B90068931F /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D96274BC8B90068931F /* ExpressionParser.swift */; };
 		0DB33D98274BC8B90068931F /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D96274BC8B90068931F /* ExpressionParser.swift */; };
+		0DB33D9A274C88340068931F /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB33D99274C88340068931F /* ExpressionParserTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -55,6 +56,7 @@
 		0DB33D91274BC2470068931F /* CalculateError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateError.swift; sourceTree = "<group>"; };
 		0DB33D93274BC5B20068931F /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		0DB33D96274BC8B90068931F /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		0DB33D99274C88340068931F /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 				0DB33D83274BBEF40068931F /* CalculatorItemQueue.swift */,
 				FBFA13B0274BC3FA00E98813 /* OperatorTests.swift */,
 				FBFA13B7274BC66400E98813 /* StringExtensionTests.swift */,
+				0DB33D99274C88340068931F /* ExpressionParserTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -278,6 +281,7 @@
 				0DB33D95274BC5B20068931F /* String.swift in Sources */,
 				0DB33D84274BBEF40068931F /* CalculatorItemQueue.swift in Sources */,
 				FBFA13B3274BC41B00E98813 /* Operator.swift in Sources */,
+				0DB33D9A274C88340068931F /* ExpressionParserTests.swift in Sources */,
 				0DB33D8E274BBF770068931F /* CalculatorQueueError.swift in Sources */,
 				0DB33D8F274BBF7C0068931F /* CalculateItem.swift in Sources */,
 				FBFA13B8274BC66400E98813 /* StringExtensionTests.swift in Sources */,

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,22 +18,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -40,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -265,19 +266,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>

--- a/Calculator/Calculator/Error/CalculateError.swift
+++ b/Calculator/Calculator/Error/CalculateError.swift
@@ -1,0 +1,19 @@
+//
+//  CalculateError.swift
+//  Calculator
+//
+//  Created by 고은 on 2021/11/22.
+//
+
+import Foundation
+
+enum CalculateError: Error, CustomStringConvertible {
+    case divideByZero
+    
+    var description: String {
+        switch self {
+        case .divideByZero:
+                    return "Cannot divide by zero"
+        }
+    }
+}

--- a/Calculator/Calculator/Error/CalculatorError.swift
+++ b/Calculator/Calculator/Error/CalculatorError.swift
@@ -1,0 +1,19 @@
+//
+//  CalculatorError.swift
+//  Calculator
+//
+//  Created by 박우연 on 2021/11/22.
+//
+
+import Foundation
+
+enum CalculatorError: Error, CustomStringConvertible {
+    case emptyQueue
+    
+    var description: String {
+        switch self {
+        case .emptyQueue:
+            return "Queue is Empty"
+        }
+    }
+}

--- a/Calculator/Calculator/Error/CalculatorQueueError.swift
+++ b/Calculator/Calculator/Error/CalculatorQueueError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum CalculatorError: Error, CustomStringConvertible {
+enum CalculatorQueueError: Error, CustomStringConvertible {
     case emptyQueue
     
     var description: String {

--- a/Calculator/Calculator/Extension/Double.swift
+++ b/Calculator/Calculator/Extension/Double.swift
@@ -1,0 +1,12 @@
+//
+//  Double.swift
+//  Calculator
+//
+//  Created by 고은 on 2021/11/22.
+//
+
+import Foundation
+
+extension Double: CalculateItem {
+    
+}

--- a/Calculator/Calculator/Extension/String.swift
+++ b/Calculator/Calculator/Extension/String.swift
@@ -1,0 +1,14 @@
+//
+//  String.swift
+//  Calculator
+//
+//  Created by 고은 on 2021/11/22.
+//
+
+import Foundation
+
+extension String {
+    func split(with target: Character) -> [String] {
+        self.split(separator: target).map { String($0) }
+    }
+}

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CalculatorItemQueue<Element> {
+struct CalculatorItemQueue<Element: CalculateItem> {
     private(set) var enQueueElements: [Element] = []
     private(set) var deQueueElements: [Element] = []
     

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -11,6 +11,10 @@ struct CalculatorItemQueue<Element: CalculateItem> {
     private(set) var enQueueElements: [Element] = []
     private(set) var deQueueElements: [Element] = []
     
+    var isEmpty: Bool {
+        return enQueueElements.isEmpty && deQueueElements.isEmpty
+    }
+    
     init(_ enQueueElements: [Element]) {
         self.enQueueElements = enQueueElements
     }

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -17,7 +17,7 @@ struct CalculatorItemQueue<Element: CalculateItem> {
     
     mutating func deQueueFirstElement() throws -> Element {
         if enQueueElements.isEmpty && deQueueElements.isEmpty {
-            throw CalculatorError.emptyQueue
+            throw CalculatorQueueError.emptyQueue
         }
         if deQueueElements.isEmpty {
             deQueueElements = enQueueElements.reversed()

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -1,0 +1,17 @@
+//
+//  CalcultorItemQueue.swift
+//  Calculator
+//
+//  Created by 고은 on 2021/11/22.
+//
+
+import Foundation
+
+struct CalculatorItemQueue<Element> {
+    private(set) var enQueueElements: [Element] = []
+    private(set) var deQueueElements: [Element] = []
+    
+    mutating func enQueueElement(_ element: Element) {
+        enQueueElements.append(element)
+    }
+}

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -11,6 +11,10 @@ struct CalculatorItemQueue<Element: CalculateItem> {
     private(set) var enQueueElements: [Element] = []
     private(set) var deQueueElements: [Element] = []
     
+    init(_ enQueueElements: [Element]) {
+        self.enQueueElements = enQueueElements
+    }
+    
     mutating func enQueueElement(_ element: Element) {
         enQueueElements.append(element)
     }

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -14,4 +14,15 @@ struct CalculatorItemQueue<Element> {
     mutating func enQueueElement(_ element: Element) {
         enQueueElements.append(element)
     }
+    
+    mutating func deQueueFirstElement() -> Element {
+        if enQueueElements.isEmpty && deQueueElements.isEmpty {
+            fatalError("Queue is empty")
+        }
+        if deQueueElements.isEmpty {
+            deQueueElements = enQueueElements.reversed()
+            enQueueElements.removeAll()
+        }
+        return deQueueElements.removeLast()
+    }
 }

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -15,9 +15,9 @@ struct CalculatorItemQueue<Element: CalculateItem> {
         enQueueElements.append(element)
     }
     
-    mutating func deQueueFirstElement() -> Element {
+    mutating func deQueueFirstElement() throws -> Element {
         if enQueueElements.isEmpty && deQueueElements.isEmpty {
-            fatalError("Queue is empty")
+            throw CalculatorError.emptyQueue
         }
         if deQueueElements.isEmpty {
             deQueueElements = enQueueElements.reversed()

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,0 +1,22 @@
+//
+//  ExpressionParser.swift
+//  Calculator
+//
+//  Created by 고은 on 2021/11/22.
+//
+
+import Foundation
+
+enum ExpressionParser {
+    private static func componentsByOperators(from input: String) -> [String] {
+            var result: [String] = [input]
+            Operator.allCases.forEach { targetOperator in
+                var splitedString: [String] = []
+                for input in result {
+                    splitedString += input.split(with: targetOperator.rawValue)
+                    result = splitedString
+                }
+            }
+            return result
+        }
+}

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -8,15 +8,26 @@
 import Foundation
 
 enum ExpressionParser {
-    private static func componentsByOperators(from input: String) -> [String] {
-        var result: [String] = [input]
-        Operator.allCases.forEach { targetOperator in
-            var splitedString: [String] = []
-            for input in result {
-                splitedString += input.split(with: targetOperator.rawValue)
-                result = splitedString
-            }
+    enum ExpressionParser {
+        static func parse(from input: String) -> Formula {
+            let operands = componentsByOperators(from: input).compactMap { Double($0) }
+            let operators = input.compactMap { Operator(rawValue: $0) }
+            return Formula(
+                operands: CalculatorItemQueue(operands),
+                operators: CalculatorItemQueue(operators)
+            )
         }
-        return result
+        
+        private static func componentsByOperators(from input: String) -> [String] {
+            var result: [String] = [input]
+            Operator.allCases.forEach { targetOperator in
+                var splitedString: [String] = []
+                for input in result {
+                    splitedString += input.split(with: targetOperator.rawValue)
+                    result = splitedString
+                }
+            }
+            return result
+        }
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -9,14 +9,14 @@ import Foundation
 
 enum ExpressionParser {
     private static func componentsByOperators(from input: String) -> [String] {
-            var result: [String] = [input]
-            Operator.allCases.forEach { targetOperator in
-                var splitedString: [String] = []
-                for input in result {
-                    splitedString += input.split(with: targetOperator.rawValue)
-                    result = splitedString
-                }
+        var result: [String] = [input]
+        Operator.allCases.forEach { targetOperator in
+            var splitedString: [String] = []
+            for input in result {
+                splitedString += input.split(with: targetOperator.rawValue)
+                result = splitedString
             }
-            return result
         }
+        return result
+    }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -8,26 +8,24 @@
 import Foundation
 
 enum ExpressionParser {
-    enum ExpressionParser {
-        static func parse(from input: String) -> Formula {
-            let operands = componentsByOperators(from: input).compactMap { Double($0) }
-            let operators = input.compactMap { Operator(rawValue: $0) }
-            return Formula(
-                operands: CalculatorItemQueue(operands),
-                operators: CalculatorItemQueue(operators)
-            )
-        }
-        
-        private static func componentsByOperators(from input: String) -> [String] {
-            var result: [String] = [input]
-            Operator.allCases.forEach { targetOperator in
-                var splitedString: [String] = []
-                for input in result {
-                    splitedString += input.split(with: targetOperator.rawValue)
-                    result = splitedString
-                }
+    static func parse(from input: String) -> Formula {
+        let operands = componentsByOperators(from: input).compactMap { Double($0) }
+        let operators = input.compactMap { Operator(rawValue: $0) }
+        return Formula(
+            operands: CalculatorItemQueue(operands),
+            operators: CalculatorItemQueue(operators)
+        )
+    }
+    
+    private static func componentsByOperators(from input: String) -> [String] {
+        var result: [String] = [input]
+        Operator.allCases.forEach { targetOperator in
+            var splitedString: [String] = []
+            for input in result {
+                splitedString += input.split(with: targetOperator.rawValue)
+                result = splitedString
             }
-            return result
         }
+        return result
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,0 +1,13 @@
+//
+//  Formula.swift
+//  Calculator
+//
+//  Created by 박우연 on 2021/11/23.
+//
+
+import Foundation
+
+struct Formula {
+    var operands: CalculatorItemQueue<Double>
+    var operators: CalculatorItemQueue<Operator>
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -10,4 +10,16 @@ import Foundation
 struct Formula {
     var operands: CalculatorItemQueue<Double>
     var operators: CalculatorItemQueue<Operator>
+    
+    mutating func result() throws -> Double {
+        let operand = try operands.deQueueFirstElement()
+        var result = operand
+        
+        while !operators.isEmpty {
+            let `operator` = try operators.deQueueFirstElement()
+            let rhs = try operands.deQueueFirstElement()
+            result = try `operator`.calculate(lhs: result, rhs: rhs)
+        }
+        return result
+    }
 }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -13,6 +13,22 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "/"
     case multiply = "*"
     
+    func calculate(lhs: Double, rhs: Double) throws -> Double {
+        switch self {
+        case .add:
+            return add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            return subtract(lhs: lhs, rhs: rhs)
+        case .divide:
+            if rhs == 0 {
+                throw CalculateError.divideByZero
+            }
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
+        }
+    }
+    
     private func add(lhs: Double, rhs: Double) -> Double {
         lhs + rhs
     }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -1,0 +1,31 @@
+//
+//  Operator.swift
+//  Calculator
+//
+//  Created by 박우연 on 2021/11/22.
+//
+
+import Foundation
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+"
+    case subtract = "_"
+    case divide = "/"
+    case multiply = "*"
+    
+    private func add(lhs: Double, rhs: Double) -> Double {
+        lhs + rhs
+    }
+    
+    private func subtract(lhs: Double, rhs: Double) -> Double {
+        lhs - rhs
+    }
+    
+    private func divide(lhs: Double, rhs: Double) -> Double {
+        return lhs / rhs
+    }
+    
+    private func multiply(lhs: Double, rhs: Double) -> Double {
+        lhs * rhs
+    }
+}

--- a/Calculator/Calculator/Protocol/CalculateItem.swift
+++ b/Calculator/Calculator/Protocol/CalculateItem.swift
@@ -1,0 +1,12 @@
+//
+//  CalculateItem.swift
+//  Calculator
+//
+//  Created by 고은 on 2021/11/22.
+//
+
+import Foundation
+
+protocol CalculateItem {
+    
+}

--- a/Calculator/CalculatorTests/CalculatorItemQueue.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueue.swift
@@ -1,0 +1,48 @@
+//
+//  CalculatorTests.swift
+//  CalculatorTests
+//
+//  Created by 고은 on 2021/11/22.
+//
+
+import XCTest
+
+class CalculatorItemQueueTests: XCTestCase {
+    var sut: CalculatorItemQueue<Double>!
+   
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = CalculatorItemQueue()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_enQueue에_요소를_추가했을때_잘들어가는지() {
+        sut.enQueueElement(1)
+        
+        XCTAssertEqual(sut.enQueueElements, [1])
+    }
+    
+    func test_enQueue에_여러개의_요소를_추가했을때_잘들어가는지() {
+        sut.enQueueElement(1)
+        sut.enQueueElement(2)
+        sut.enQueueElement(3)
+        
+        XCTAssertEqual(sut.enQueueElements, [1, 2, 3])
+    }
+    
+    func test_deQueue를_실행했을때_빈배열이면_에러를던지는지() {
+        XCTAssertThrowsError(try sut.deQueueFirstElement())
+    }
+    
+    func test_enQueue에_요소여러개를_추가하고_deQueue했을때_마지막요소가_빠지는지() {
+        sut.enQueueElement(1)
+        sut.enQueueElement(2)
+        sut.enQueueElement(3)
+        
+        XCTAssertEqual(try sut.deQueueFirstElement(), 1)
+    }
+}

--- a/Calculator/CalculatorTests/CalculatorItemQueue.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueue.swift
@@ -12,7 +12,7 @@ class CalculatorItemQueueTests: XCTestCase {
    
     override func setUpWithError() throws {
         try super.setUpWithError()
-        sut = CalculatorItemQueue()
+        sut = CalculatorItemQueue([])
     }
 
     override func tearDownWithError() throws {

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -1,0 +1,48 @@
+//
+//  ExpressionParserTests.swift
+//  CalculatorTests
+//
+//  Created by 고은 on 2021/11/23.
+//
+
+import XCTest
+
+class ExpressionParserTests: XCTestCase {
+    var sut: ExpressionParser.Type!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = ExpressionParser.self
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    //MARK: - componentsByOperators()
+    func test_parse메서드를_호출했을때_정수와_음수가섞인_피연산자가_반환되는지() {
+        var operands = sut.parse(from: "1+2_-3*4/5").operands
+        
+        [1.0, 2.0, -3.0, 4.0, 5.0].forEach { element in
+            XCTAssertEqual(element, try! operands.deQueueFirstElement())
+        }
+    }
+    
+    //MARK: - parse()
+    func test_parse메서드를_호출했을때_피연산자가_반환되는지() {
+        var operands = sut.parse(from: "10+3_7*5/2").operands
+        
+        [10.0, 3.0, 7.0, 5.0, 2.0].forEach { element in
+            XCTAssertEqual(element, try! operands.deQueueFirstElement())
+        }
+    }
+    
+    func test_parse메서드를_호출했을때_연산자가_반환되는지() {
+        var operators = sut.parse(from: "10+3_7*5/2").operators
+        
+        [Operator.add, Operator.subtract, Operator.multiply, Operator.divide].forEach { element in
+            XCTAssertEqual(element, try! operators.deQueueFirstElement())
+        }
+    }
+}

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -1,0 +1,70 @@
+//
+//  FormulaTests.swift
+//  CalculatorTests
+//
+//  Created by 박우연 on 2021/11/23.
+//
+
+import XCTest
+
+class FormulaTests: XCTestCase {
+    var operands: CalculatorItemQueue<Double>!
+    var operators: CalculatorItemQueue<Operator>!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        operands = CalculatorItemQueue<Double>([])
+        operators = CalculatorItemQueue<Operator>([])
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        operands = nil
+        operators = nil
+    }
+    
+    func test_result메서드를_호출했을때_더하기가_잘되는지() {
+        operands.enQueueElement(1994)
+        operands.enQueueElement(1004)
+        operators.enQueueElement(Operator.add)
+        var formula = Formula(operands: operands, operators: operators)
+        
+        XCTAssertEqual(try formula.result(), 2998)
+    }
+    
+    func test_result메서드를_호출했을때_빼기가_잘되는지() {
+        operands.enQueueElement(1994)
+        operands.enQueueElement(1004)
+        operators.enQueueElement(Operator.subtract)
+        var formula = Formula(operands: operands, operators: operators)
+        
+        XCTAssertEqual(try formula.result(), 990)
+    }
+    
+    func test_result메서드를_호출했을때_곱하기가_잘되는지() {
+        operands.enQueueElement(10)
+        operands.enQueueElement(4)
+        operators.enQueueElement(Operator.multiply)
+        var formula = Formula(operands: operands, operators: operators)
+        
+        XCTAssertEqual(try formula.result(), 40)
+    }
+    
+    func test_result메서드를_호출했을때_나누기가_잘되는지() {
+        operands.enQueueElement(10)
+        operands.enQueueElement(4)
+        operators.enQueueElement(Operator.divide)
+        var formula = Formula(operands: operands, operators: operators)
+        
+        XCTAssertEqual(try formula.result(), 2.5)
+    }
+   
+    func test_0으로_나누려고할때_에러를_던지는지() {
+        operands.enQueueElement(10)
+        operands.enQueueElement(0)
+        operators.enQueueElement(Operator.divide)
+        var formula = Formula(operands: operands, operators: operators)
+        
+        XCTAssertThrowsError(try formula.result())
+    }
+}

--- a/Calculator/CalculatorTests/OperatorTests.swift
+++ b/Calculator/CalculatorTests/OperatorTests.swift
@@ -1,0 +1,46 @@
+//
+//  OperatorTests.swift
+//  CalculatorTests
+//
+//  Created by 박우연 on 2021/11/22.
+//
+
+import XCTest
+
+class OperatorTests: XCTestCase {
+    var sut: Operator!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Operator(rawValue: "+")
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+
+    func test_when_case_is_add() {
+        sut = .add
+        
+        XCTAssertEqual(try sut.calculate(lhs: 10, rhs: 4), 14)
+    }
+    
+    func test_when_case_is_subtract() {
+        sut = .subtract
+        
+        XCTAssertEqual(try sut.calculate(lhs: 10, rhs: 4), 6)
+    }
+    
+    func test_when_case_is_divide() {
+        sut = .divide
+        
+        XCTAssertEqual(try sut.calculate(lhs: 10, rhs: 4), 2.5)
+    }
+    
+    func test_when_case_is_multiply() {
+        sut = .multiply
+
+        XCTAssertEqual(try sut.calculate(lhs: 10, rhs: 4), 40)
+    }
+}

--- a/Calculator/CalculatorTests/StringExtensionTests.swift
+++ b/Calculator/CalculatorTests/StringExtensionTests.swift
@@ -1,0 +1,41 @@
+//
+//  StringExtensionTests.swift
+//  CalculatorTests
+//
+//  Created by 박우연 on 2021/11/22.
+//
+
+import XCTest
+
+class StringExtensionTests: XCTestCase {
+    var sut: String = ""
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+    }
+    
+    func test_문자열_1더하기2가_연산자를_제외하고_배열로_반환되는지() {
+        let input = "1+2"
+        let result = input.split(with: "+")
+        
+        XCTAssertEqual(result, ["1", "2"])
+    }
+    
+    func test_여러문자열이_연산자를_제외하고_배열로_반환되는지() {
+        let input = "2+3+4+6+7"
+        let result = input.split(with: "+")
+        
+        XCTAssertEqual(result, ["2", "3", "4", "6", "7"])
+    }
+    
+    func test_연산자가_여러개일때_타겟연산자를_제외하고_문자열로_반환하는지() {
+        let input = "2+3-4*6/7+8"
+        let result = input.split(with: "+")
+        
+        XCTAssertEqual(result, ["2", "3-4*6/7", "8"])
+    }
+}


### PR DESCRIPTION
안녕하세요 엘림! @lina0322 ☺️
계산기(모둠) 9모둠 고사리와 앨리입니다!

사전에 말씀드렸던대로, 이전 개인 프로젝트의 진도를 반영하여 step2까지만 병합해보았습니다 :)
리팩토링을 해보려고 했는데 이번 프로젝트 step2가 리팩토링이어서 그냥 두었습니다.
부족한 점이 많겠지만, 잘 부탁드려요! 감사합니다ㅎㅎ

## 고민했던 점 및 조언을 얻고 싶은 부분
1. `linked list` vs `double stack` : linkedList는 자료 중간의 요소를 꺼내올 경우 유리하다고 판단하였습니다. 하지만 이번 계산기 프로젝트는 앞선 경우가 필요하지 않다고 판단하였기 때문에 공간복잡도 측면에서 낫다고 생각하여, doubleStack을 선택하였습니다.
    1. 고정 공간을 고려하여 공간 복잡도를 계산하였습니다. 다만, 구글링에서는 두 자료구조의 공간복잡도가 동일하다고 확인되었습니다. 엘림은 이 부분에 대해서 어떻게 생각하시는지 궁금합니다.
2. 더블스택 vs 배열
    
    비슷한 방법의 두 자료구조를 생각해보았습니다. b가 아닌 더블스택을 사용해야 하는 명확한 이유가 있을까요?
    
    1. `double stack` → enqueue stack, dequeue stack으로 나누어 dequeue()를 호출할 때, enqueue stack의 요소들을 reversed해서 dequeue stack으로 집어넣어 removeLast하는 방법
    2. `array` → array 하나만을 생성하여 reversed - removeLast - reversed의 순서로 가는 방법
3. reversed()의 시간복잡도: [공식문서](https://developer.apple.com/documentation/swift/array/1690025-reversed)에서는 시간복잡도를 O(1)이라고 기재했는데, 저희가 CalculatorItemQueue에서 사용한 reversed는 시간복잡도를 O(n)이라고 보여주고 있습니다. 공식문서에서 말하는 O(1)이 특정 케이스로 한정하여 말하는 건지 고민됩니다. 엘림은 어떻게 생각하시나요?