### PR TITLE
계산기 1 [STEP 2] Doogie

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		AC2801D627E173DB0029363B /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2801D527E173DB0029363B /* CalculatorItemQueue.swift */; };
 		AC2801D827E173EB0029363B /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2801D727E173EB0029363B /* CalculateItem.swift */; };
 		AC2801E027E175530029363B /* CalculatorItemQueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2801DF27E175530029363B /* CalculatorItemQueueTest.swift */; };
+		AC2833DA27E4360D00214D70 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2833D927E4360D00214D70 /* Operator.swift */; };
+		AC2833DC27E4544900214D70 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2833DB27E4544900214D70 /* Formula.swift */; };
+		AC2833E427E4571F00214D70 /* FormulaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2833E327E4571F00214D70 /* FormulaTest.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -26,6 +29,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		AC2833E527E4571F00214D70 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +43,10 @@
 		AC2801D727E173EB0029363B /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		AC2801DD27E175530029363B /* CalculatorItemQueueTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC2801DF27E175530029363B /* CalculatorItemQueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTest.swift; sourceTree = "<group>"; };
+		AC2833D927E4360D00214D70 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		AC2833DB27E4544900214D70 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		AC2833E127E4571F00214D70 /* FormulaTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC2833E327E4571F00214D70 /* FormulaTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTest.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -45,6 +59,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		AC2801DA27E175530029363B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC2833DE27E4571F00214D70 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -76,6 +97,8 @@
 			children = (
 				AC2801D527E173DB0029363B /* CalculatorItemQueue.swift */,
 				AC2801D727E173EB0029363B /* CalculateItem.swift */,
+				AC2833D927E4360D00214D70 /* Operator.swift */,
+				AC2833DB27E4544900214D70 /* Formula.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -98,11 +121,20 @@
 			path = CalculatorItemQueueTest;
 			sourceTree = "<group>";
 		};
+		AC2833E227E4571F00214D70 /* FormulaTest */ = {
+			isa = PBXGroup;
+			children = (
+				AC2833E327E4571F00214D70 /* FormulaTest.swift */,
+			);
+			path = FormulaTest;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				AC2801DE27E175530029363B /* CalculatorItemQueueTest */,
+				AC2833E227E4571F00214D70 /* FormulaTest */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -112,6 +144,7 @@
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				AC2801DD27E175530029363B /* CalculatorItemQueueTest.xctest */,
+				AC2833E127E4571F00214D70 /* FormulaTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -148,6 +181,24 @@
 			productReference = AC2801DD27E175530029363B /* CalculatorItemQueueTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		AC2833E027E4571F00214D70 /* FormulaTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AC2833E727E4571F00214D70 /* Build configuration list for PBXNativeTarget "FormulaTest" */;
+			buildPhases = (
+				AC2833DD27E4571F00214D70 /* Sources */,
+				AC2833DE27E4571F00214D70 /* Frameworks */,
+				AC2833DF27E4571F00214D70 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AC2833E627E4571F00214D70 /* PBXTargetDependency */,
+			);
+			name = FormulaTest;
+			productName = FormulaTest;
+			productReference = AC2833E127E4571F00214D70 /* FormulaTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -178,6 +229,10 @@
 						CreatedOnToolsVersion = 13.2.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					AC2833E027E4571F00214D70 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -198,12 +253,20 @@
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				AC2801DC27E175530029363B /* CalculatorItemQueueTest */,
+				AC2833E027E4571F00214D70 /* FormulaTest */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		AC2801DB27E175530029363B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC2833DF27E4571F00214D70 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -231,11 +294,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AC2833DD27E4571F00214D70 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AC2833E427E4571F00214D70 /* FormulaTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				AC2801D827E173EB0029363B /* CalculateItem.swift in Sources */,
+				AC2833DC27E4544900214D70 /* Formula.swift in Sources */,
+				AC2833DA27E4360D00214D70 /* Operator.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				AC2801D627E173DB0029363B /* CalculatorItemQueue.swift in Sources */,
@@ -250,6 +323,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = AC2801E127E175530029363B /* PBXContainerItemProxy */;
+		};
+		AC2833E627E4571F00214D70 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = AC2833E527E4571F00214D70 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -306,6 +384,47 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Doogie.CalculatorItemQueueTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		AC2833E827E4571F00214D70 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SD8J3B58T9;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = Doogie.FormulaTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		AC2833E927E4571F00214D70 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SD8J3B58T9;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Doogie.FormulaTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -481,6 +600,15 @@
 			buildConfigurations = (
 				AC2801E427E175530029363B /* Debug */,
 				AC2801E527E175530029363B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AC2833E727E4571F00214D70 /* Build configuration list for PBXNativeTarget "FormulaTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AC2833E827E4571F00214D70 /* Debug */,
+				AC2833E927E4571F00214D70 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		AC2833E427E4571F00214D70 /* FormulaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2833E327E4571F00214D70 /* FormulaTest.swift */; };
 		ACE2158427E81FCF0029EB52 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE2158327E81FCF0029EB52 /* ExpressionParser.swift */; };
 		ACE2158627E822DF0029EB52 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE2158527E822DF0029EB52 /* Extensions.swift */; };
