### PR TITLE
계산기(모둠) [Step1] 알라딘, 호박

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2514146C274C7DE60086B0A8 /* CalculateItemQueueError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2514146B274C7DE60086B0A8 /* CalculateItemQueueError.swift */; };
+		2514146E274CBA620086B0A8 /* NumberFormatError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2514146D274CBA620086B0A8 /* NumberFormatError.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
@@ -45,6 +46,7 @@
 
 /* Begin PBXFileReference section */
 		2514146B274C7DE60086B0A8 /* CalculateItemQueueError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItemQueueError.swift; sourceTree = "<group>"; };
+		2514146D274CBA620086B0A8 /* NumberFormatError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatError.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				2514146B274C7DE60086B0A8 /* CalculateItemQueueError.swift */,
+				2514146D274CBA620086B0A8 /* NumberFormatError.swift */,
 			);
 			path = Errors;
 			sourceTree = "<group>";
@@ -316,6 +319,7 @@
 			files = (
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				ED1A7A822740E12C002B36CE /* Formula.swift in Sources */,
+				2514146E274CBA620086B0A8 /* NumberFormatError.swift in Sources */,
 				ED1A7A75273E3FCC002B36CE /* Operator.swift in Sources */,
 				ED00CF4C273BA29A0081B9F3 /* CalculatorItemQueue.swift in Sources */,
 				ED1A7A8B274285CB002B36CE /* Double+Extensions.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2514146C274C7DE60086B0A8 /* CalculateItemQueueError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2514146B274C7DE60086B0A8 /* CalculateItemQueueError.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
@@ -43,6 +44,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2514146B274C7DE60086B0A8 /* CalculateItemQueueError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItemQueueError.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -90,6 +92,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2514146A274C7D940086B0A8 /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				2514146B274C7DE60086B0A8 /* CalculateItemQueueError.swift */,
+			);
+			path = Errors;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
@@ -111,6 +121,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				2514146A274C7D940086B0A8 /* Errors */,
 				ED1A7A8D274286AA002B36CE /* Controller */,
 				ED1A7A8C27428670002B36CE /* View */,
 				ED1A7A8727428592002B36CE /* Extensions */,
@@ -311,6 +322,7 @@
 				ED1A7A89274285A9002B36CE /* String+Extensions.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				ED00CF42273982370081B9F3 /* LinkedList.swift in Sources */,
+				2514146C274C7DE60086B0A8 /* CalculateItemQueueError.swift in Sources */,
 				ED1A7A862741445C002B36CE /* ExpressionParser.swift in Sources */,
 				ED1A7A9027429023002B36CE /* CalculateItem.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
-		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
+		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
@@ -46,7 +46,7 @@
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C713D9452570E5EB001C3AFC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorViewController.swift; sourceTree = "<group>"; };
 		C713D9482570E5EB001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -190,7 +190,7 @@
 			children = (
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
-				C713D9452570E5EB001C3AFC /* ViewController.swift */,
+				C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -303,7 +303,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				ED1A7A822740E12C002B36CE /* Formula.swift in Sources */,
 				ED1A7A75273E3FCC002B36CE /* Operator.swift in Sources */,
 				ED00CF4C273BA29A0081B9F3 /* CalculatorItemQueue.swift in Sources */,

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -13,39 +13,15 @@ class CalculatorViewController: UIViewController {
     @IBOutlet var historyStackView: UIStackView!
     
     private var isPositiveOperand = true
-    
+    private var currentOperand = ""
+    private var currentOperator = ""
     private var isZero: Bool {
         return currentOperand == "0"
     }
-    
     private var isNotZero: Bool {
         return currentOperand != "0"
     }
-    
-    private var currentOperand: String {
-        get {
-            guard let currentOperand = currentOperandLabel.text else {
-                return ""
-            }
-            return currentOperand
-        }
-        set {
-            currentOperandLabel.text = newValue
-        }
-    }
-    
-    private var currentOperator: String {
-        get {
-            guard let currentOperator = currentOperatorLabel.text else {
-                return ""
-            }
-            return currentOperator
-        }
-        set {
-            currentOperatorLabel.text = newValue
-        }
-    }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         removeFormulaStackViews()
@@ -60,6 +36,7 @@ class CalculatorViewController: UIViewController {
             currentOperand = ""
         }
         currentOperand += numberPressedString
+        update(label: currentOperandLabel, to: currentOperand)
     }
     
     @IBAction func operatorButtonPressed(_ sender: UIButton) {
@@ -69,6 +46,7 @@ class CalculatorViewController: UIViewController {
         }
         updateHistoryStackView(with: currentOperator, and: currentOperand)
         currentOperator = operatorPressedString
+        update(label: currentOperatorLabel, to: currentOperator)
         resetCurrentOperand()
     }
     
