### PR TITLE
계산기 모둠 [STEP 2] Jiseong, aCafela coffee

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		A634AFFC2740B06A0050CBFC /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A634AFFB2740B06A0050CBFC /* CalculateError.swift */; };
 		A634AFFD2740B8350050CBFC /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A634AFFB2740B06A0050CBFC /* CalculateError.swift */; };
 		A63C2ED727394B7900B89DE8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63C2ED627394B7900B89DE8 /* CalculatorItemQueue.swift */; };
-		A63C2ED927394B8C00B89DE8 /* CalculateItemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63C2ED827394B8C00B89DE8 /* CalculateItemProtocol.swift */; };
 		A6825FC1273D1AFD001FFD9B /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FC0273D1AFD001FFD9B /* Operator.swift */; };
 		A6825FC5273D245B001FFD9B /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FC4273D245B001FFD9B /* ExpressionParser.swift */; };
 		A6825FC7273D2478001FFD9B /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FC6273D2478001FFD9B /* Formula.swift */; };
@@ -18,9 +17,6 @@
 		A6E75470273E5FA7005ED9CB /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FC4273D245B001FFD9B /* ExpressionParser.swift */; };
 		A6E75471273E5FA9005ED9CB /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FC0273D1AFD001FFD9B /* Operator.swift */; };
 		A6E75472273E5FAB005ED9CB /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63C2ED627394B7900B89DE8 /* CalculatorItemQueue.swift */; };
-		A6E75473273E5FAE005ED9CB /* CalculateItemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63C2ED827394B8C00B89DE8 /* CalculateItemProtocol.swift */; };
-		A6E75476273E5FB3005ED9CB /* Double+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FBD273D1AAE001FFD9B /* Double+extension.swift */; };
-		A6E75477273E5FB3005ED9CB /* Double+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FBD273D1AAE001FFD9B /* Double+extension.swift */; };
 		A6E75479273E5FC8005ED9CB /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FEC273D2730001FFD9B /* OperatorTests.swift */; };
 		A6E7547A273E5FCA005ED9CB /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FDC273D26EF001FFD9B /* FormulaTests.swift */; };
 		A6E7547B273E5FCC005ED9CB /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6825FCE273D26CB001FFD9B /* ExpressionParserTests.swift */; };
@@ -46,9 +42,7 @@
 /* Begin PBXFileReference section */
 		A634AFFB2740B06A0050CBFC /* CalculateError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateError.swift; sourceTree = "<group>"; };
 		A63C2ED627394B7900B89DE8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
-		A63C2ED827394B8C00B89DE8 /* CalculateItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItemProtocol.swift; sourceTree = "<group>"; };
 		A63C2EE727397AFF00B89DE8 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
-		A6825FBD273D1AAE001FFD9B /* Double+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+extension.swift"; sourceTree = "<group>"; };
 		A6825FC0273D1AFD001FFD9B /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		A6825FC4273D245B001FFD9B /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		A6825FC6273D2478001FFD9B /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
@@ -92,28 +86,12 @@
 			path = Error;
 			sourceTree = "<group>";
 		};
-		A63C2EDC27394C6400B89DE8 /* Protocol */ = {
-			isa = PBXGroup;
-			children = (
-				A63C2ED827394B8C00B89DE8 /* CalculateItemProtocol.swift */,
-			);
-			path = Protocol;
-			sourceTree = "<group>";
-		};
 		A63C2EDD27394C7900B89DE8 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
 				C713D9452570E5EB001C3AFC /* ViewController.swift */,
 			);
 			path = Controller;
