### PR TITLE
계산기(모둠) STEP2 고사리, Allie

### DIFF
--- a/Calculator/Calculator/Error/CalculateError.swift
+++ b/Calculator/Calculator/Error/CalculateError.swift
@@ -7,13 +7,15 @@
 
 import Foundation
 
-enum CalculateError: Error, CustomStringConvertible {
+enum CalculateError: Error {
     case divideByZero
-    
-    var description: String {
+}
+
+extension CalculateError: LocalizedError {
+    var errorDescription: String? {
         switch self {
         case .divideByZero:
-                    return "Cannot divide by zero"
+            return "Cannot divide by zero"
         }
     }
 }

--- a/Calculator/Calculator/Error/CalculatorQueueError.swift
+++ b/Calculator/Calculator/Error/CalculatorQueueError.swift
@@ -7,10 +7,12 @@
 
 import Foundation
 
-enum CalculatorQueueError: Error, CustomStringConvertible {
+enum CalculatorQueueError: Error {
     case emptyQueue
-    
-    var description: String {
+}
+
+extension CalculatorQueueError: LocalizedError {
+    var errorDescription: String? {
         switch self {
         case .emptyQueue:
             return "Queue is Empty"

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -15,7 +15,7 @@ struct CalculatorItemQueue<Element: CalculateItem> {
         return enQueueElements.isEmpty && deQueueElements.isEmpty
     }
     
-    mutating func enQueueElement(_ element: Element) {
+    mutating func enQueue(_ element: Element) {
         enQueueElements.append(element)
     }
     

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -15,10 +15,6 @@ struct CalculatorItemQueue<Element: CalculateItem> {
         return enQueueElements.isEmpty && deQueueElements.isEmpty
     }
     
-    init(_ enQueueElements: [Element]) {
-        self.enQueueElements = enQueueElements
-    }
-    
     mutating func enQueueElement(_ element: Element) {
         enQueueElements.append(element)
     }
@@ -32,5 +28,11 @@ struct CalculatorItemQueue<Element: CalculateItem> {
             enQueueElements.removeAll()
         }
         return deQueueElements.removeLast()
+    }
+}
+
+extension CalculatorItemQueue {
+    init(_ enQueueElements: [Element]) {
+        self.enQueueElements = enQueueElements
     }
 }

--- a/Calculator/Calculator/Model/CalcultorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalcultorItemQueue.swift
@@ -30,9 +30,3 @@ struct CalculatorItemQueue<Element: CalculateItem> {
         return deQueueElements.removeLast()
     }
 }
-
-extension CalculatorItemQueue {
-    init(_ enQueueElements: [Element]) {
-        self.enQueueElements = enQueueElements
-    }
-}

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -12,8 +12,8 @@ enum ExpressionParser {
         let operands = componentsByOperators(from: input).compactMap { Double($0) }
         let operators = input.compactMap { Operator(rawValue: $0) }
         return Formula(
-            operands: CalculatorItemQueue(operands),
-            operators: CalculatorItemQueue(operators)
+            operands: CalculatorItemQueue(enQueueElements: operands),
+            operators: CalculatorItemQueue(enQueueElements: operators)
         )
     }
     

--- a/Calculator/CalculatorTests/CalculatorItemQueue.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueue.swift
@@ -21,15 +21,15 @@ class CalculatorItemQueueTests: XCTestCase {
     }
     
     func test_enQueue에_요소를_추가했을때_잘들어가는지() {
-        sut.enQueueElement(1)
+        sut.enQueue(1)
         
         XCTAssertEqual(sut.enQueueElements, [1])
     }
     
     func test_enQueue에_여러개의_요소를_추가했을때_잘들어가는지() {
-        sut.enQueueElement(1)
-        sut.enQueueElement(2)
-        sut.enQueueElement(3)
+        sut.enQueue(1)
+        sut.enQueue(2)
+        sut.enQueue(3)
         
         XCTAssertEqual(sut.enQueueElements, [1, 2, 3])
     }
@@ -39,9 +39,9 @@ class CalculatorItemQueueTests: XCTestCase {
     }
     
     func test_enQueue에_요소여러개를_추가하고_deQueue했을때_마지막요소가_빠지는지() {
-        sut.enQueueElement(1)
-        sut.enQueueElement(2)
-        sut.enQueueElement(3)
+        sut.enQueue(1)
+        sut.enQueue(2)
+        sut.enQueue(3)
         
         XCTAssertEqual(try sut.deQueueFirstElement(), 1)
     }

--- a/Calculator/CalculatorTests/CalculatorItemQueue.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueue.swift
@@ -12,7 +12,7 @@ class CalculatorItemQueueTests: XCTestCase {
    
     override func setUpWithError() throws {
         try super.setUpWithError()
-        sut = CalculatorItemQueue([])
+        sut = CalculatorItemQueue(enQueueElements: [])
     }
 
     override func tearDownWithError() throws {

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -13,8 +13,8 @@ class FormulaTests: XCTestCase {
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        operands = CalculatorItemQueue<Double>([])
-        operators = CalculatorItemQueue<Operator>([])
+        operands = CalculatorItemQueue<Double>(enQueueElements: [])
+        operators = CalculatorItemQueue<Operator>(enQueueElements: [])
     }
 
     override func tearDownWithError() throws {
@@ -24,45 +24,45 @@ class FormulaTests: XCTestCase {
     }
     
     func test_result메서드를_호출했을때_더하기가_잘되는지() {
-        operands.enQueueElement(1994)
-        operands.enQueueElement(1004)
-        operators.enQueueElement(Operator.add)
+        operands.enQueue(1994)
+        operands.enQueue(1004)
+        operators.enQueue(Operator.add)
         var formula = Formula(operands: operands, operators: operators)
         
         XCTAssertEqual(try formula.result(), 2998)
     }
     
     func test_result메서드를_호출했을때_빼기가_잘되는지() {
-        operands.enQueueElement(1994)
-        operands.enQueueElement(1004)
-        operators.enQueueElement(Operator.subtract)
+        operands.enQueue(1994)
+        operands.enQueue(1004)
+        operators.enQueue(Operator.subtract)
         var formula = Formula(operands: operands, operators: operators)
         
         XCTAssertEqual(try formula.result(), 990)
     }
     
     func test_result메서드를_호출했을때_곱하기가_잘되는지() {
-        operands.enQueueElement(10)
-        operands.enQueueElement(4)
-        operators.enQueueElement(Operator.multiply)
+        operands.enQueue(10)
+        operands.enQueue(4)
+        operators.enQueue(Operator.multiply)
         var formula = Formula(operands: operands, operators: operators)
         
         XCTAssertEqual(try formula.result(), 40)
     }
     
     func test_result메서드를_호출했을때_나누기가_잘되는지() {
-        operands.enQueueElement(10)
-        operands.enQueueElement(4)
-        operators.enQueueElement(Operator.divide)
+        operands.enQueue(10)
+        operands.enQueue(4)
+        operators.enQueue(Operator.divide)
         var formula = Formula(operands: operands, operators: operators)
         
         XCTAssertEqual(try formula.result(), 2.5)
     }
    
     func test_0으로_나누려고할때_에러를_던지는지() {
-        operands.enQueueElement(10)
-        operands.enQueueElement(0)
-        operators.enQueueElement(Operator.divide)
+        operands.enQueue(10)
+        operands.enQueue(0)
+        operators.enQueue(Operator.divide)
         var formula = Formula(operands: operands, operators: operators)
         
         XCTAssertThrowsError(try formula.result())


### PR DESCRIPTION
안녕하세요, 엘림! @lina0322 Step 2의 1차 PR 요청드립니다.

step 1의 리뷰로 말씀해주신 내용은 step 2의 PR에 포함하였으며, step 1의 코멘트로 남겨주신 개선점은 해당 코멘트의 답변으로 달았습니다. 개선된 코드의 커밋은 teamStep2 브랜치에 포함시켰으니 참고 부탁드릴게요😊

1. CustomStringConvertible 과 LocalizedError의 errorDescription 프로퍼티를 사용하는 차이에 대해서 고민해보았습니다.
    1. 기능적 차이는 확인하지 못하였으나, 누구나 errorDescription을 읽으면 의도를 유추할 수 있기 때문에 가독성이 향상되는 장점이 있을 거라고 추측해보았습니다.
    2. extension으로 오류 메세지를 따로 관리하는 것이 각자의 역할을 분명히 하여 객체 지향적이라고 판단하였습니다.
2. CalculatorItemQueue의 enQueueElement 메서드의 네이밍이 불필요한 단어가 중복되는 것 같아 enQueue로 수정하였습니다. 해당 네이밍을 선택하게 된 이유에 대해서는 링크를 첨부하겠습니다! 
    1. [참고링크](https://github.com/yagom-academy/ios-juice-maker/pull/120#discussion_r737175059)
3.  

> 혹시 사용한 reversed가 시간복잡도가 O(n)이 나온것은 어떻게 확인하셨나요?제가 알기로는 reversed()는 뒤집어서 새로운 메모리에 바로 저장하기때문에 O(1)이 나오는 것으로 알고있거든요🤔
> 

→ 저희도 처음에 O(1)이라고 생각했는데, 코드에서 확인해보니 아래와같이 O(n)이라고 나오더라구요! 아래와 같이 reversed() 메서드가 두종류가 있는 것 같습니다..!

![image](https://user-images.githubusercontent.com/85180502/143435723-c94230d4-6d3d-4c65-b1c7-f9cc2e9d383c.png)

![image](https://user-images.githubusercontent.com/85180502/143435787-68579c89-ec63-4678-80fc-bb507a41830b.png)

4.

> b가 array인가요..? 더블 스택이 현재 요구사항에 있는 부분이라서, 왜 요구사항에 더블스택에 있느냐고 여쭤보시는걸까요?
> 

→ **큐타입 구현(요구사항)**을 위해서 현재는 array 두 개로 더블스택을 구현하는 방법을 사용하고 있는데요, array 하나만을 생성하여 reversed - removeLast - reversed의 순서로 가는 방법도 있을 것 같아서요! 굳이 더블스택을 꼭 사용해야하는건가 라는 생각이 들어서 질문드렸습니다!ㅎㅎ

5.  

> 질문이 잘 이해가 안가는데요..! 두 분이 고정 공간을 고려하여 공간 복잡도를 계산하셨다고 했는데, 어떤 방법으로 계산하셨는지 그리고 어떤 결과가 나오신건지요?😀
> 

→ 고정 공간과 가변 공간을 토대로 계산되는 공간 복잡도에서 고정 공간이란, `입력과 출력의 횟수나 크기와 관계없는 공간의 요구(코드 저장 공간, 단순 변수, 고정 크기의 구조 변수, 상수)`를 의미합니다.

이것을 기반으로 linked list와 `double stack`을 보았을 때, 후자는 `기존 배열을 사용하여 고정 공간이 상대적으로 적게 요구`되기 때문에 double stack의 공간 복잡도가 낫다고 계산하였습니다.