@@ -145,6 +123,7 @@ extension CalculatorViewController {
     
     private func resetCurrentOperand() {
         currentOperand = "0"
+        currentOperandLabel.text = "0"
     }
     
     private func toggleSignOfOperand() {
@@ -153,6 +132,7 @@ extension CalculatorViewController {
         } else {
             currentOperand = "-" + currentOperand
         }
+        update(label: currentOperandLabel, to: currentOperand)
     }
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -7,12 +7,12 @@
 import UIKit
 
 class CalculatorViewController: UIViewController {
-    
+    //MARK: - @IBOutlet Properties
     @IBOutlet weak var currentOperandLabel: UILabel!
     @IBOutlet weak var currentOperatorLabel: UILabel!
     @IBOutlet weak var historyStackView: UIStackView!
     @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
-    
+    //MARK: - Properties
     private var isPositiveOperand = true
     private var currentOperand = ""
     private var currentOperator = ""
@@ -23,13 +23,13 @@ class CalculatorViewController: UIViewController {
     private var isNotZero: Bool {
         return currentOperand != "0"
     }
-
+    //MARK: - View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         removeFormulaStackViews()
         resetCurrentOperand()
     }
-    
+    //MARK: - @IBAction Properties
     @IBAction func touchUpDigitButton(_ sender: UIButton) {
         guard let numberPressedString = sender.accessibilityIdentifier else {
             return
@@ -82,18 +82,28 @@ class CalculatorViewController: UIViewController {
         isPositiveOperand.toggle()
         toggleSignOfOperand()
     }
-    
 }
 
 extension CalculatorViewController {
+    // MARK: - Functions
     private func removeFormulaStackViews() {
         historyStackView.arrangedSubviews.forEach { placeHolderView in
             placeHolderView.removeFromSuperview()
         }
     }
     
+    private func resetCurrentOperand() {
+        currentOperand = "0"
+        currentOperandLabel.text = "0"
+    }
+    
     private func update(label: UILabel, to data: String) {
         label.text = data
+    }
+    
+    private func refreshCalculateHistory() {
+        updateHistoryStackView(with: currentOperator, and: currentOperand)
+        historyStack.append(contentsOf: [currentOperator, currentOperand])
     }
     
     private func updateHistoryStackView(with currentOperator: String, and currentOperand: String) {
@@ -103,6 +113,27 @@ extension CalculatorViewController {
     
     private func add(_ formulaStackView: UIStackView, to historyStackView: UIStackView) {
         historyStackView.addArrangedSubview(formulaStackView)
+    }
+    
+    private func toggleSignOfOperand() {
+        if isPositiveOperand {
+            currentOperand = currentOperand.filter { $0.isNumber }
+        } else {
+            currentOperand = "-" + currentOperand
+        }
+        update(label: currentOperandLabel, to: currentOperand)
+    }
+    
+    private func autoScrollToBottom() {
+        calculationHistoryScrollView.layoutIfNeeded()
+        let contentSizeHeight = calculationHistoryScrollView.contentSize.height
+        let boundsHeight = calculationHistoryScrollView.bounds.height
+        let contentInsetBottom = calculationHistoryScrollView.contentInset.bottom
+        let bottomOffset = CGPoint(x: 0, y: contentSizeHeight - boundsHeight + contentInsetBottom)
+        
+        if bottomOffset.y > 0 {
+            calculationHistoryScrollView.setContentOffset(bottomOffset, animated: true)
+        }
     }
     
     private func createFormulaStackView(with currentOperator: String, and currentOperand: String) -> UIStackView {
@@ -137,25 +168,6 @@ extension CalculatorViewController {
         return label
     }
     
-    private func resetCurrentOperand() {
-        currentOperand = "0"
-        currentOperandLabel.text = "0"
-    }
-    
-    private func toggleSignOfOperand() {
-        if isPositiveOperand {
-            currentOperand = currentOperand.filter { $0.isNumber }
-        } else {
-            currentOperand = "-" + currentOperand
-        }
-        update(label: currentOperandLabel, to: currentOperand)
-    }
-    
-    private func refreshCalculateHistory() {
-        updateHistoryStackView(with: currentOperator, and: currentOperand)
-        historyStack.append(contentsOf: [currentOperator, currentOperand])
-    }
-    
     private func calculateResult(from historyStack: [String]) -> String? {
         let equationString = historyStack.filter { $0 != "" }.joined()
         var formula = ExpressionParser.parse(from: equationString)
@@ -164,17 +176,5 @@ extension CalculatorViewController {
             return nil
         }
         return result
-    }
-    
-    private func autoScrollToBottom() {
-        calculationHistoryScrollView.layoutIfNeeded()
-        let contentSizeHeight = calculationHistoryScrollView.contentSize.height
-        let boundsHeight = calculationHistoryScrollView.bounds.height
-        let contentInsetBottom = calculationHistoryScrollView.contentInset.bottom
-        let bottomOffset = CGPoint(x: 0, y: contentSizeHeight - boundsHeight + contentInsetBottom)
-        
-        if bottomOffset.y > 0 {
-            calculationHistoryScrollView.setContentOffset(bottomOffset, animated: true)
-        }
     }
 }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -64,11 +64,11 @@ class CalculatorViewController: UIViewController {
         }
         historyStack.removeAll()
         setCurrentOperator(to: "")
+        removeFormulaStackViews()
+        update(currentOperandLabel, to: result)
+        update(currentOperatorLabel, to: currentOperator)
         let newOperand = result.removedCommas
         setCurrentOperand(to: newOperand)
-        removeFormulaStackViews()
-        update(currentOperandLabel, to: newOperand)
-        update(currentOperatorLabel, to: currentOperator)
     }
     
     @IBAction func touchUpACButton(_ sender: Any) {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -63,10 +63,10 @@ final class CalculatorViewController: UIViewController {
             return
         }
         clearCalculationHistory()
-        update(currentOperandLabel, to: result)
+        updateOperandLabel(currentOperandLabel, to: result)
         changeCurrentOperatorData(to: "")
-        let newOperand = result.withoutCommas
-        setCurrentOperand(to: newOperand)
+        //let newOperand = result.withoutCommas
+        setCurrentOperand(to: result)
     }
     
     @IBAction private func touchUpACButton(_ sender: Any) {
@@ -101,7 +101,7 @@ extension CalculatorViewController {
     
     private func changeCurrentOperandData(to newOperand: String) {
         setCurrentOperand(to: newOperand)
-        update(currentOperandLabel, to: newOperand)
+        updateOperandLabel(currentOperandLabel, to: newOperand)
     }
     
     private func setCurrentOperand(to newOperand: String) {
@@ -110,14 +110,18 @@ extension CalculatorViewController {
     
     private func changeCurrentOperatorData(to newOperator: String) {
         setCurrentOperator(to: newOperator)
-        update(currentOperatorLabel, to: newOperator)
+        updateOperatorLabel(currentOperatorLabel, to: newOperator)
     }
     
     private func setCurrentOperator(to newOperator: String) {
         currentOperator = newOperator
     }
     
-    private func update(_ label: UILabel, to data: String) {
+    private func updateOperatorLabel(_ label: UILabel, to data: String) {
+        label.text = data
+    }
+    
+    private func updateOperandLabel(_ label: UILabel, to data: String) {
         do {
             guard let presentableString = try data.convertNumberToPresentableFormat() else {
                 return

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -63,7 +63,7 @@ class CalculatorViewController: UIViewController {
         clearCalculationHistory()
         update(currentOperandLabel, to: result)
         changeCurrentOperatorData(to: "")
-        let newOperand = result.removedCommas
+        let newOperand = result.withoutCommas
         setCurrentOperand(to: newOperand)
     }
     
@@ -128,10 +128,11 @@ extension CalculatorViewController {
     }
     
     private func calculateResult(from historyStack: [String]) -> String? {
-        let equationString = historyStack.filter { $0 != "" }.joined()
+        let equationString = historyStack.filter { $0 != "" }
+            .joined()
         var formula = ExpressionParser.parse(from: equationString)
         let rawResult = formula.result()
-        guard let result = rawResult.presentingFormat else {
+        guard let result = rawResult.presentableFormat else {
             return nil
         }
         return result
@@ -144,11 +145,7 @@ extension CalculatorViewController {
     
     private func updateHistoryStackView(with currentOperator: String, and currentOperand: String) {
         let formulaStackView = createFormulaStackView(with: currentOperator, and: currentOperand)
-        add(formulaStackView, to: calculationHistoryStackView)
-    }
-    
-    private func add(_ formulaStackView: UIStackView, to historyStackView: UIStackView) {
-        historyStackView.addArrangedSubview(formulaStackView)
+        calculationHistoryStackView.addArrangedSubview(formulaStackView)
     }
     
     private func clearCalculationHistory() {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -14,7 +14,6 @@ final class CalculatorViewController: UIViewController {
     @IBOutlet private weak var calculationHistoryScrollView: UIScrollView!
     
     //MARK: - Properties
-    private var isPositiveOperand = true
     private var currentOperand = ""
     private var currentOperator = ""
     private var historyStack: [String] = []
@@ -81,10 +80,15 @@ final class CalculatorViewController: UIViewController {
     }
     
     @IBAction private func touchUpSignButton(_ sender: Any) {
-        guard isNotZero else {
+        guard isNotZero,
+              let doubleOperand = Double(currentOperand),
+              doubleOperand != 0 else {
             return
         }
-        toggleSignOfOperand()
+        guard let newOperand = (doubleOperand * -1).presentableFormat else {
+            return
+        }
+        changeCurrentOperandData(to: newOperand)
     }
 }
 
@@ -165,18 +169,6 @@ extension CalculatorViewController {
     private func clearCalculationHistory() {
         historyStack.removeAll()
         removeFormulaStackViews()
-    }
-    
-    private func toggleSignOfOperand() {
-        isPositiveOperand.toggle()
-        if isPositiveOperand {
-            let newOperand = currentOperand.filter { $0.isNumber }
-            setCurrentOperand(to: newOperand)
-        } else {
-            let newOperand = "-" + currentOperand
-            setCurrentOperand(to: newOperand)
-        }
-        update(currentOperandLabel, to: currentOperand)
     }
     
     private func createFormulaStackView(with currentOperator: String, and currentOperand: String) -> UIStackView {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -118,7 +118,18 @@ extension CalculatorViewController {
     }
     
     private func update(_ label: UILabel, to data: String) {
-        label.text = data
+        do {
+            guard let presentableString = try data.convertNumberToPresentableFormat() else {
+                return
+            }
+            label.text = presentableString
+        } catch NumberFormatError.numberFormatFailed {
+            print(NumberFormatError.numberFormatFailed)
+        } catch NumberFormatError.typeCastingFailed {
+            print(NumberFormatError.typeCastingFailed)
+        } catch let error {
+            print(error)
+        }
     }
     
     private func autoScrollToBottom() {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -12,6 +12,7 @@ final class CalculatorViewController: UIViewController {
     @IBOutlet private weak var currentOperatorLabel: UILabel!
     @IBOutlet private weak var calculationHistoryStackView: UIStackView!
     @IBOutlet private weak var calculationHistoryScrollView: UIScrollView!
+    
     //MARK: - Properties
     private var isPositiveOperand = true
     private var currentOperand = ""
@@ -25,12 +26,14 @@ final class CalculatorViewController: UIViewController {
     private var isNotZero: Bool {
         return currentOperand != "0"
     }
+    
     //MARK: - View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         removeFormulaStackViews()
         changeCurrentOperandData(to: "0")
     }
+    
     //MARK: - @IBAction Methods
     @IBAction private func touchUpDigitButton(_ sender: UIButton) {
         guard let numberPressedString = sender.accessibilityIdentifier else {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -8,9 +8,9 @@ import UIKit
 
 class CalculatorViewController: UIViewController {
     
-    @IBOutlet var currentOperandLabel: UILabel!
-    @IBOutlet var currentOperatorLabel: UILabel!
-    @IBOutlet var historyStackView: UIStackView!
+    @IBOutlet weak var currentOperandLabel: UILabel!
+    @IBOutlet weak var currentOperatorLabel: UILabel!
+    @IBOutlet weak var historyStackView: UIStackView!
     @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
     
     private var isPositiveOperand = true

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -15,6 +15,7 @@ class CalculatorViewController: UIViewController {
     private var isPositiveOperand = true
     private var currentOperand = ""
     private var currentOperator = ""
+    private var historyStack: [String] = []
     private var isZero: Bool {
         return currentOperand == "0"
     }
@@ -45,14 +46,30 @@ class CalculatorViewController: UIViewController {
             return
         }
         updateHistoryStackView(with: currentOperator, and: currentOperand)
+        historyStack.append(contentsOf: [currentOperator, currentOperand])
         currentOperator = operatorPressedString
         update(label: currentOperatorLabel, to: currentOperator)
         resetCurrentOperand()
     }
     
+    @IBAction func calculateButtonPressed(_ sender: Any) {
+        updateHistoryStackView(with: currentOperator, and: currentOperand)
+        historyStack.append(contentsOf: [currentOperator, currentOperand])
+        let equationString = historyStack.filter { $0 != "" }.joined()
+        var formula = ExpressionParser.parse(from: equationString)
+        let result = formula.result()
+        currentOperand = String(result)
+        historyStack.removeAll()
+        currentOperator = ""
+        removeFormulaStackViews()
+        update(label: currentOperandLabel, to: currentOperand)
+        update(label: currentOperatorLabel, to: currentOperator)
+    }
+    
     @IBAction func acButtonPressed(_ sender: Any) {
         removeFormulaStackViews()
         resetCurrentOperand()
+        historyStack.removeAll()
     }
     
     @IBAction func ceButtonPressed(_ sender: Any) {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -33,7 +33,7 @@ class CalculatorViewController: UIViewController {
         guard let numberPressedString = sender.accessibilityIdentifier else {
             return
         }
-        if isZero {
+        if isZero && numberPressedString != "." {
             currentOperand = ""
         }
         currentOperand += numberPressedString
@@ -53,7 +53,9 @@ class CalculatorViewController: UIViewController {
     
     @IBAction func calculateButtonPressed(_ sender: Any) {
         refreshCalculateHistory()
-        currentOperand = calculateResult(from: historyStack)
+        guard let currentOperand = calculateResult(from: historyStack) else {
+            return
+        }
         historyStack.removeAll()
         currentOperator = ""
         removeFormulaStackViews()
@@ -152,11 +154,14 @@ extension CalculatorViewController {
         historyStack.append(contentsOf: [currentOperator, currentOperand])
     }
     
-    private func calculateResult(from historyStack: [String]) -> String {
+    private func calculateResult(from historyStack: [String]) -> String? {
         let equationString = historyStack.filter { $0 != "" }.joined()
         var formula = ExpressionParser.parse(from: equationString)
-        let result = formula.result()
-        return String(result)
+        let rawResult = formula.result()
+        guard let result = rawResult.presentingFormat else {
+            return nil
+        }
+        return result
     }
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -31,7 +31,7 @@ class CalculatorViewController: UIViewController {
         removeFormulaStackViews()
         changeCurrentOperandData(to: "0")
     }
-    //MARK: - @IBAction Properties
+    //MARK: - @IBAction Methods
     @IBAction func touchUpDigitButton(_ sender: UIButton) {
         guard let numberPressedString = sender.accessibilityIdentifier else {
             return
@@ -85,7 +85,7 @@ class CalculatorViewController: UIViewController {
 }
 
 extension CalculatorViewController {
-    // MARK: - Functions
+    // MARK: - Methods
     private func removeFormulaStackViews() {
         calculationHistoryStackView.arrangedSubviews
             .forEach { stackView in

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -10,7 +10,7 @@ class CalculatorViewController: UIViewController {
     //MARK: - @IBOutlet Properties
     @IBOutlet weak var currentOperandLabel: UILabel!
     @IBOutlet weak var currentOperatorLabel: UILabel!
-    @IBOutlet weak var historyStackView: UIStackView!
+    @IBOutlet weak var calculationHistoryStackView: UIStackView!
     @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
     //MARK: - Properties
     private var isPositiveOperand = true
@@ -87,7 +87,7 @@ class CalculatorViewController: UIViewController {
 extension CalculatorViewController {
     // MARK: - Functions
     private func removeFormulaStackViews() {
-        historyStackView.arrangedSubviews.forEach { placeHolderView in
+        calculationHistoryStackView.arrangedSubviews.forEach { placeHolderView in
             placeHolderView.removeFromSuperview()
         }
     }
@@ -108,7 +108,7 @@ extension CalculatorViewController {
     
     private func updateHistoryStackView(with currentOperator: String, and currentOperand: String) {
         let formulaStackView = createFormulaStackView(with: currentOperator, and: currentOperand)
-        add(formulaStackView, to: historyStackView)
+        add(formulaStackView, to: calculationHistoryStackView)
     }
     
     private func add(_ formulaStackView: UIStackView, to historyStackView: UIStackView) {
@@ -139,7 +139,7 @@ extension CalculatorViewController {
     private func createFormulaStackView(with currentOperator: String, and currentOperand: String) -> UIStackView {
         let formulaStackView = createStackView()
         let operandLabel = createLabel(with: currentOperand)
-        if historyStackView.arrangedSubviews.isEmpty {
+        if calculationHistoryStackView.arrangedSubviews.isEmpty {
             formulaStackView.addArrangedSubview(operandLabel)
             return formulaStackView
         }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -14,6 +14,14 @@ class CalculatorViewController: UIViewController {
     
     private var isPositiveOperand = true
     
+    private var isZero: Bool {
+        return currentOperand == "0"
+    }
+    
+    private var isNotZero: Bool {
+        return currentOperand != "0"
+    }
+    
     private var currentOperand: String {
         get {
             guard let currentOperand = currentOperandLabel.text else {
@@ -48,7 +56,7 @@ class CalculatorViewController: UIViewController {
         guard let numberPressedString = sender.accessibilityIdentifier else {
             return
         }
-        if currentOperand == "0" {
+        if isZero {
             currentOperand = ""
         }
         currentOperand += numberPressedString
@@ -56,7 +64,7 @@ class CalculatorViewController: UIViewController {
     
     @IBAction func operatorButtonPressed(_ sender: UIButton) {
         guard let operatorPressedString = sender.accessibilityIdentifier,
-              currentOperand != "0" else {
+              isNotZero else {
             return
         }
         updateHistoryStackView(with: currentOperator, and: currentOperand)
@@ -74,12 +82,11 @@ class CalculatorViewController: UIViewController {
     }
     
     @IBAction func toggleSignButtonPressed(_ sender: Any) {
-        isPositiveOperand.toggle()
-        if isPositiveOperand {
-            currentOperand = currentOperand.filter { $0.isNumber }
-        } else {
-            currentOperand = "-" + currentOperand
+        guard isNotZero else {
+            return
         }
+        isPositiveOperand.toggle()
+        toggleSignOfOperand()
     }
     
 }
@@ -137,7 +144,15 @@ extension CalculatorViewController {
     }
     
     private func resetCurrentOperand() {
-        self.currentOperand = "0"
+        currentOperand = "0"
+    }
+    
+    private func toggleSignOfOperand() {
+        if isPositiveOperand {
+            currentOperand = currentOperand.filter { $0.isNumber }
+        } else {
+            currentOperand = "-" + currentOperand
+        }
     }
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -30,7 +30,7 @@ class CalculatorViewController: UIViewController {
         resetCurrentOperand()
     }
     
-    @IBAction func numberButtonPressed(_ sender: UIButton) {
+    @IBAction func touchUpDigitButton(_ sender: UIButton) {
         guard let numberPressedString = sender.accessibilityIdentifier else {
             return
         }
@@ -41,7 +41,7 @@ class CalculatorViewController: UIViewController {
         update(label: currentOperandLabel, to: currentOperand)
     }
     
-    @IBAction func operatorButtonPressed(_ sender: UIButton) {
+    @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         guard let operatorPressedString = sender.accessibilityIdentifier,
               isNotZero else {
             return
@@ -53,7 +53,7 @@ class CalculatorViewController: UIViewController {
         autoScrollToBottom()
     }
     
-    @IBAction func calculateButtonPressed(_ sender: Any) {
+    @IBAction func touchUpCalculateButton(_ sender: Any) {
         refreshCalculateHistory()
         guard let currentOperand = calculateResult(from: historyStack) else {
             return
@@ -65,17 +65,17 @@ class CalculatorViewController: UIViewController {
         update(label: currentOperatorLabel, to: currentOperator)
     }
     
-    @IBAction func acButtonPressed(_ sender: Any) {
+    @IBAction func touchUpACButton(_ sender: Any) {
         removeFormulaStackViews()
         resetCurrentOperand()
         historyStack.removeAll()
     }
     
-    @IBAction func ceButtonPressed(_ sender: Any) {
+    @IBAction func touchUpCEButton(_ sender: Any) {
         resetCurrentOperand()
     }
     
-    @IBAction func toggleSignButtonPressed(_ sender: Any) {
+    @IBAction func touchUpSignButton(_ sender: Any) {
         guard isNotZero else {
             return
         }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -24,7 +24,7 @@ final class CalculatorViewController: UIViewController {
     }
     
     private var isNotZero: Bool {
-        return currentOperand != "0"
+        return !isZero
     }
     
     //MARK: - View Lifecycle

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -8,10 +8,10 @@ import UIKit
 
 final class CalculatorViewController: UIViewController {
     //MARK: - @IBOutlet Properties
-    @IBOutlet weak var currentOperandLabel: UILabel!
-    @IBOutlet weak var currentOperatorLabel: UILabel!
-    @IBOutlet weak var calculationHistoryStackView: UIStackView!
-    @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
+    @IBOutlet private weak var currentOperandLabel: UILabel!
+    @IBOutlet private weak var currentOperatorLabel: UILabel!
+    @IBOutlet private weak var calculationHistoryStackView: UIStackView!
+    @IBOutlet private weak var calculationHistoryScrollView: UIScrollView!
     //MARK: - Properties
     private var isPositiveOperand = true
     private var currentOperand = ""
@@ -32,7 +32,7 @@ final class CalculatorViewController: UIViewController {
         changeCurrentOperandData(to: "0")
     }
     //MARK: - @IBAction Methods
-    @IBAction func touchUpDigitButton(_ sender: UIButton) {
+    @IBAction private func touchUpDigitButton(_ sender: UIButton) {
         guard let numberPressedString = sender.accessibilityIdentifier else {
             return
         }
@@ -43,7 +43,7 @@ final class CalculatorViewController: UIViewController {
         changeCurrentOperandData(to: newOperand)
     }
     
-    @IBAction func touchUpOperatorButton(_ sender: UIButton) {
+    @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
         guard let operatorPressedString = sender.accessibilityIdentifier,
               isNotZero else {
             return
@@ -54,7 +54,7 @@ final class CalculatorViewController: UIViewController {
         autoScrollToBottom()
     }
     
-    @IBAction func touchUpCalculateButton(_ sender: Any) {
+    @IBAction private func touchUpCalculateButton(_ sender: Any) {
         refreshCalculateHistory(with: currentOperator, and: currentOperand)
         setCurrentOperand(to: "0")
         guard let result = calculateResult(from: historyStack) else {
@@ -67,16 +67,16 @@ final class CalculatorViewController: UIViewController {
         setCurrentOperand(to: newOperand)
     }
     
-    @IBAction func touchUpACButton(_ sender: Any) {
+    @IBAction private func touchUpACButton(_ sender: Any) {
         clearCalculationHistory()
         changeCurrentOperandData(to: "0")
     }
     
-    @IBAction func touchUpCEButton(_ sender: Any) {
+    @IBAction private func touchUpCEButton(_ sender: Any) {
         changeCurrentOperandData(to: "0")
     }
     
-    @IBAction func touchUpSignButton(_ sender: Any) {
+    @IBAction private func touchUpSignButton(_ sender: Any) {
         guard isNotZero else {
             return
         }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -11,6 +11,7 @@ class CalculatorViewController: UIViewController {
     @IBOutlet var currentOperandLabel: UILabel!
     @IBOutlet var currentOperatorLabel: UILabel!
     @IBOutlet var historyStackView: UIStackView!
+    @IBOutlet weak var calculationHistoryScrollView: UIScrollView!
     
     private var isPositiveOperand = true
     private var currentOperand = ""
@@ -49,6 +50,7 @@ class CalculatorViewController: UIViewController {
         currentOperator = operatorPressedString
         update(label: currentOperatorLabel, to: currentOperator)
         resetCurrentOperand()
+        autoScrollToBottom()
     }
     
     @IBAction func calculateButtonPressed(_ sender: Any) {
@@ -163,5 +165,16 @@ extension CalculatorViewController {
         }
         return result
     }
+    
+    private func autoScrollToBottom() {
+        calculationHistoryScrollView.layoutIfNeeded()
+        let contentSizeHeight = calculationHistoryScrollView.contentSize.height
+        let boundsHeight = calculationHistoryScrollView.bounds.height
+        let contentInsetBottom = calculationHistoryScrollView.contentInset.bottom
+        let bottomOffset = CGPoint(x: 0, y: contentSizeHeight - boundsHeight + contentInsetBottom)
+        
+        if bottomOffset.y > 0 {
+            calculationHistoryScrollView.setContentOffset(bottomOffset, animated: true)
+        }
+    }
 }
-

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -38,6 +38,11 @@ class CalculatorViewController: UIViewController {
         update(label: self.currentOperatorLabel, to: currentOperatorString)
         updateCurrentLabels()
     }
+    @IBAction func acButtonPressed(_ sender: Any) {
+        removePlaceholderViews()
+        updateCurrentLabels()
+    }
+    
 }
 
 extension CalculatorViewController {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -45,20 +45,15 @@ class CalculatorViewController: UIViewController {
               isNotZero else {
             return
         }
-        updateHistoryStackView(with: currentOperator, and: currentOperand)
-        historyStack.append(contentsOf: [currentOperator, currentOperand])
+        refreshCalculateHistory()
         currentOperator = operatorPressedString
         update(label: currentOperatorLabel, to: currentOperator)
         resetCurrentOperand()
     }
     
     @IBAction func calculateButtonPressed(_ sender: Any) {
-        updateHistoryStackView(with: currentOperator, and: currentOperand)
-        historyStack.append(contentsOf: [currentOperator, currentOperand])
-        let equationString = historyStack.filter { $0 != "" }.joined()
-        var formula = ExpressionParser.parse(from: equationString)
-        let result = formula.result()
-        currentOperand = String(result)
+        refreshCalculateHistory()
+        currentOperand = calculateResult(from: historyStack)
         historyStack.removeAll()
         currentOperator = ""
         removeFormulaStackViews()
@@ -150,6 +145,18 @@ extension CalculatorViewController {
             currentOperand = "-" + currentOperand
         }
         update(label: currentOperandLabel, to: currentOperand)
+    }
+    
+    private func refreshCalculateHistory() {
+        updateHistoryStackView(with: currentOperator, and: currentOperand)
+        historyStack.append(contentsOf: [currentOperator, currentOperand])
+    }
+    
+    private func calculateResult(from historyStack: [String]) -> String {
+        let equationString = historyStack.filter { $0 != "" }.joined()
+        var formula = ExpressionParser.parse(from: equationString)
+        let result = formula.result()
+        return String(result)
     }
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -17,7 +17,7 @@ class CalculatorViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        removePlaceholderViews()
+        removeFormulaStackViews()
         updateCurrentLabels()
     }
     
@@ -26,27 +26,28 @@ class CalculatorViewController: UIViewController {
             return
         }
         currentNumberString += numberPressedString
-        update(label: self.currentNumberLabel, to: currentNumberString)
+        update(label: currentNumberLabel, to: currentNumberString)
     }
     
     @IBAction func operatorButtonPressed(_ sender: UIButton) {
-        addToStackView()
         guard let operatorPressedString = sender.accessibilityIdentifier else {
             return
         }
+        updateHistoryStackView()
         currentOperatorString = operatorPressedString
-        update(label: self.currentOperatorLabel, to: currentOperatorString)
+        update(label: currentOperatorLabel, to: currentOperatorString)
         updateCurrentLabels()
     }
+    
     @IBAction func acButtonPressed(_ sender: Any) {
-        removePlaceholderViews()
+        removeFormulaStackViews()
         updateCurrentLabels()
     }
     
 }
 
 extension CalculatorViewController {
-    private func removePlaceholderViews() {
+    private func removeFormulaStackViews() {
         historyStackView.arrangedSubviews.forEach { placeHolderView in
             placeHolderView.removeFromSuperview()
         }
@@ -56,8 +57,12 @@ extension CalculatorViewController {
         label.text = data
     }
     
-    private func addToStackView() {
+    private func updateHistoryStackView() {
         let formulaStackView = createFormulaStackView(with: currentOperatorString, and: currentNumberString)
+        add(formulaStackView, to: historyStackView)
+    }
+    
+    private func add(_ formulaStackView: UIStackView, to historyStackView: UIStackView) {
         historyStackView.addArrangedSubview(formulaStackView)
     }
     

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -87,9 +87,10 @@ class CalculatorViewController: UIViewController {
 extension CalculatorViewController {
     // MARK: - Functions
     private func removeFormulaStackViews() {
-        calculationHistoryStackView.arrangedSubviews.forEach { placeHolderView in
-            placeHolderView.removeFromSuperview()
-        }
+        calculationHistoryStackView.arrangedSubviews
+            .forEach { placeHolderView in
+                placeHolderView.removeFromSuperview()
+            }
     }
     
     private func resetCurrentOperand() {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class CalculatorViewController: UIViewController {
+final class CalculatorViewController: UIViewController {
     //MARK: - @IBOutlet Properties
     @IBOutlet weak var currentOperandLabel: UILabel!
     @IBOutlet weak var currentOperatorLabel: UILabel!

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -1,8 +1,8 @@
 //
 //  Calculator - CalculatorViewController.swift
-//  Created by yagom. 
+//  Created by yagom.
 //  Copyright © yagom. All rights reserved.
-// 
+//
 
 import UIKit
 
@@ -28,6 +28,7 @@ class CalculatorViewController: UIViewController {
         super.viewDidLoad()
         removeFormulaStackViews()
         resetCurrentOperand()
+        update(currentOperandLabel, to: currentOperand)
     }
     //MARK: - @IBAction Properties
     @IBAction func touchUpDigitButton(_ sender: UIButton) {
@@ -35,10 +36,11 @@ class CalculatorViewController: UIViewController {
             return
         }
         if isZero && numberPressedString != "." {
-            currentOperand = ""
+            setCurrentOperand(to: "")
         }
-        currentOperand += numberPressedString
-        update(label: currentOperandLabel, to: currentOperand)
+        let newOperand = currentOperand + numberPressedString
+        setCurrentOperand(to: newOperand)
+        update(currentOperandLabel, to: currentOperand)
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
@@ -47,32 +49,38 @@ class CalculatorViewController: UIViewController {
             return
         }
         refreshCalculateHistory()
-        currentOperator = operatorPressedString
-        update(label: currentOperatorLabel, to: currentOperator)
+        setCurrentOperator(to: operatorPressedString)
+        update(currentOperatorLabel, to: currentOperator)
         resetCurrentOperand()
+        update(currentOperandLabel, to: currentOperand)
         autoScrollToBottom()
     }
     
     @IBAction func touchUpCalculateButton(_ sender: Any) {
         refreshCalculateHistory()
-        guard let currentOperand = calculateResult(from: historyStack) else {
+        resetCurrentOperand()
+        guard let result = calculateResult(from: historyStack) else {
             return
         }
         historyStack.removeAll()
-        currentOperator = ""
+        setCurrentOperator(to: "")
+        let newOperand = result.removedCommas
+        setCurrentOperand(to: newOperand)
         removeFormulaStackViews()
-        update(label: currentOperandLabel, to: currentOperand)
-        update(label: currentOperatorLabel, to: currentOperator)
+        update(currentOperandLabel, to: newOperand)
+        update(currentOperatorLabel, to: currentOperator)
     }
     
     @IBAction func touchUpACButton(_ sender: Any) {
         removeFormulaStackViews()
         resetCurrentOperand()
+        update(currentOperandLabel, to: currentOperand)
         historyStack.removeAll()
     }
     
     @IBAction func touchUpCEButton(_ sender: Any) {
         resetCurrentOperand()
+        update(currentOperandLabel, to: currentOperand)
     }
     
     @IBAction func touchUpSignButton(_ sender: Any) {
@@ -94,11 +102,18 @@ extension CalculatorViewController {
     }
     
     private func resetCurrentOperand() {
-        currentOperand = "0"
-        currentOperandLabel.text = "0"
+        setCurrentOperand(to: "0")
     }
     
-    private func update(label: UILabel, to data: String) {
+    private func setCurrentOperand(to newOperand: String) {
+        currentOperand = newOperand
+    }
+    
+    private func setCurrentOperator(to newOperator: String) {
+        currentOperator = newOperator
+    }
+    
+    private func update(_ label: UILabel, to data: String) {
         label.text = data
     }
     
@@ -118,11 +133,13 @@ extension CalculatorViewController {
     
     private func toggleSignOfOperand() {
         if isPositiveOperand {
-            currentOperand = currentOperand.filter { $0.isNumber }
+            let newOperand = currentOperand.filter { $0.isNumber }
+            setCurrentOperand(to: newOperand)
         } else {
-            currentOperand = "-" + currentOperand
+            let newOperand = "-" + currentOperand
+            setCurrentOperand(to: newOperand)
         }
-        update(label: currentOperandLabel, to: currentOperand)
+        update(currentOperandLabel, to: currentOperand)
     }
     
     private func autoScrollToBottom() {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -133,9 +133,21 @@ extension CalculatorViewController {
         let equationString = historyStack.filter { $0 != "" }
             .joined()
         var formula = ExpressionParser.parse(from: equationString)
-        let rawResult = formula.result()
+        let rawResult = getCalculationResult(from: &formula)
         guard let result = rawResult.presentableFormat else {
             return nil
+        }
+        return result
+    }
+    
+    private func getCalculationResult(from formula: inout Formula) -> Double {
+        var result = 0.0
+        do {
+            try result = formula.result()
+        } catch CalculateItemQueueError.queueIsEmpty {
+            print(CalculateItemQueueError.queueIsEmpty)
+        } catch let error {
+            print(error)
         }
         return result
     }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -186,7 +186,7 @@ extension CalculatorViewController {
         stackView.axis = .horizontal
         stackView.alignment = .fill
         stackView.distribution = .fill
-        stackView.spacing = 8
+        stackView.spacing = 8.0
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -88,8 +88,8 @@ extension CalculatorViewController {
     // MARK: - Functions
     private func removeFormulaStackViews() {
         calculationHistoryStackView.arrangedSubviews
-            .forEach { placeHolderView in
-                placeHolderView.removeFromSuperview()
+            .forEach { stackView in
+                stackView.removeFromSuperview()
             }
     }
     

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -28,7 +28,7 @@ class CalculatorViewController: UIViewController {
         resetCurrentOperand()
     }
     
-    @IBAction func numberPressed(_ sender: UIButton) {
+    @IBAction func numberButtonPressed(_ sender: UIButton) {
         guard let numberPressedString = sender.accessibilityIdentifier else {
             return
         }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -91,9 +91,7 @@ extension CalculatorViewController {
     // MARK: - Methods
     private func removeFormulaStackViews() {
         calculationHistoryStackView.arrangedSubviews
-            .forEach { stackView in
-                stackView.removeFromSuperview()
-            }
+            .forEach { $0.removeFromSuperview() }
     }
     
     private func changeCurrentOperandData(to newOperand: String) {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -1,12 +1,12 @@
 //
-//  Calculator - ViewController.swift
+//  Calculator - CalculatorViewController.swift
 //  Created by yagom. 
 //  Copyright © yagom. All rights reserved.
 // 
 
 import UIKit
 
-class ViewController: UIViewController {
+class CalculatorViewController: UIViewController {
     
     @IBOutlet var currentNumberLabel: UILabel!
     @IBOutlet var currentOperatorLabel: UILabel!

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -44,6 +44,9 @@ class CalculatorViewController: UIViewController {
         updateCurrentLabels()
     }
     
+    @IBAction func ceButtonPressed(_ sender: Any) {
+        updateCurrentLabels()
+    }
 }
 
 extension CalculatorViewController {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -38,7 +38,9 @@ class CalculatorViewController: UIViewController {
         update(label: self.currentOperatorLabel, to: currentOperatorString)
         updateCurrentLabels()
     }
-    
+}
+
+extension CalculatorViewController {
     private func removePlaceholderViews() {
         historyStackView.arrangedSubviews.forEach { placeHolderView in
             placeHolderView.removeFromSuperview()

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -10,6 +10,8 @@ class ViewController: UIViewController {
     
     @IBOutlet var currentNumberLabel: UILabel!
     @IBOutlet var currentOperatorLabel: UILabel!
+    @IBOutlet var historyStackView: UIStackView!
+    
     var currentNumberString = ""
     var currentOperator = ""
     override func viewDidLoad() {
@@ -25,17 +27,50 @@ class ViewController: UIViewController {
     }
     
     @IBAction func operatorButtonPressed(_ sender: UIButton) {
-        // convert current buffer to UIStackView and add to UIScrollView
-        // reset currentNumberLabel to 0
+        addToStackView()
         guard let operatorPressedString = sender.accessibilityIdentifier else {
             return
         }
         currentOperator = operatorPressedString
         update(label: self.currentOperatorLabel, to: currentOperator)
+        updateCurrentLabels()
     }
     
     private func update(label: UILabel, to data: String) {
         label.text = data
+    }
+    
+    private func addToStackView() {
+        let formulaStackView = createFormulaStackView(with: currentOperator, and: currentNumberString)
+        historyStackView.addArrangedSubview(formulaStackView)
+    }
+    
+    private func createFormulaStackView(with operator: String, and operand: String) -> UIStackView {
+        let stackView = UIStackView()
+        let operandLabel = createLabel(with: operand)
+        let operatorLabel = createLabel(with: `operator`)
+        stackView.axis = .horizontal
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(operatorLabel)
+        stackView.addArrangedSubview(operandLabel)
+        return stackView
+    }
+    
+    private func createLabel(with item: String) -> UILabel {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.text = item
+        label.textColor = .white
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }
+    
+    private func updateCurrentLabels() {
+        self.currentNumberLabel.text = "0"
+        self.currentNumberString = ""
     }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -16,6 +16,7 @@ class ViewController: UIViewController {
     var currentOperator = ""
     override func viewDidLoad() {
         super.viewDidLoad()
+        removePlaceholderViews()
     }
 
     @IBAction func numberPressed(_ sender: UIButton) {
@@ -34,6 +35,12 @@ class ViewController: UIViewController {
         currentOperator = operatorPressedString
         update(label: self.currentOperatorLabel, to: currentOperator)
         updateCurrentLabels()
+    }
+    
+    private func removePlaceholderViews() {
+        historyStackView.arrangedSubviews.forEach { placeHolderView in
+            placeHolderView.removeFromSuperview()
+        }
     }
     
     private func update(label: UILabel, to data: String) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
             return
         }
         currentNumberString += numberPressedString
-        update(self.currentNumberLabel, to: currentNumberString)
+        update(label: self.currentNumberLabel, to: currentNumberString)
     }
     
     @IBAction func operatorButtonPressed(_ sender: UIButton) {
@@ -31,10 +31,10 @@ class ViewController: UIViewController {
             return
         }
         currentOperator = operatorPressedString
-        update(self.currentOperatorLabel, to: currentOperator)
+        update(label: self.currentOperatorLabel, to: currentOperator)
     }
     
-    private func update(_ label: UILabel, to data: String) {
+    private func update(label: UILabel, to data: String) {
         label.text = data
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -12,13 +12,15 @@ class ViewController: UIViewController {
     @IBOutlet var currentOperatorLabel: UILabel!
     @IBOutlet var historyStackView: UIStackView!
     
-    var currentNumberString = ""
-    var currentOperator = ""
+    private var currentNumberString = ""
+    private var currentOperatorString = ""
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         removePlaceholderViews()
+        updateCurrentLabels()
     }
-
+    
     @IBAction func numberPressed(_ sender: UIButton) {
         guard let numberPressedString = sender.accessibilityIdentifier else {
             return
@@ -32,8 +34,8 @@ class ViewController: UIViewController {
         guard let operatorPressedString = sender.accessibilityIdentifier else {
             return
         }
-        currentOperator = operatorPressedString
-        update(label: self.currentOperatorLabel, to: currentOperator)
+        currentOperatorString = operatorPressedString
+        update(label: self.currentOperatorLabel, to: currentOperatorString)
         updateCurrentLabels()
     }
     
@@ -48,7 +50,7 @@ class ViewController: UIViewController {
     }
     
     private func addToStackView() {
-        let formulaStackView = createFormulaStackView(with: currentOperator, and: currentNumberString)
+        let formulaStackView = createFormulaStackView(with: currentOperatorString, and: currentNumberString)
         historyStackView.addArrangedSubview(formulaStackView)
     }
     

--- a/Calculator/Calculator/Errors/CalculateItemQueueError.swift
+++ b/Calculator/Calculator/Errors/CalculateItemQueueError.swift
@@ -1,0 +1,12 @@
+//
+//  CalculateItemQueueError.swift
+//  Calculator
+//
+//  Created by 박병호 on 2021/11/23.
+//
+
+import Foundation
+
+enum CalculateItemQueueError: Error {
+    case queueIsEmpty
+}

--- a/Calculator/Calculator/Errors/CalculateItemQueueError.swift
+++ b/Calculator/Calculator/Errors/CalculateItemQueueError.swift
@@ -7,9 +7,11 @@
 
 import Foundation
 
-enum CalculateItemQueueError: String, CustomStringConvertible, Error {
+enum CalculateItemQueueError: String, Error {
     case queueIsEmpty = "큐가 비어있습니다."
-    
+}
+
+extension CalculateItemQueueError: CustomStringConvertible {
     var description: String {
         return rawValue
     }

--- a/Calculator/Calculator/Errors/CalculateItemQueueError.swift
+++ b/Calculator/Calculator/Errors/CalculateItemQueueError.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
-enum CalculateItemQueueError: Error {
-    case queueIsEmpty
+enum CalculateItemQueueError: String, CustomStringConvertible, Error {
+    case queueIsEmpty = "큐가 비어있습니다."
+    
+    var description: String {
+        return rawValue
+    }
 }

--- a/Calculator/Calculator/Errors/NumberFormatError.swift
+++ b/Calculator/Calculator/Errors/NumberFormatError.swift
@@ -1,0 +1,19 @@
+//
+//  NumberFormatError.swift
+//  Calculator
+//
+//  Created by 박병호 on 2021/11/23.
+//
+
+import Foundation
+
+enum NumberFormatError: String, Error {
+    case numberFormatFailed = "Number fomatting 실패"
+    case typeCastingFailed = "형변환 실패"
+}
+
+extension NumberFormatError: CustomStringConvertible {
+    var description: String {
+        return rawValue
+    }
+}

--- a/Calculator/Calculator/Extensions/Double+Extensions.swift
+++ b/Calculator/Calculator/Extensions/Double+Extensions.swift
@@ -8,13 +8,16 @@
 import Foundation
 
 extension Double: CalculateItem {
-//    var decimalFormat: String {
-//        let formatter = NumberFormatter()
-//        formatter.numberStyle = .decimal
-//        formatter.maximumFractionDigits = 20
-//        
-//        let number = NSNumber(value: value)
-//        let formattedValue = formatter.string(from: number)!
-//        return "\(name): \(formattedValue)"
-//    }
+    var presentingFormat: String? {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = 20
+        numberFormatter.minimumFractionDigits = 0
+        numberFormatter.maximumFractionDigits = 0
+        numberFormatter.roundingMode = .up
+        guard let result = numberFormatter.string(from: NSNumber(value: self)) else {
+            return nil
+        }
+        return result
+    }
 }

--- a/Calculator/Calculator/Extensions/Double+Extensions.swift
+++ b/Calculator/Calculator/Extensions/Double+Extensions.swift
@@ -11,10 +11,8 @@ extension Double: CalculateItem {
     var presentableFormat: String? {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
-        numberFormatter.maximumSignificantDigits = 20
-        numberFormatter.minimumFractionDigits = 0
-        numberFormatter.maximumFractionDigits = 0
-        numberFormatter.roundingMode = .up
+        numberFormatter.maximumFractionDigits = 20
+        
         guard let result = numberFormatter.string(from: NSNumber(value: self)) else {
             return nil
         }

--- a/Calculator/Calculator/Extensions/Double+Extensions.swift
+++ b/Calculator/Calculator/Extensions/Double+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Double: CalculateItem {
-    var presentingFormat: String? {
+    var presentableFormat: String? {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         numberFormatter.maximumSignificantDigits = 20

--- a/Calculator/Calculator/Extensions/Double+Extensions.swift
+++ b/Calculator/Calculator/Extensions/Double+Extensions.swift
@@ -8,5 +8,13 @@
 import Foundation
 
 extension Double: CalculateItem {
-    
+//    var decimalFormat: String {
+//        let formatter = NumberFormatter()
+//        formatter.numberStyle = .decimal
+//        formatter.maximumFractionDigits = 20
+//        
+//        let number = NSNumber(value: value)
+//        let formattedValue = formatter.string(from: number)!
+//        return "\(name): \(formattedValue)"
+//    }
 }

--- a/Calculator/Calculator/Extensions/String+Extensions.swift
+++ b/Calculator/Calculator/Extensions/String+Extensions.swift
@@ -14,7 +14,7 @@ extension String {
             .compactMap { String($0) }
     }
     
-    var removedCommas: String {
+    var withoutCommas: String {
         return self.filter { $0 != "," }
     }
     

--- a/Calculator/Calculator/Extensions/String+Extensions.swift
+++ b/Calculator/Calculator/Extensions/String+Extensions.swift
@@ -15,7 +15,7 @@ extension String {
     }
     
     var removedCommas: String {
-        return self.filter { $0.isNumber }
+        return self.filter { $0 != "," }
     }
     
 }

--- a/Calculator/Calculator/Extensions/String+Extensions.swift
+++ b/Calculator/Calculator/Extensions/String+Extensions.swift
@@ -13,4 +13,9 @@ extension String {
             .split(separator: target)
             .compactMap { String($0) }
     }
+    
+    var removedCommas: String {
+        return self.filter { $0.isNumber }
+    }
+    
 }

--- a/Calculator/Calculator/Extensions/String+Extensions.swift
+++ b/Calculator/Calculator/Extensions/String+Extensions.swift
@@ -18,4 +18,38 @@ extension String {
         return self.filter { $0 != "," }
     }
     
+    func convertNumberToPresentableFormat() throws -> String? {
+        let inputOperand = self
+        guard let operand = Double(inputOperand) else {
+            throw NumberFormatError.typeCastingFailed
+        }
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumFractionDigits = 20
+        
+        if inputOperand.contains(".") {
+            return try inputOperand.convertToPresentableWithDot()
+        }
+        
+        return numberFormatter.string(for: operand)
+    }
+    
+    private func convertToPresentableWithDot() throws -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumFractionDigits = 20
+        
+        let dotFront = self.split(with: ".")[0]
+        guard let formattedDotFront = numberFormatter.string(for: Double(dotFront)) else {
+            throw NumberFormatError.numberFormatFailed
+        }
+        
+        if self.split(with: ".").count == 1 {
+            return formattedDotFront + "."
+        }
+        
+        let dotBack = self.split(with: ".")[1]
+        
+        return formattedDotFront + "." + dotBack
+    }
 }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -23,8 +23,12 @@ struct CalculatorItemQueue<T> {
     }
     
     @discardableResult
-    mutating func dequeue() -> T? {
-        return list.retrieveHeadValue()
+    mutating func dequeue() throws -> T {
+        guard let headValue = list.retrieveHeadValue() else {
+            throw CalculateItemQueueError.queueIsEmpty
+        }
+
+        return headValue
     }
     
     mutating func removeAll() {

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -27,7 +27,6 @@ struct CalculatorItemQueue<T> {
         guard let headValue = list.retrieveHeadValue() else {
             throw CalculateItemQueueError.queueIsEmpty
         }
-
         return headValue
     }
     

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -11,12 +11,12 @@ struct Formula {
     var operands: CalculatorItemQueue<Double>
     var operators: CalculatorItemQueue<Operator>
     
-    mutating func result() -> Double {
-        guard var resultValue = operands.dequeue() else {
-            return Double.zero
-        }
-        while let currentOperator = operators.dequeue(),
-              let currentOperand = operands.dequeue() {
+    mutating func result() throws -> Double {
+        var resultValue = try operands.dequeue()
+        
+        while operators.isNotEmpty {
+            let currentOperator = try operators.dequeue()
+            let currentOperand = try operands.dequeue()
             resultValue = currentOperator.calculate(lhs: resultValue, rhs: currentOperand)
         }
         return resultValue

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -9,9 +9,9 @@ import Foundation
 
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
-    case subtract = "-"
-    case divide = "/"
-    case multiply = "*"
+    case subtract = "−"
+    case divide = "÷"
+    case multiply = "𝗑"
     
     func calculate(lhs: Double, rhs: Double) -> Double {
         switch self {

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -139,7 +139,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JnG-Mc-lMF"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="lcv-Ii-mvJ"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
@@ -151,7 +151,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Lb5-CD-ZSd"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AIG-tD-sqF"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
@@ -163,7 +163,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ft9-9V-Ouc"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ucG-Jp-KpF"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
@@ -192,7 +192,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="l8U-wf-Wpj"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fgo-i7-fJR"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
@@ -204,7 +204,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="82m-EQ-qCx"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AYK-Jz-jvx"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
@@ -216,7 +216,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="OSV-J6-GMQ"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vd2-hJ-wNk"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
@@ -245,7 +245,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6JT-4m-RTk"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HTc-Xu-Zvq"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
@@ -257,7 +257,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QRq-U7-RFA"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="v2H-ca-WN9"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
@@ -269,7 +269,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RK1-b8-hKf"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ejF-Go-Sqk"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
@@ -298,7 +298,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gUg-l6-gEt"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Edq-QO-er6"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
@@ -310,7 +310,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gZy-AV-dA5"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4O2-xF-piD"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
@@ -322,7 +322,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="e71-ZM-ufB"/>
+                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JBr-TX-24a"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
@@ -336,9 +336,6 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
-                                                <connections>
-                                                    <action selector="calculateButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AW5-Ow-f8o"/>
-                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="acButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RQI-KB-iII"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -97,6 +97,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="ceButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1g1-NQ-vgB"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -336,6 +336,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="calculateButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zsE-pU-ecL"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -86,7 +86,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="acButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RQI-KB-iII"/>
+                                                    <action selector="touchUpACButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RQI-KB-iII"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
@@ -98,7 +98,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="ceButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1g1-NQ-vgB"/>
+                                                    <action selector="touchUpCEButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1g1-NQ-vgB"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
@@ -110,7 +110,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="toggleSignButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2fG-dG-Q19"/>
+                                                    <action selector="touchUpSignButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2fG-dG-Q19"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
@@ -122,7 +122,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="G79-kC-Vm9"/>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="G79-kC-Vm9"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -139,7 +139,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="lcv-Ii-mvJ"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="lcv-Ii-mvJ"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
@@ -151,7 +151,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AIG-tD-sqF"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AIG-tD-sqF"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
@@ -163,7 +163,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ucG-Jp-KpF"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ucG-Jp-KpF"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
@@ -175,7 +175,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HOE-dV-xrA"/>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HOE-dV-xrA"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -192,7 +192,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fgo-i7-fJR"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fgo-i7-fJR"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
@@ -204,7 +204,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AYK-Jz-jvx"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AYK-Jz-jvx"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
@@ -216,7 +216,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vd2-hJ-wNk"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vd2-hJ-wNk"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
@@ -228,7 +228,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6eo-aC-PSg"/>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6eo-aC-PSg"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -245,7 +245,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HTc-Xu-Zvq"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HTc-Xu-Zvq"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
@@ -257,7 +257,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="v2H-ca-WN9"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="v2H-ca-WN9"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
@@ -269,7 +269,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ejF-Go-Sqk"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ejF-Go-Sqk"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
@@ -281,7 +281,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aeG-dG-t3V"/>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aeG-dG-t3V"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -298,7 +298,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Edq-QO-er6"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Edq-QO-er6"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
@@ -310,7 +310,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4O2-xF-piD"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4O2-xF-piD"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
@@ -322,7 +322,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="numberButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JBr-TX-24a"/>
+                                                    <action selector="touchUpDigitButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JBr-TX-24a"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
@@ -337,7 +337,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="calculateButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zsE-pU-ecL"/>
+                                                    <action selector="touchUpCalculateButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zsE-pU-ecL"/>
                                                 </connections>
                                             </button>
                                         </subviews>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -370,6 +370,7 @@
                     <connections>
                         <outlet property="currentNumberLabel" destination="Lwz-OF-XHD" id="hdC-Q9-Qsb"/>
                         <outlet property="currentOperatorLabel" destination="HPC-iy-qdm" id="70X-jP-Nf7"/>
+                        <outlet property="historyStackView" destination="XRe-QE-UJf" id="oY8-r4-PAc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -109,6 +109,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="toggleSignButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2fG-dG-Q19"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -377,8 +380,8 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="currentNumberLabel" destination="Lwz-OF-XHD" id="hdC-Q9-Qsb"/>
-                        <outlet property="currentOperatorLabel" destination="HPC-iy-qdm" id="70X-jP-Nf7"/>
+                        <outlet property="currentOperandLabel" destination="Lwz-OF-XHD" id="Zsn-QM-bwK"/>
+                        <outlet property="currentOperatorLabel" destination="HPC-iy-qdm" id="NZT-pb-9WR"/>
                         <outlet property="historyStackView" destination="XRe-QE-UJf" id="oY8-r4-PAc"/>
                     </connections>
                 </viewController>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -336,6 +336,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="calculateButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AW5-Ow-f8o"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -384,9 +384,9 @@
                     </view>
                     <connections>
                         <outlet property="calculationHistoryScrollView" destination="BOT-7g-vxv" id="yie-p4-L1s"/>
+                        <outlet property="calculationHistoryStackView" destination="XRe-QE-UJf" id="oY8-r4-PAc"/>
                         <outlet property="currentOperandLabel" destination="Lwz-OF-XHD" id="Zsn-QM-bwK"/>
                         <outlet property="currentOperatorLabel" destination="HPC-iy-qdm" id="NZT-pb-9WR"/>
-                        <outlet property="historyStackView" destination="XRe-QE-UJf" id="oY8-r4-PAc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -383,6 +383,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="calculationHistoryScrollView" destination="BOT-7g-vxv" id="yie-p4-L1s"/>
                         <outlet property="currentOperandLabel" destination="Lwz-OF-XHD" id="Zsn-QM-bwK"/>
                         <outlet property="currentOperatorLabel" destination="HPC-iy-qdm" id="NZT-pb-9WR"/>
                         <outlet property="historyStackView" destination="XRe-QE-UJf" id="oY8-r4-PAc"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -312,6 +312,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="e71-ZM-ufB"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -8,10 +8,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Calculator View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="CalculatorViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Calculator/CalculatorTests/Tests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/Tests/CalculatorItemQueueTests.swift
@@ -43,14 +43,14 @@ class CalculatorItemQueueTests: XCTestCase {
     }
     
     func testCalculatorQueueDequeue_givenRemoveAllOfMultipleMixedItems_expectIsEmpty() {
-        let newItems: [Any] = [20, "+", 30, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "−", 2]
         appendContents(of: newItems, to: &sut)
         sut.removeAll()
         XCTAssertTrue(sut.isEmpty)
     }
     
     func testCalculatorQueueDequeue_givenMultipleDequeue_expectIsEmpty() {
-        let newItems: [Any] = [20, "+", 30, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "−", 2]
         appendContents(of: newItems, to: &sut)
         removeAll(of: &sut)
         XCTAssertTrue(sut.isEmpty)

--- a/Calculator/CalculatorTests/Tests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/Tests/CalculatorItemQueueTests.swift
@@ -27,17 +27,17 @@ class CalculatorItemQueueTests: XCTestCase {
         XCTAssertTrue(sut.isNotEmpty)
     }
     
-    func testCalculatorItemQueueDequeue_givenNewInteger_expectFirstItemEqualToInsertedItem() {
+    func testCalculatorItemQueueDequeue_givenNewInteger_expectFirstItemEqualToInsertedItem() throws {
         let newData = 10
         sut.enqueue(newData)
-        guard let removedItem = sut.dequeue() as? Int else { return }
+        guard let removedItem = try sut.dequeue() as? Int else { return }
         XCTAssertEqual(removedItem, newData)
     }
     
-    func testCalculatorItemQueueDequeue_givenNewOperator_expectFirstItemEqualToInsertedItem() {
+    func testCalculatorItemQueueDequeue_givenNewOperator_expectFirstItemEqualToInsertedItem() throws {
         let newData = "+"
         sut.enqueue(newData)
-        let removedItem = sut.dequeue()
+        let removedItem = try sut.dequeue()
         guard let removedItem = removedItem as? String else { return }
         XCTAssertEqual(removedItem, newData)
     }
@@ -49,10 +49,10 @@ class CalculatorItemQueueTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
-    func testCalculatorQueueDequeue_givenMultipleDequeue_expectIsEmpty() {
+    func testCalculatorQueueDequeue_givenMultipleDequeue_expectIsEmpty() throws {
         let newItems: [Any] = [20, "+", 30, "−", 2]
         appendContents(of: newItems, to: &sut)
-        removeAll(of: &sut)
+        try removeAll(of: &sut)
         XCTAssertTrue(sut.isEmpty)
     }
     
@@ -89,9 +89,9 @@ class CalculatorItemQueueTests: XCTestCase {
         return nil
     }
     
-    private func removeAll(of queue: inout CalculatorItemQueue<Any>) {
+    private func removeAll(of queue: inout CalculatorItemQueue<Any>) throws {
         while queue.isNotEmpty {
-            queue.dequeue()
+            try queue.dequeue()
         }
     }
 }

--- a/Calculator/CalculatorTests/Tests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/Tests/ExpressionParserTests.swift
@@ -9,28 +9,28 @@ import XCTest
 @testable import Calculator
 class ExpressionParserTests: XCTestCase {
     
-    func testExpressionParserParse_givenMixedExpression_expectCorrectFormula() {
+    func testExpressionParserParse_givenMixedExpression_expectCorrectFormula() throws {
         let testOperands: [Double] = [10, 23, 4]
         let testOperators: [Operator] = [.add, .divide]
         var mockFormula = Formula(operands: createQueue(with: testOperands), operators: createQueue(with: testOperators))
         var resultFormula = ExpressionParser.parse(from: "10+23÷4")
-        XCTAssertTrue(isSameFormula(formula: &resultFormula, otherFormula: &mockFormula))
+        XCTAssertTrue(try isSameFormula(formula: &resultFormula, otherFormula: &mockFormula))
     }
     
-    func testExpressionParserParse_givenInvalidExpression_expectCorrectFormula() {
+    func testExpressionParserParse_givenInvalidExpression_expectCorrectFormula() throws {
         let testOperands: [Double] = [10, 23, 4]
         let testOperators: [Operator] = [.add, .divide, .subtract, .multiply]
         var mockFormula = Formula(operands: createQueue(with: testOperands), operators: createQueue(with: testOperators))
         var resultFormula = ExpressionParser.parse(from: "10+23÷4−𝗑")
-        XCTAssertTrue(isSameFormula(formula: &resultFormula, otherFormula: &mockFormula))
+        XCTAssertTrue(try isSameFormula(formula: &resultFormula, otherFormula: &mockFormula))
     }
     
-    func testExpressionParserParse_givenOnlyOperators_expectCorrectFormula() {
+    func testExpressionParserParse_givenOnlyOperators_expectCorrectFormula() throws {
         let testOperands: [Double] = []
         let testOperators: [Operator] = [.add, .divide, .subtract, .multiply]
         var mockFormula = Formula(operands: createQueue(with: testOperands), operators: createQueue(with: testOperators))
         var resultFormula = ExpressionParser.parse(from: "+÷−𝗑")
-        XCTAssertTrue(isSameFormula(formula: &resultFormula, otherFormula: &mockFormula))
+        XCTAssertTrue(try isSameFormula(formula: &resultFormula, otherFormula: &mockFormula))
     }
     
     private func createQueue<T>(with elements: [T]) -> CalculatorItemQueue<T> {
@@ -41,20 +41,19 @@ class ExpressionParserTests: XCTestCase {
         return queue
     }
     
-    private func isSameFormula(formula: inout Formula, otherFormula: inout Formula) -> Bool {
-        let firstFormulaOperands = convertToArray(from: &formula.operands)
-        let firstFormulaOperators = convertToArray(from: &formula.operators)
-        let secondFormulaOperands = convertToArray(from: &otherFormula.operands)
-        let secondFormulaOperators = convertToArray(from: &otherFormula.operators)
+    private func isSameFormula(formula: inout Formula, otherFormula: inout Formula) throws -> Bool {
+        let firstFormulaOperands = try convertToArray(from: &formula.operands)
+        let firstFormulaOperators = try convertToArray(from: &formula.operators)
+        let secondFormulaOperands = try convertToArray(from: &otherFormula.operands)
+        let secondFormulaOperators = try convertToArray(from: &otherFormula.operators)
         return firstFormulaOperands == secondFormulaOperands && firstFormulaOperators == secondFormulaOperators
     }
     
-    private func convertToArray<T>(from queue: inout CalculatorItemQueue<T>) -> [T] {
+    private func convertToArray<T>(from queue: inout CalculatorItemQueue<T>) throws -> [T] {
         var elements: [T] = []
         while queue.isNotEmpty {
-            if let element = queue.dequeue() {
-                elements.append(element)
-            }
+            let element = try queue.dequeue()
+            elements.append(element)
         }
         return elements
     }

--- a/Calculator/CalculatorTests/Tests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/Tests/ExpressionParserTests.swift
@@ -13,7 +13,7 @@ class ExpressionParserTests: XCTestCase {
         let testOperands: [Double] = [10, 23, 4]
         let testOperators: [Operator] = [.add, .divide]
         var mockFormula = Formula(operands: createQueue(with: testOperands), operators: createQueue(with: testOperators))
-        var resultFormula = ExpressionParser.parse(from: "10+23/4")
+        var resultFormula = ExpressionParser.parse(from: "10+23÷4")
         XCTAssertTrue(isSameFormula(formula: &resultFormula, otherFormula: &mockFormula))
     }
     
@@ -21,7 +21,7 @@ class ExpressionParserTests: XCTestCase {
         let testOperands: [Double] = [10, 23, 4]
         let testOperators: [Operator] = [.add, .divide, .subtract, .multiply]
         var mockFormula = Formula(operands: createQueue(with: testOperands), operators: createQueue(with: testOperators))
-        var resultFormula = ExpressionParser.parse(from: "10+23/4-*")
+        var resultFormula = ExpressionParser.parse(from: "10+23÷4−𝗑")
         XCTAssertTrue(isSameFormula(formula: &resultFormula, otherFormula: &mockFormula))
     }
     
@@ -29,7 +29,7 @@ class ExpressionParserTests: XCTestCase {
         let testOperands: [Double] = []
         let testOperators: [Operator] = [.add, .divide, .subtract, .multiply]
         var mockFormula = Formula(operands: createQueue(with: testOperands), operators: createQueue(with: testOperators))
-        var resultFormula = ExpressionParser.parse(from: "+/-*")
+        var resultFormula = ExpressionParser.parse(from: "+÷−𝗑")
         XCTAssertTrue(isSameFormula(formula: &resultFormula, otherFormula: &mockFormula))
     }
     

--- a/Calculator/CalculatorTests/Tests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/Tests/FormulaTests.swift
@@ -25,74 +25,76 @@ class FormulaTests: XCTestCase {
         sut = nil
     }
     
-    func testFormulaResult_given30Add20Subtract10_expect40() {
+    func testFormulaResult_given30Add20Subtract10_expect40() throws {
         let testOperands: [Double] = [30, 20, 10]
         let testOperators: [Operator] = [.add, .subtract]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertEqual(sut.result(), 40)
+        XCTAssertEqual(try sut.result(), 40)
     }
     
-    func testFormulaResult_givenNoNumberAndAdd_expectZero() {
+    func testFormulaResult_givenNoNumberAndAdd_expectZero() throws {
         let testOperands: [Double] = []
         let testOperators: [Operator] = [.add]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertTrue(sut.result().isZero)
+        XCTAssertThrowsError(try sut.result()) {
+            error in XCTAssertEqual(error as? CalculateItemQueueError, CalculateItemQueueError.queueIsEmpty)
+        }
     }
     
-    func testFormulaResult_given30Add20Subtract10Divide20_expect2() {
+    func testFormulaResult_given30Add20Subtract10Divide20_expect2() throws {
         let testOperands: [Double] = [30, 20, 10, 20]
         let testOperators: [Operator] = [.add, .subtract, .divide]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertEqual(sut.result(), 2)
+        XCTAssertEqual(try sut.result(), 2)
     }
     
-    func testFormulaResult_given30Divide10Divide10_expectOpoint3() {
+    func testFormulaResult_given30Divide10Divide10_expectOpoint3() throws {
         let testOperands: [Double] = [30, 10, 10]
         let testOperators: [Operator] = [.divide, .divide]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertEqual(sut.result(), 0.3)
+        XCTAssertEqual(try sut.result(), 0.3)
     }
     
-    func testFormulaResult_given30Multiply20Multiply10_expect6000() {
+    func testFormulaResult_given30Multiply20Multiply10_expect6000() throws {
         let testOperands: [Double] = [30, 20, 10]
         let testOperators: [Operator] = [.multiply, .multiply]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertEqual(sut.result(), 6000)
+        XCTAssertEqual(try sut.result(), 6000)
     }
     
-    func testFormulaResult_given100Divide0_expectNaN() {
+    func testFormulaResult_given100Divide0_expectNaN() throws {
         let testOperands: [Double] = [100, 0]
         let testOperators: [Operator] = [.divide]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertTrue(sut.result().isNaN)
+        XCTAssertTrue(try sut.result().isNaN)
     }
     
-    func testFormulaResult_given2Add3Multiply3Subtract1_expect14() {
+    func testFormulaResult_given2Add3Multiply3Subtract1_expect14() throws {
         let testOperands: [Double] = [2, 3, 3, 1]
         let testOperators: [Operator] = [.add, .multiply, .subtract]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertEqual(sut.result(), 14)
+        XCTAssertEqual(try sut.result(), 14)
     }
     
-    func testFormulaResult_given3Divide3Add2Subtract1_expect2() {
+    func testFormulaResult_given3Divide3Add2Subtract1_expect2() throws {
         let testOperands: [Double] = [3, 3, 2, 1]
         let testOperators: [Operator] = [.divide, .add, .subtract]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertEqual(sut.result(), 2)
+        XCTAssertEqual(try sut.result(), 2)
     }
     
-    func testFormulaResult_given1Add2Subtract3Multiply2Subtract3Divide6_expectNegativeZeroPoint5() {
+    func testFormulaResult_given1Add2Subtract3Multiply2Subtract3Divide6_expectNegativeZeroPoint5() throws {
         let testOperands: [Double] = [1, 2, 3, 2, 3, 6]
         let testOperators: [Operator] = [.add, .subtract, .multiply, .subtract, .divide]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertEqual(sut.result(), -0.5)
+        XCTAssertEqual(try sut.result(), -0.5)
     }
     
-    func testFormulaResult_given0Point123Divide1Point22340000_expect1Point2234() {
+    func testFormulaResult_given0Point123Divide1Point22340000_expect1Point2234() throws {
         let testOperands: [Double] = [0.123, 1.22340000]
         let testOperators: [Operator] = [.divide]
         setup(formula: &sut, with: testOperands, and: testOperators)
-        XCTAssertEqual(sut.result(), 0.10053948013732221)
+        XCTAssertEqual(try sut.result(), 0.10053948013732221)
     }
     
     private func setup(formula: inout Formula, with operands: [Double], and operators: [Operator]) {

--- a/Calculator/CalculatorTests/Tests/LinkedListTests.swift
+++ b/Calculator/CalculatorTests/Tests/LinkedListTests.swift
@@ -56,21 +56,21 @@ class LinkedListTests: XCTestCase {
     }
     
     func testLinkedListAppend_givenNewOperators_expectCorrectSequence() {
-        let newItems = ["+", "-", "*", "/"]
+        let newItems = ["+", "−", "𝗑", "÷"]
         appendContents(of: newItems, to: &sut)
         let convertedNewItems = convertToLinkedListArray(from: newItems)
         XCTAssertEqual(sut.convertedToDummyItemArray, convertedNewItems)
     }
     
     func testLinkedListAppend_givenMixedElements_expectCorrectSequence() {
-        let newItems: [Any] = [20, "+", 30, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "−", 2]
         appendContents(of: newItems, to: &sut)
         let convertedNewItems = convertToLinkedListArray(from: newItems) as [DummyItem]
         XCTAssertEqual(sut.convertedToDummyItemArray, convertedNewItems)
     }
     
     func testLinkedListRemoveHead_givenRemovedHeadFromMixedElements_expectRemovedHeadEqualsFirstInsertedItem() {
-        let newItems: [Any] = [20, "+", 30, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "−", 2]
         appendContents(of: newItems, to: &sut)
         let removedValue = sut.retrieveHeadValue()
         let firstInsertedItem = DummyItem.number(value: 20)
@@ -78,7 +78,7 @@ class LinkedListTests: XCTestCase {
     }
     
     func testLinkedListRemoveAll_givenRemoveAllFromElements_expectIsEmpty() {
-        let newItems: [Any] = [20, "+", 30, "-", 2]
+        let newItems: [Any] = [20, "+", 30, "−", 2]
         appendContents(of: newItems, to: &sut)
         sut.removeAll()
         XCTAssertTrue(sut.isEmpty)


### PR DESCRIPTION
안녕하세요 도미닉! @AppleCEO
이번 Step 에서 호박과 함께 서로의 프로젝트를 합쳐봤습니다!
합치면서 버그가 발생하는 부분들만 서로 보완하다보니, 조언을 얻고싶은 부분이 좀 적은것 같습니다😅
앞으로 리팩토링을 어떻게 해야되는지도 같이 고민을 해봤는데, 그 부분들에 대해서는 추후의 Step 에서 더 자세하게 여쭤보겠습니다!
혹시 저희가 아래에 적어둔 고민거리/리팩토링거리 이외의 수정이 필요한 부분들을 찝어주시면 감사하겠습니다!
리뷰 잘부탁드립니다🙏

## 고민했던 점

1. `UILabel` 의 내용을 바로 꺼내서 사용할지, 아니면 프로퍼티에 저장을 해놓다가 `UILabel` 은 따로 업데이트 시킬지 고민해봤습니다. 굳이 프로퍼티가 필요하지않을것 같아서 `STEP2` 에서 그 부분을 리팩토링 할 예정입니다.
    
    ```swift
    var currentOperandLabelText: String {
    	get {
    		if let operandString = currentOperandLabel.text {
    			return operandString
    		}
    	}
    	set {
    		currentOperandLabel.text = newValue
    	}
    }
    ```
    
    - 이런식으로 `UILabel` 의 내용물을 `get` , `set` 하는 방법도 고려해보고있습니다.
2. `NumberFormatter` , `UILabel`, `UIStackView` 인스턴스를 생성할때, `subclassing` 을 사용해서 custom class 를 이용하는 방법에 대해서 고민 해봤습니다. 
    1. 아직 적용 시키지는 않았지만, 추후에 리팩토링 할 때 적용 시켜볼 예정입니다.
3. `"0",` `""`, `8.0`, `0.0` 등, 하드코딩된 값들을 어떤식으로 관리할지에 대한 고민을 했습니다. 
    - 이것 또한 추후에 리팩토링 할 때  적용 시켜볼 예정입니다.

## 조언을 얻고싶은 점

1. 저번에 문자열을 관리하는 열거형에서 문자열을 리턴하기 위해서 `CustomStringConvertible` 프로토콜을 사용하라는 말씀을 주셔서 이번에 오류의 문자열 관리에도 사용해 보았습니다. 에러 관련한 문자열을 관리 할 때도 `CustomStringConvertible` 프로토콜을 사용하여 관리하는 것이 효과적인가요? 아니면 더 좋은 방법이 있을까요? 

```swift
enum CalculateItemQueueError: String, Error {
    case queueIsEmpty = "큐가 비어있습니다."
}

extension CalculateItemQueueError: CustomStringConvertible {
    var description: String {
        return rawValue
    }
}
```