-			sourceTree = "<group>";
-		};
-		A6825FBF273D1AB2001FFD9B /* Extension */ = {
-			isa = PBXGroup;
-			children = (
-				A6825FBD273D1AAE001FFD9B /* Double+extension.swift */,
-			);
-			path = Extension;
 			sourceTree = "<group>";
 		};
 		A6825FF7273D2853001FFD9B /* Model */ = {
@@ -164,8 +142,6 @@
 				A634AFFE2740CB360050CBFC /* Error */,
 				A6825FF7273D2853001FFD9B /* Model */,
 				A63C2EDD27394C7900B89DE8 /* Controller */,
-				A63C2EDC27394C6400B89DE8 /* Protocol */,
-				A6825FBF273D1AB2001FFD9B /* Extension */,
 				C713D9472570E5EB001C3AFC /* Main.storyboard */,
 				C713D94A2570E5ED001C3AFC /* Assets.xcassets */,
 				C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */,
@@ -274,9 +250,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A6E75477273E5FB3005ED9CB /* Double+extension.swift in Sources */,
 				A6E75470273E5FA7005ED9CB /* ExpressionParser.swift in Sources */,
-				A6E75473273E5FAE005ED9CB /* CalculateItemProtocol.swift in Sources */,
 				A6E75471273E5FA9005ED9CB /* Operator.swift in Sources */,
 				A6E7547C273E5FCE005ED9CB /* CalculatorItemQueueTests.swift in Sources */,
 				A6E7547A273E5FCA005ED9CB /* FormulaTests.swift in Sources */,
@@ -295,10 +269,8 @@
 				A6825FC5273D245B001FFD9B /* ExpressionParser.swift in Sources */,
 				A634AFFC2740B06A0050CBFC /* CalculateError.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
-				A63C2ED927394B8C00B89DE8 /* CalculateItemProtocol.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				A6825FC1273D1AFD001FFD9B /* Operator.swift in Sources */,
-				A6E75476273E5FB3005ED9CB /* Double+extension.swift in Sources */,
 				A63C2ED727394B7900B89DE8 /* CalculatorItemQueue.swift in Sources */,
 				A6825FC7273D2478001FFD9B /* Formula.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -86,7 +86,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="ACButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iwG-mu-78h"/>
+                                                    <action selector="allClearButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Eke-KD-8nV"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
@@ -97,7 +97,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="CEButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UZ1-LS-Adf"/>
+                                                    <action selector="clearEntryButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="usM-uk-UXR"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
@@ -318,7 +318,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="EqualButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="39M-fO-dUP"/>
+                                                    <action selector="equalButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aFw-fD-DhJ"/>
                                                 </connections>
                                             </button>
                                         </subviews>

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -119,7 +119,7 @@ class ViewController: UIViewController {
     
     @IBAction private func equalButtonPressed(_ sender: UIButton) {
         guard symbolLabel.text?.isEmpty == false else { return }
-        addRecord(with: sender.currentTitle)
+        addRecord()
         entireFormula = removeComma(of: entireFormula)
         
         var formula = ExpressionParser.parse(from: entireFormula)
@@ -139,13 +139,13 @@ class ViewController: UIViewController {
         }
     }
     
-    private func addRecord(with operator: String?) {
+    private func addRecord(with operator: String? = nil) {
         recordingStackView.addArrangedSubview(formulaStackView)
         scrollToBottom()
         entireFormula += symbolLabel.text ?? ""
         entireFormula += numberLabel.text ?? ""
         
-        if `operator` != "=" {
+        if `operator` != nil {
             symbolLabel.text = `operator`
         }
     }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -11,7 +11,7 @@ class ViewController: UIViewController {
     private var resultNumber = ""
     private var entireFormula = ""
     
-    private var numberFormatter: NumberFormatter = NumberFormatter()
+    private let numberFormatter: NumberFormatter = NumberFormatter()
     
     private var operatorsLabel: UILabel {
         let operatorsLabel = UILabel()
@@ -51,7 +51,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         initializeNumberLabel()
         initializeSymbolLabel()
-        initializeNumberFormatter(of: numberFormatter)
+        initializeNumberFormatter()
         recordingStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
     }
     
@@ -159,9 +159,9 @@ class ViewController: UIViewController {
         symbolLabel.text?.removeAll()
     }
     
-    private func initializeNumberFormatter(of formatter: NumberFormatter) {
-        formatter.numberStyle = .decimal
-        formatter.maximumSignificantDigits = 20
+    private func initializeNumberFormatter() {
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = 20
     }
     
     private func removeComma(of string: String) -> String {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -19,7 +19,7 @@ class ViewController: UIViewController {
         operatorsLabel.textColor = .white
         operatorsLabel.textAlignment = .right
         operatorsLabel.adjustsFontForContentSizeCategory = true
-        
+    
         return operatorsLabel
     }
     
@@ -61,7 +61,7 @@ class ViewController: UIViewController {
             
             inputNumber += sender.currentTitle ?? ""
             
-            if inputNumber.contains(".") {
+            if inputNumber.isContainDot {
                 numberLabel.text = inputNumber
             } else {
                 numberLabel.text = numberFormatter.string(for: Double(inputNumber))
@@ -88,9 +88,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction private func dotButtonPressed(_ sender: UIButton) {
-        guard var text = numberLabel.text else { return }
-        
-        guard !isContainDot(text: text) else { return }
+        guard var text = numberLabel.text, text.isContainDot == false else { return }
         
         text += "."
         inputNumber = text
@@ -158,10 +156,6 @@ class ViewController: UIViewController {
         symbolLabel.text?.removeAll()
     }
     
-    private func isContainDot(text: String) -> Bool {
-        return text.contains(".")
-    }
-    
     private func initializeNumberFormatter(of formatter: NumberFormatter) {
         formatter.numberStyle = .decimal
         formatter.maximumSignificantDigits = 20
@@ -174,5 +168,11 @@ class ViewController: UIViewController {
     private func scrollToBottom(_ scrollView: UIScrollView) {
         scrollView.layoutIfNeeded()
         scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.frame.height), animated: false)
+    }
+}
+
+fileprivate extension String {
+    var isContainDot: Bool {
+        return self.contains(".")
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -74,9 +74,8 @@ class ViewController: UIViewController {
     }
     
     @IBAction private func operatorButtonPressed(_ sender: UIButton) {
-        if numberLabel.text == "0" {
+        if numberLabel.text == "0" || resultNumber == numberLabel.text {
             symbolLabel.text = sender.currentTitle
-            return
         } else {
             addRecord(with: sender.currentTitle)
         }
@@ -140,10 +139,6 @@ class ViewController: UIViewController {
     }
     
     private func addRecord(with operator: String?) {
-        if resultNumber == numberLabel.text {
-            symbolLabel.text = `operator`
-            return
-        }
         recordingStackView.addArrangedSubview(formulaStackView)
         scrollToBottom(calculatorScrollView)
         entireFormula += symbolLabel.text ?? ""

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -81,7 +81,7 @@ class ViewController: UIViewController {
             addRecord(with: sender.currentTitle)
         }
         initializeNumberLabel()
-        scrollToBottom(calculatorScrollView)
+        scrollToBottom()
     }
     
     @IBAction private func CEButtonPressed(_ sender: UIButton) {
@@ -141,7 +141,7 @@ class ViewController: UIViewController {
     
     private func addRecord(with operator: String?) {
         recordingStackView.addArrangedSubview(formulaStackView)
-        scrollToBottom(calculatorScrollView)
+        scrollToBottom()
         entireFormula += symbolLabel.text ?? ""
         entireFormula += numberLabel.text ?? ""
         
@@ -168,9 +168,9 @@ class ViewController: UIViewController {
         return string.replacingOccurrences(of: ",", with: "")
     }
     
-    private func scrollToBottom(_ scrollView: UIScrollView) {
-        scrollView.layoutIfNeeded()
-        scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.frame.height), animated: false)
+    private func scrollToBottom() {
+        calculatorScrollView.layoutIfNeeded()
+        calculatorScrollView.setContentOffset(CGPoint(x: 0, y: calculatorScrollView.contentSize.height - calculatorScrollView.frame.height), animated: false)
     }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -84,7 +84,7 @@ class ViewController: UIViewController {
         scrollToBottom()
     }
     
-    @IBAction private func CEButtonPressed(_ sender: UIButton) {
+    @IBAction private func clearEntryButtonPressed(_ sender: UIButton) {
         initializeNumberLabel()
     }
     
@@ -109,7 +109,7 @@ class ViewController: UIViewController {
         numberLabel.text = inputNumber
     }
     
-    @IBAction private func ACButtonPressed(_ sender: UIButton) {
+    @IBAction private func allClearButtonPressed(_ sender: UIButton) {
         recordingStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         entireFormula.removeAll()
         resultNumber.removeAll()
@@ -117,7 +117,7 @@ class ViewController: UIViewController {
         initializeSymbolLabel()
     }
     
-    @IBAction private func EqualButtonPressed(_ sender: UIButton) {
+    @IBAction private func equalButtonPressed(_ sender: UIButton) {
         guard symbolLabel.text?.isEmpty == false else { return }
         addRecord(with: sender.currentTitle)
         entireFormula = removeComma(of: entireFormula)

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -56,9 +56,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction private func numberButtonPressed(_ sender: UIButton) {
+        guard resultNumber != numberLabel.text else { return }
+        
         if sender.currentTitle == "0" || sender.currentTitle == "00" {
             guard inputNumber.isEmpty == false else { return }
-            
+
             inputNumber += sender.currentTitle ?? ""
             
             if inputNumber.isContainDot {
@@ -66,7 +68,6 @@ class ViewController: UIViewController {
             } else {
                 numberLabel.text = numberFormatter.string(for: Double(inputNumber))
             }
-            
         } else {
             inputNumber += sender.currentTitle ?? ""
             numberLabel.text = numberFormatter.string(for: Double(removeComma(of: inputNumber)))

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -83,7 +83,9 @@ class ViewController: UIViewController {
         } else {
             recordingStackView.addArrangedSubview(formulaStackView)
             symbolLabel.text = sender.currentTitle
-            addEntireFormula()
+            guard let number = numberLabel.text, let symbol = symbolLabel.text else { return }
+            entireFormula += number
+            entireFormula += symbol
         }
         initializeNumberLabel()
         scrollToBottom(calculatorScrollView)
@@ -161,12 +163,6 @@ class ViewController: UIViewController {
         return text.contains(".")
     }
     
-    private func addEntireFormula() {
-        guard let number = numberLabel.text, let symbol = symbolLabel.text else { return }
-        entireFormula += number
-        entireFormula += symbol
-    }
-    
     private func initializeNumberFormatter(of formatter: NumberFormatter) {
         formatter.numberStyle = .decimal
         formatter.maximumSignificantDigits = 20
@@ -181,5 +177,3 @@ class ViewController: UIViewController {
         scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.frame.height), animated: false)
     }
 }
-
-

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -8,6 +8,7 @@ class ViewController: UIViewController {
     @IBOutlet private weak var calculatorScrollView: UIScrollView!
     
     private var inputNumber = ""
+    private var resultNumber = ""
     private var entireFormula = ""
     
     private var numberFormatter: NumberFormatter = NumberFormatter()
@@ -76,6 +77,9 @@ class ViewController: UIViewController {
         if numberLabel.text == "0" {
             symbolLabel.text = sender.currentTitle
             return
+        } else if resultNumber == numberLabel.text {
+            symbolLabel.text = sender.currentTitle
+            entireFormula += symbolLabel.text ?? ""
         } else {
             recordingStackView.addArrangedSubview(formulaStackView)
             symbolLabel.text = sender.currentTitle
@@ -115,6 +119,7 @@ class ViewController: UIViewController {
     @IBAction private func ACButtonPressed(_ sender: UIButton) {
         recordingStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         entireFormula.removeAll()
+        resultNumber.removeAll()
         initializeNumberLabel()
         initializeSymbolLabel()
     }
@@ -133,6 +138,7 @@ class ViewController: UIViewController {
             initializeSymbolLabel()
             let result = try formula.result()
             numberLabel.text = numberFormatter.string(for: result)
+            resultNumber = numberLabel.text ?? ""
         } catch CalculateError.emptyQueue {
             return
         } catch CalculateError.divideWithZero {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -77,15 +77,8 @@ class ViewController: UIViewController {
         if numberLabel.text == "0" {
             symbolLabel.text = sender.currentTitle
             return
-        } else if resultNumber == numberLabel.text {
-            symbolLabel.text = sender.currentTitle
-            entireFormula += symbolLabel.text ?? ""
         } else {
-            recordingStackView.addArrangedSubview(formulaStackView)
-            symbolLabel.text = sender.currentTitle
-            guard let number = numberLabel.text, let symbol = symbolLabel.text else { return }
-            entireFormula += number
-            entireFormula += symbol
+            addRecord(with: sender.currentTitle)
         }
         initializeNumberLabel()
         scrollToBottom(calculatorScrollView)
@@ -128,14 +121,10 @@ class ViewController: UIViewController {
     
     @IBAction private func EqualButtonPressed(_ sender: UIButton) {
         guard symbolLabel.text?.isEmpty == false else { return }
-        
-        recordingStackView.addArrangedSubview(formulaStackView)
-        
-        entireFormula += numberLabel.text ?? ""
+        addRecord(with: sender.currentTitle)
         entireFormula = removeComma(of: entireFormula)
         
         var formula = ExpressionParser.parse(from: entireFormula)
-        
         do {
             initializeSymbolLabel()
             let result = try formula.result()
@@ -147,6 +136,21 @@ class ViewController: UIViewController {
             numberLabel.text = "NaN"
         } catch {
             print(error)
+        }
+    }
+    
+    private func addRecord(with operator: String?) {
+        if resultNumber == numberLabel.text {
+            symbolLabel.text = `operator`
+            return
+        }
+        recordingStackView.addArrangedSubview(formulaStackView)
+        scrollToBottom(calculatorScrollView)
+        entireFormula += symbolLabel.text ?? ""
+        entireFormula += numberLabel.text ?? ""
+        
+        if `operator` != "=" {
+            symbolLabel.text = `operator`
         }
     }
     

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -1,4 +1,4 @@
-struct CalculatorItemQueue<Element: CalculateItem> {
+struct CalculatorItemQueue<Element> {
     private var inputStack = [Element]()
     private var outputStack = [Element]()
     

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -37,12 +37,3 @@ fileprivate extension String {
         return result
     }
 }
-
-fileprivate extension Character {
-    init?(text: String) {
-        guard text.count == 1 else {
-            return nil
-        }
-        self.init(text)
-    }
-}

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -1,4 +1,4 @@
-enum Operator: Character, CaseIterable, CalculateItem {
+enum Operator: Character, CaseIterable {
     case add = "+"
     case substract = "−"
     case divide = "÷"

--- a/Calculator/Calculator/Protocol/CalculateItemProtocol.swift
+++ b/Calculator/Calculator/Protocol/CalculateItemProtocol.swift
@@ -1,1 +1,0 @@
-protocol CalculateItem { }


### PR DESCRIPTION
안녕하세요 메이슨! ([@myssun0325](https://github.com/myssun0325))
Jiseong, aCafela 입니다!
계산기 모둠 Step2 PR 제출합니다.

viewController.swift 리펙터링 했어요.

잘부탁드립니다

## 고민한 점

### CalculatorItemQueue 제네릭 타입

큐를 범용적이게 만들어주기 위해 타입 제약을 걸었던 `CalculateItem` 프로토콜을 제거하였습니다.

### 가독성 개선을 위한 수정

버튼의 액션함수 내부 코드가 조건 판단 등 많은 일을 맡고, 가독성이 좋지 않아 함수를 분리하였습니다.
`entireFormula` 프로퍼티에 값을 추가할때 `addRecord(with:)` 함수를 사용하도록 수정
`scrollToBottom()`, `initializeNumberFormatter()` 함수의 파라미터 제거

### 버그 수정

계산 결과가 레코드(스크롤 뷰)에 추가되는걸 막기 위한 수정입니다.
`resultNumber` 프로퍼티와 비교해서, `numberLabel`이 계산 결과인지 확인합니다.

## 조언받고 싶은 점

### ViewController 내부 코드 분류

현재 ViewController의 크기가 방대해져 우선 프로퍼티는 프로퍼티끼리, 액션함수는 액션함수끼리, 그 외 함수들은 함수들끼리 정리를 하였는데 저희가 아는 방법은 Mark 주석을 활용하여 분류를 명시하거나 extension 을 활용하여 분류를 명시하는 것인데, 어느 것이 더 일반적으로 사용하는 방법인지 몰라서 조언을 얻고싶습니다. 메이슨은 ViewController가 방대해졌을때 보통 어떤식으로 분류해주시나요? 혹시 저희가 아는 방법보다 더 좋은 방법이 있다면 알고싶습니다!

### 액션함수 네이밍 (버튼)

Swift API Guideline을 찾아봐도 액션함수에 대한 네이밍에 대한 글은 찾지못했습니다. 저희는 버튼 액션함수명으로 `~~ButtonPressed()` 라고 네이밍을 해주었는데, 저희가 한 네이밍이 일반적으로 많이 쓰이는 것인지 궁금합니다! 
메이슨은 액션함수 네이밍을 어떻게 해주시나요?