+		ACE2158E27E82C970029EB52 /* ExpressionParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE2158D27E82C970029EB52 /* ExpressionParserTest.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -38,6 +39,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		ACE2158F27E82C970029EB52 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +59,8 @@
 		AC2833E327E4571F00214D70 /* FormulaTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTest.swift; sourceTree = "<group>"; };
 		ACE2158327E81FCF0029EB52 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		ACE2158527E822DF0029EB52 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		ACE2158B27E82C970029EB52 /* ExpressionParserTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionParserTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		ACE2158D27E82C970029EB52 /* ExpressionParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTest.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -70,6 +80,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		AC2833DE27E4571F00214D70 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ACE2158827E82C970029EB52 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -135,12 +152,21 @@
 			path = FormulaTest;
 			sourceTree = "<group>";
 		};
+		ACE2158C27E82C970029EB52 /* ExpressionParserTest */ = {
+			isa = PBXGroup;
+			children = (
+				ACE2158D27E82C970029EB52 /* ExpressionParserTest.swift */,
+			);
+			path = ExpressionParserTest;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				AC2801DE27E175530029363B /* CalculatorItemQueueTest */,
 				AC2833E227E4571F00214D70 /* FormulaTest */,
+				ACE2158C27E82C970029EB52 /* ExpressionParserTest */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -151,6 +177,7 @@
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				AC2801DD27E175530029363B /* CalculatorItemQueueTest.xctest */,
 				AC2833E127E4571F00214D70 /* FormulaTest.xctest */,
+				ACE2158B27E82C970029EB52 /* ExpressionParserTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -205,6 +232,24 @@
 			productReference = AC2833E127E4571F00214D70 /* FormulaTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		ACE2158A27E82C970029EB52 /* ExpressionParserTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ACE2159127E82C970029EB52 /* Build configuration list for PBXNativeTarget "ExpressionParserTest" */;
+			buildPhases = (
+				ACE2158727E82C970029EB52 /* Sources */,
+				ACE2158827E82C970029EB52 /* Frameworks */,
+				ACE2158927E82C970029EB52 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				ACE2159027E82C970029EB52 /* PBXTargetDependency */,
+			);
+			name = ExpressionParserTest;
+			productName = ExpressionParserTest;
+			productReference = ACE2158B27E82C970029EB52 /* ExpressionParserTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -239,6 +284,10 @@
 						CreatedOnToolsVersion = 13.2.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					ACE2158A27E82C970029EB52 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -260,6 +309,7 @@
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				AC2801DC27E175530029363B /* CalculatorItemQueueTest */,
 				AC2833E027E4571F00214D70 /* FormulaTest */,
+				ACE2158A27E82C970029EB52 /* ExpressionParserTest */,
 			);
 		};
 /* End PBXProject section */
@@ -273,6 +323,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		AC2833DF27E4571F00214D70 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ACE2158927E82C970029EB52 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -308,6 +365,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		ACE2158727E82C970029EB52 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ACE2158E27E82C970029EB52 /* ExpressionParserTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -336,6 +401,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = AC2833E527E4571F00214D70 /* PBXContainerItemProxy */;
+		};
+		ACE2159027E82C970029EB52 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = ACE2158F27E82C970029EB52 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -433,6 +503,47 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Doogie.FormulaTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		ACE2159227E82C970029EB52 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SD8J3B58T9;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = Doogie.ExpressionParserTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		ACE2159327E82C970029EB52 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SD8J3B58T9;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Doogie.ExpressionParserTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -617,6 +728,15 @@
 			buildConfigurations = (
 				AC2833E827E4571F00214D70 /* Debug */,
 				AC2833E927E4571F00214D70 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ACE2159127E82C970029EB52 /* Build configuration list for PBXNativeTarget "ExpressionParserTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ACE2159227E82C970029EB52 /* Debug */,
+				ACE2159327E82C970029EB52 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		AC2833DA27E4360D00214D70 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2833D927E4360D00214D70 /* Operator.swift */; };
 		AC2833DC27E4544900214D70 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2833DB27E4544900214D70 /* Formula.swift */; };
 		AC2833E427E4571F00214D70 /* FormulaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2833E327E4571F00214D70 /* FormulaTest.swift */; };
+		ACE2158427E81FCF0029EB52 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE2158327E81FCF0029EB52 /* ExpressionParser.swift */; };
+		ACE2158627E822DF0029EB52 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE2158527E822DF0029EB52 /* Extensions.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -47,6 +49,8 @@
 		AC2833DB27E4544900214D70 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		AC2833E127E4571F00214D70 /* FormulaTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC2833E327E4571F00214D70 /* FormulaTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTest.swift; sourceTree = "<group>"; };
+		ACE2158327E81FCF0029EB52 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		ACE2158527E822DF0029EB52 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -99,6 +103,8 @@
 				AC2801D727E173EB0029363B /* CalculateItem.swift */,
 				AC2833D927E4360D00214D70 /* Operator.swift */,
 				AC2833DB27E4544900214D70 /* Formula.swift */,
+				ACE2158327E81FCF0029EB52 /* ExpressionParser.swift */,
+				ACE2158527E822DF0029EB52 /* Extensions.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -307,11 +313,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				AC2801D827E173EB0029363B /* CalculateItem.swift in Sources */,
+				ACE2158627E822DF0029EB52 /* Extensions.swift in Sources */,
 				AC2833DC27E4544900214D70 /* Formula.swift in Sources */,
 				AC2833DA27E4360D00214D70 /* Operator.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				AC2801D627E173DB0029363B /* CalculatorItemQueue.swift in Sources */,
+				ACE2158427E81FCF0029EB52 /* ExpressionParser.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -39,6 +39,16 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AC2833E027E4571F00214D70"
+               BuildableName = "FormulaTest.xctest"
+               BlueprintName = "FormulaTest"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -49,6 +49,16 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ACE2158A27E82C970029EB52"
+               BuildableName = "ExpressionParserTest.xctest"
+               BlueprintName = "ExpressionParserTest"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -1,5 +1,3 @@
 import Foundation
 
 protocol CalculateItem {}
-
-extension Double: CalculateItem {}

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -6,6 +6,7 @@ struct CalculatorItemQueue<item: CalculateItem> {
     var count: Int { enqueueList.count + dequeueList.count }
     var first: item? { dequeueList.isEmpty ? enqueueList.first : dequeueList.last }
     var last: item? { enqueueList.isEmpty ? dequeueList.first : enqueueList.last }
+    var isEmpty: Bool { enqueueList.isEmpty && dequeueList.isEmpty }
     
     mutating func enqueue(_ item: item) {
         enqueueList.append(item)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,7 +1,25 @@
 import Foundation
 
 enum ExpressionParser {
-    private func componentsByOperators(from input: String) -> [String] {
+    static func parse(from input: String) -> Formula {
+        let formulaArray = componentsByOperators(from: input)
+        var operandQueue = CalculatorItemQueue<Double>()
+        var operationQueue = CalculatorItemQueue<Operator>()
+        for element in formulaArray {
+            if let number = Double(element) {
+                operandQueue.enqueue(number)
+            } else {
+                for op in Operator.allCases {
+                    if op.rawValue == Character(element) {
+                        operationQueue.enqueue(op)
+                    }
+                }
+            }
+        }
+        return Formula(operands: operandQueue, operations: operationQueue)
+    }
+    
+    static private func componentsByOperators(from input: String) -> [String] {
         return input.split(with: " ")
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum ExpressionParser {
+    private func componentsByOperators(from input: String) -> [String] {
+        return input.split(with: " ")
+    }
+}

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -5,15 +5,14 @@ enum ExpressionParser {
         let formulaArray = componentsByOperators(from: input)
         var operandQueue = CalculatorItemQueue<Double>()
         var operationQueue = CalculatorItemQueue<Operator>()
+
         for element in formulaArray {
             if let number = Double(element) {
                 operandQueue.enqueue(number)
-            } else {
-                for op in Operator.allCases {
-                    if op.rawValue == Character(element) {
-                        operationQueue.enqueue(op)
-                    }
-                }
+                continue
+            }
+            if let operation = Operator(rawValue: Character(element)) {
+                operationQueue.enqueue(operation)
             }
         }
         return Formula(operands: operandQueue, operations: operationQueue)

--- a/Calculator/Calculator/Model/Extensions.swift
+++ b/Calculator/Calculator/Model/Extensions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Double: CalculateItem {}
+
+extension String {
+    func split(with target: Character) -> [String] {
+        return self.split(separator: target).map({String($0)})
+    }
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct Formula {
+    var operands = CalculatorItemQueue<Double>()
+    var operations = CalculatorItemQueue<Operator>()
+    
+    func result() -> Double {
+        return 0
+    }
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -6,14 +6,11 @@ struct Formula {
     
     mutating func result() -> Double {
         guard var result = operands.dequeue() else { return 0}
+        
         while !operands.isEmpty {
             guard let rhs = operands.dequeue() else { return result }
-            let pickedOperation = operations.dequeue()
-            for op in Operator.allCases {
-                if pickedOperation == op {
-                    result = op.calcuate(lhs: result, rhs: rhs)
-                }
-            }
+            guard let pickedOperation = operations.dequeue() else { return result }
+            result = pickedOperation.calcuate(lhs: result, rhs: rhs)
         }
         return result
     }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -4,7 +4,17 @@ struct Formula {
     var operands = CalculatorItemQueue<Double>()
     var operations = CalculatorItemQueue<Operator>()
     
-    func result() -> Double {
-        return 0
+    mutating func result() -> Double {
+        guard var result = operands.dequeue() else { return 0}
+        while !operands.isEmpty {
+            guard let rhs = operands.dequeue() else { return result }
+            let pickedOperation = operations.dequeue()
+            for op in Operator.allCases {
+                if pickedOperation == op {
+                    result = op.calcuate(lhs: result, rhs: rhs)
+                }
+            }
+        }
+        return result
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -5,11 +5,12 @@ struct Formula {
     var operations = CalculatorItemQueue<Operator>()
     
     mutating func result() -> Double {
-        guard var result = operands.dequeue() else { return 0}
+        guard var result = operands.dequeue() else { return 0 }
         
         while !operands.isEmpty {
             guard let rhs = operands.dequeue() else { return result }
             guard let pickedOperation = operations.dequeue() else { return result }
+            guard rhs != 0 || pickedOperation != .divide else { return .nan }
             result = pickedOperation.calcuate(lhs: result, rhs: rhs)
         }
         return result

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+"
+    case subtract = "-"
+    case divide = "÷"
+    case multiply = "×"
+    func calcuate(lhs: Double, rhs: Double) -> Double {
+        switch self {
+        case .add:
+            return lhs + rhs
+        case .subtract:
+            return lhs - rhs
+        case .divide:
+            return lhs / rhs
+        case .multiply:
+            return lhs * rhs
+        }
+    }
+}

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -8,13 +8,25 @@ enum Operator: Character, CaseIterable, CalculateItem {
     func calcuate(lhs: Double, rhs: Double) -> Double {
         switch self {
         case .add:
-            return lhs + rhs
+            return add(lhs: lhs, rhs: rhs)
         case .subtract:
-            return lhs - rhs
+            return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            return lhs / rhs
+            return divide(lhs: lhs, rhs: rhs)
         case .multiply:
-            return lhs * rhs
+            return multiply(lhs: lhs, rhs: rhs)
         }
+    }
+    private func add(lhs: Double, rhs: Double) -> Double {
+        return lhs + rhs
+    }
+    private func subtract(lhs: Double, rhs: Double) -> Double {
+        return lhs - rhs
+    }
+    private func divide(lhs: Double, rhs: Double) -> Double {
+        return lhs / rhs
+    }
+    private func multiply(lhs: Double, rhs: Double) -> Double {
+        return lhs * rhs
     }
 }

--- a/Calculator/CalculatorItemQueueTest/CalculatorItemQueueTest.swift
+++ b/Calculator/CalculatorItemQueueTest/CalculatorItemQueueTest.swift
@@ -90,6 +90,40 @@ class CalculatorItemQueueTest: XCTestCase {
         XCTAssertEqual(sut.last, input5)
     }
     
+    //MARK: - isEmpty
+    func test_isEmpty호출시_리스트들이비어있을때_true를반환하는지() {
+        //when
+        sut.removeAll()
+        //then
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
+    func test_isEmpty호출시_enqueueList만요소가있을때_false를반환하는지() {
+        //when
+        sut.enqueue(1)
+        //then
+        XCTAssertFalse(sut.isEmpty)
+    }
+    
+    func test_isEmpty호출시_dequeueList만요소가있을때_false를반환하는지() {
+        //when
+        sut.enqueue(1)
+        sut.enqueue(2)
+        sut.dequeue()
+        //then
+        XCTAssertFalse(sut.isEmpty)
+    }
+    
+    func test_isEmpty호출시_두리스트다요소가있을때_false를반환하는지() {
+        //when
+        sut.enqueue(1)
+        sut.enqueue(2)
+        sut.dequeue()
+        sut.enqueue(123)
+        //then
+        XCTAssertFalse(sut.isEmpty)
+        
+    }
     //MARK: - enqueue()
     func test_enqueue호출시_정상적으로추가가되는지() {
         //given

--- a/Calculator/ExpressionParserTest/ExpressionParserTest.swift
+++ b/Calculator/ExpressionParserTest/ExpressionParserTest.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Calculator
+
+class ExpressionParserTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+    }
+    
+    func test_parse호출시_from에계산식을넣으면_옳바른결과를바환하는지() {
+        //given
+        let input = " 3 + 4 × -2 ÷ 7"
+        //when
+        var result = ExpressionParser.parse(from: input)
+        //then
+        XCTAssertEqual(result.result(), -2)
+    }
+}

--- a/Calculator/ExpressionParserTest/ExpressionParserTest.swift
+++ b/Calculator/ExpressionParserTest/ExpressionParserTest.swift
@@ -14,9 +14,18 @@ class ExpressionParserTest: XCTestCase {
     func test_parse호출시_from에계산식을넣으면_옳바른결과를바환하는지() {
         //given
         let input = " 3 + 4 × -2 ÷ 7"
+        let input2 = "3 + 4 × -2 ÷ 7"
+        let input3 = "3 + 4 × -2 ÷ 7 "
+        let input4 = " 3 + 4 × -2 ÷ 7 "
         //when
         var result = ExpressionParser.parse(from: input)
+        var result2 = ExpressionParser.parse(from: input2)
+        var result3 = ExpressionParser.parse(from: input3)
+        var result4 = ExpressionParser.parse(from: input4)
         //then
         XCTAssertEqual(result.result(), -2)
+        XCTAssertEqual(result2.result(), -2)
+        XCTAssertEqual(result3.result(), -2)
+        XCTAssertEqual(result4.result(), -2)
     }
 }

--- a/Calculator/FormulaTest/FormulaTest.swift
+++ b/Calculator/FormulaTest/FormulaTest.swift
@@ -1,0 +1,35 @@
+//
+//  FormulaTest.swift
+//  FormulaTest
+//
+//  Created by 최최성균 on 2022/03/18.
+//
+
+import XCTest
+@testable import Calculator
+
+class FormulaTest: XCTestCase {
+    var sut: Formula!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Formula()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+
+    //MARK: - result()
+    func test_result호출시_2와3과plus가있을때_5를반환하는지() {
+        //given
+        sut.operands.enqueue(2)
+        sut.operands.enqueue(3)
+        sut.operations.enqueue(.add)
+        //when
+        let result = sut.result()
+        //then
+        XCTAssertEqual(result, 5)
+    }
+}

--- a/Calculator/FormulaTest/FormulaTest.swift
+++ b/Calculator/FormulaTest/FormulaTest.swift
@@ -60,6 +60,20 @@ class FormulaTest: XCTestCase {
         XCTAssertEqual(result, 0)
     }
     
+    func test_result호출시_숫자하나와연산자만2개있을경우_해당숫자를반환하는지() {
+        //given
+        let inputNumber = 3.0
+        let inputOperation = Operator.divide
+        let inputOperation2 = Operator.subtract
+        //when
+        sut.operands.enqueue(inputNumber)
+        sut.operations.enqueue(inputOperation)
+        sut.operations.enqueue(inputOperation2)
+        let result = sut.result()
+        //then
+        XCTAssertEqual(result, inputNumber)
+    }
+    
     func test_result호출시_6나누기3빼기6곱하기4진행시_음수16을반환하는지() {
         //given
         sut.operands.enqueue(6)
@@ -74,6 +88,4 @@ class FormulaTest: XCTestCase {
         //then
         XCTAssertEqual(result, -16)
     }
-    
-
 }

--- a/Calculator/FormulaTest/FormulaTest.swift
+++ b/Calculator/FormulaTest/FormulaTest.swift
@@ -22,14 +22,36 @@ class FormulaTest: XCTestCase {
     }
 
     //MARK: - result()
-    func test_result호출시_2와3과plus가있을때_5를반환하는지() {
+    func test_result호출시_6나누기3빼기6곱하기4진행시_음수16을반환하는지() {
         //given
-        sut.operands.enqueue(2)
+        sut.operands.enqueue(6)
         sut.operands.enqueue(3)
-        sut.operations.enqueue(.add)
+        sut.operations.enqueue(.divide)
+        sut.operands.enqueue(6)
+        sut.operations.enqueue(.subtract)
+        sut.operands.enqueue(4)
+        sut.operations.enqueue(.multiply)
         //when
         let result = sut.result()
         //then
-        XCTAssertEqual(result, 5)
+        XCTAssertEqual(result, -16)
+    }
+    
+    func test_result호출시_6인큐후연산자가없을경우_6을반환하는지() {
+        //given
+        sut.operands.enqueue(6)
+        //when
+        let result = sut.result()
+        //then
+        XCTAssertEqual(result, 6)
+    }
+    
+    func test_result호출시_연산자만있을경우_0을반환하는지() {
+        //given
+        sut.operations.enqueue(.divide)
+        //when
+        let result = sut.result()
+        //then
+        XCTAssertEqual(result, 0)
     }
 }

--- a/Calculator/FormulaTest/FormulaTest.swift
+++ b/Calculator/FormulaTest/FormulaTest.swift
@@ -22,6 +22,44 @@ class FormulaTest: XCTestCase {
     }
 
     //MARK: - result()
+    func test_rsult호출시_숫자가입력되지않았을경우_0을반환하는지() {
+        //when
+        let result = sut.result()
+        //then
+        XCTAssertEqual(result, 0)
+    }
+    
+    func test_rsult호출시_숫자하나만입력되었을경우_해당숫자를반환하는지() {
+        //given
+        let input = 4.3
+        //when
+        sut.operands.enqueue(input)
+        let result = sut.result()
+        //then
+        XCTAssertEqual(result, input)
+    }
+    
+    func test_rsult호출시_숫자하나와연산자하나만입력되었을경우_해당숫자를반환하는지() {
+        //given
+        let inputNum = 3.4
+        let inputOperation = Operator.multiply
+        //when
+        sut.operands.enqueue(inputNum)
+        sut.operations.enqueue(inputOperation)
+        let result = sut.result()
+        //then
+        XCTAssertEqual(result, inputNum)
+    }
+    func test_result호출시_연산자만있을경우_0을반환하는지() {
+        //given
+        let inputOperation = Operator.divide
+        //when
+        sut.operations.enqueue(inputOperation)
+        let result = sut.result()
+        //then
+        XCTAssertEqual(result, 0)
+    }
+    
     func test_result호출시_6나누기3빼기6곱하기4진행시_음수16을반환하는지() {
         //given
         sut.operands.enqueue(6)
@@ -37,21 +75,5 @@ class FormulaTest: XCTestCase {
         XCTAssertEqual(result, -16)
     }
     
-    func test_result호출시_6인큐후연산자가없을경우_6을반환하는지() {
-        //given
-        sut.operands.enqueue(6)
-        //when
-        let result = sut.result()
-        //then
-        XCTAssertEqual(result, 6)
-    }
-    
-    func test_result호출시_연산자만있을경우_0을반환하는지() {
-        //given
-        sut.operations.enqueue(.divide)
-        //when
-        let result = sut.result()
-        //then
-        XCTAssertEqual(result, 0)
-    }
+
 }

--- a/Calculator/FormulaTest/FormulaTest.swift
+++ b/Calculator/FormulaTest/FormulaTest.swift
@@ -75,7 +75,7 @@ class FormulaTest: XCTestCase {
     }
     
     func test_result호출시_6나누기3빼기6곱하기4진행시_음수16을반환하는지() {
-        //given
+        //when
         sut.operands.enqueue(6)
         sut.operands.enqueue(3)
         sut.operations.enqueue(.divide)
@@ -83,9 +83,22 @@ class FormulaTest: XCTestCase {
         sut.operations.enqueue(.subtract)
         sut.operands.enqueue(4)
         sut.operations.enqueue(.multiply)
-        //when
         let result = sut.result()
         //then
         XCTAssertEqual(result, -16)
+    }
+    
+    func test_result호출시_0으로나눌경우_nan을반환하는지() {
+        //when
+        sut.operands.enqueue(6)
+        sut.operations.enqueue(.divide)
+        sut.operands.enqueue(3)
+        sut.operations.enqueue(.divide)
+        sut.operands.enqueue(0)
+        sut.operations.enqueue(.multiply)
+        sut.operands.enqueue(4)
+        let result = sut.result()
+        //then
+        XCTAssertTrue(result.isNaN)
     }
 }

--- a/README.md
+++ b/README.md
@@ -32,3 +32,26 @@
 - *`LinkedList`*
 
 ## PR 후 개선사항
+- Double Stack으로 큐를 구현함에 있으 낮은 이해도로 인해 발생된 문제 들 개선
+
+1. count
+
+변경전
+```swift
+var count: Int { dequeueList.isEmpty ? enqueueList.count : dequeueList.count }
+```
+변경 후
+```swift
+var count: Int { enqueueList.count + dequeueList.count }
+```
+2. first, last
+변경전
+```swift
+var first: item? { enqueueList.first }
+var last: item? { enqueueList.last }
+```
+변경 후
+```swift
+var first: item? { dequeueList.isEmpty ? enqueueList.first : dequeueList.last }
+var last: item? { enqueueList.isEmpty ? dequeueList.first : enqueueList.last }
+```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
     - 주말은 필요에 따라
 
 ## UML 
-![Untitled (1)](https://user-images.githubusercontent.com/82325822/158533449-03543b04-be60-4cfa-8ef9-373f671e7f0d.jpg)
+![](https://i.imgur.com/S7NAWZo.png)
+(해당 UML은 제가 작성한 것이 아닌 프로젝트 요구사항임)
 
 ## STEP 1 기능 구현
 - DoubleStack을 이용해 Queue구현
@@ -55,3 +56,75 @@ var last: item? { enqueueList.last }
 var first: item? { dequeueList.isEmpty ? enqueueList.first : dequeueList.last }
 var last: item? { enqueueList.isEmpty ? dequeueList.first : enqueueList.last }
 ```
+## STEP 2 기능 구현
+- 연산자에 따른 연산 방법 구현
+- 입력된 계산식을 연산자와 피연산자로 구분
+- 구분된 연산자와 피연산자를 각각의 큐에 넣기
+
+## 고민했던 것들
+### 1. 계산식 인큐 방식 고민
+
+최초에는 연산자를 누를 때 마다 큐에 추가되는 방식으로 구현하고 싶었음
+그래서 뷰컨트롤러에서의 구현까지 염두해 두고 뷰컨트롤러에 Formula 인스턴스를 생성해 연산자를 한번 눌러줄 때 마다 큐에 추가하려는 방식으로 구현했음
+
+그런데 프로젝트에서 요청한 UML에 끼워 맞추다 보니 불필요한 과정이 너무 많이 생기기 시작
+예를 들면
+```swift
+func parse(from input: String) -> Formula
+```
+위 함수의 반환값은 Formula타입인데 해당 타입을 활용하면서 연산자를 누를 때마다 enqueue를 해주려면 아래와 같은 방식으로밖에는 구현이 힘들었음
+```swift
+    func test_parse호출후result호출시_125빼기5곱하기음수4나누기음수5이_96을반환하는지() {
+        var result = ExpressionParser.parse(from: "125")
+        sut.operands.enqueue(result.operands.dequeue()!)
+        result = ExpressionParser.parse(from: "-5")
+        sut.operands.enqueue(result.operands.dequeue()!)
+        sut.operations.enqueue(result.operations.dequeue()!)
+        result = ExpressionParser.parse(from: "×-4")
+        sut.operands.enqueue(result.operands.dequeue()!)
+        sut.operations.enqueue(result.operations.dequeue()!)
+        result = ExpressionParser.parse(from: "÷-5")
+        sut.operands.enqueue(result.operands.dequeue()!)
+        sut.operations.enqueue(result.operations.dequeue()!)
+        
+        XCTAssertEqual(sut.result(), 96)
+    }
+```
+위는 테스트 코드 인데 UML이 연산자와 피연산자를 분리한 값을 Formula타입으로 반환하기를 원하다 보니 반환된 값에서 다시 dequeue를 해서 뷰컨에서 생성된 Formula인스턴스로 넣어주는 불필요한 과정이 생겨버림
+
+(애초에 Formula로 반환하는 것이 parse() 함수에서 직접 넣어 줄 수 있으면 위 방법도 좋았겠으나 이번 프로젝트는 기존 UML에 필요한 타입등은 추가가 가능하나 이미 설정된 내용은 수정이 불가하기에 전체적으로 뒤엎고 현재와 같이 연산자, 피연산자를 하나의 스트링으로 받아 = 을 눌렀을 때 한번만 반환 하도록 구현)
+
+#### 2. Character(요소) 를 통해 변환시 요소가 한자리가 아닐 때
+
+```swift=
+        for element in formulaArray {
+            if let number = Double(element) {
+                operandQueue.enqueue(number)
+            }
+            if let operation = Operator(rawValue: Character(element)) {
+                operationQueue.enqueue(operation)
+            }
+        }
+```
+이렇게 실행했을 때 Character(element)에 한자리 숫자가 아닌 수가 들어올 경우 발생되는 문제
+해당 배열에는 double로 변환되는 요소 아니면 character로 변환되는 연산자 둘중 하나라고 생각해
+아래와 같이 수정
+
+```swift=
+        for element in formulaArray {
+            if let number = Double(element) {
+                operandQueue.enqueue(number)
+                continue
+            }
+            if let operation = Operator(rawValue: Character(element)) {
+                operationQueue.enqueue(operation)
+            }
+        }
+```
+
+## 배운 개념
+- *`기존 타입의 확장 및 메서드 생성`*
+- *`map & compactMap`*
+- *`nan`*
+
+## PR 후 개선사항


### PR DESCRIPTION
@wonhee009

안녕하세요 라자냐!

STEP2의 UML을 나름 대로 해석을 했는데 첫 생각을 잘못 하다보니 전체 다 갈아 엎는 과정이 있어 조금 늦은 시간에 PR드립니다
이번 PR도 잘 부탁드립니다!

# UML
![image](https://user-images.githubusercontent.com/82325822/159289023-93138e9d-f97f-48d9-865d-92e98db1c90f.png)

# 고민한점 및 해결 방법
### 1. 계산식 인큐 방식 고민

최초에는 연산자를 누를 때 마다 큐에 추가되는 방식으로 구현하고 싶었습니다
그래서 뷰컨트롤러에서의 구현까지 염두해 두고 뷰컨트롤러에 Formula 인스턴스를 생성해 연산자를 한번 눌러줄 때 마다 큐에 추가하려는 방식으로 구현했는데... 프로젝트에서 요청한 UML에 끼워 맞추다 보니 불필요한 과정이 너무 많이 생기기 시작했습니다
예를 들면
```swift
func parse(from input: String) -> Formula
```
위 함수의 반환값은 Formula타입인데 해당 타입을 활용하면서 연산자를 누를 때마다 enqueue를 해주려면 아래와 같은 방식으로밖에는 구현이 힘들더라구요..
```swift
    func test_parse호출후result호출시_125빼기5곱하기음수4나누기음수5이_96을반환하는지() {
        var result = ExpressionParser.parse(from: "125")
        sut.operands.enqueue(result.operands.dequeue()!)
        result = ExpressionParser.parse(from: "-5")
        sut.operands.enqueue(result.operands.dequeue()!)
        sut.operations.enqueue(result.operations.dequeue()!)
        result = ExpressionParser.parse(from: "×-4")
        sut.operands.enqueue(result.operands.dequeue()!)
        sut.operations.enqueue(result.operations.dequeue()!)
        result = ExpressionParser.parse(from: "÷-5")
        sut.operands.enqueue(result.operands.dequeue()!)
        sut.operations.enqueue(result.operations.dequeue()!)
        
        XCTAssertEqual(sut.result(), 96)
    }
```
위는 테스트 코드 인데 UML이 연산자와 피연산자를 분리한 값을 Formula타입으로 반환하기를 원하다 보니 반환된 값에서 다시 dequeue를 해서 뷰컨에서 생성된 Formula인스턴스로 넣어주는 불필요한 과정이 생겨버렸습니다

애초에 Formula로 반환하는 것이 parse() 함수에서 직접 넣어 줄 수 있으면 위 방법도 좋았겠으나 이번 프로젝트는 기존 UML에 필요한 타입등은 추가가 가능하나 이미 설정된 내용은 수정이 불가하기에 전체적으로 뒤엎고 연산자, 피연산자를 하나의 스트링으로 받아 = 을 눌렀을 때 한번만 반환 하도록 구현 하였습니다

(혹시라도 제 표현력이 부족해서 이해가 힘드실 수도 있을 것 같아 이전 버전의 링크도 남깁니다!
https://github.com/doogie97/ios-calculator-app/tree/Calculate%EC%9D%B4%EC%A0%84%EB%B0%A9%EC%8B%9D)

### 2. Character(요소) 를 통해 변환시 요소가 한자리가 아닐 때

```swift
        for element in formulaArray {
            if let number = Double(element) {
                operandQueue.enqueue(number)
            }
            if let operation = Operator(rawValue: Character(element)) {
                operationQueue.enqueue(operation)
            }
        }
```
이렇게 실행했을 때 Character(element)에 한자리 숫자가 아닌 수가 들어올 경우 발생되는 문제
해당 배열에는 double로 변환되는 요소 아니면 character로 변환되는 연산자 둘중 하나라고 생각해
아래와 같이 수정

```swift
        for element in formulaArray {
            if let number = Double(element) {
                operandQueue.enqueue(number)
                continue
            }
            if let operation = Operator(rawValue: Character(element)) {
                operationQueue.enqueue(operation)
            }
        }
```

# 조언받고 싶은 내용

들여 쓰기 제한이라는 부분에 대해 오래도록 고민했는데 들여쓰기를 피하고자 작성하는 코드가 더 복잡해지는 경우가 생각보다 많았습니다.
for 구문안에 if문 하나가 있는 정도는 가독성에 있어서는 개인적으로는 더 좋게 읽혀지긴 하는데 이 부분에 대해서 실제 현업에 있는 분들은 어떻게 생각하는지 궁금합니다!