### PR TITLE
계산기 I [STEP2] papri

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		67E3EEE927E9F5F6008CA439 /* DoubleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */; };
 		67E3EEEB27E9F816008CA439 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEEA27E9F816008CA439 /* StringExtension.swift */; };
 		67E3EEEC27E9F816008CA439 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEEA27E9F816008CA439 /* StringExtension.swift */; };
+		67E3EEEE27E9F8B4008CA439 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEED27E9F8B4008CA439 /* Operator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -41,6 +42,7 @@
 		67E3EEE427E9F507008CA439 /* CalculateItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItemProtocol.swift; sourceTree = "<group>"; };
 		67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtension.swift; sourceTree = "<group>"; };
 		67E3EEEA27E9F816008CA439 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
+		67E3EEED27E9F8B4008CA439 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				673A21DE27E0AB120090AF86 /* CalculatorItemQueue.swift */,
+				67E3EEED27E9F8B4008CA439 /* Operator.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -278,6 +281,7 @@
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				67E3EEE527E9F508008CA439 /* CalculateItemProtocol.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				67E3EEEE27E9F8B4008CA439 /* Operator.swift in Sources */,
 				673A21DF27E0AB120090AF86 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		67E3EEEB27E9F816008CA439 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEEA27E9F816008CA439 /* StringExtension.swift */; };
 		67E3EEEC27E9F816008CA439 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEEA27E9F816008CA439 /* StringExtension.swift */; };
 		67E3EEEE27E9F8B4008CA439 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEED27E9F8B4008CA439 /* Operator.swift */; };
+		67E3EEF627E9FAC6008CA439 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEF527E9FAC6008CA439 /* OperatorTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -33,6 +34,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		67E3EEF727E9FAC7008CA439 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -43,6 +51,8 @@
 		67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtension.swift; sourceTree = "<group>"; };
 		67E3EEEA27E9F816008CA439 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		67E3EEED27E9F8B4008CA439 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		67E3EEF327E9FAC6008CA439 /* OperatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		67E3EEF527E9FAC6008CA439 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -55,6 +65,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		673A21CF27E0A79D0090AF86 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67E3EEF027E9FAC6008CA439 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -134,11 +151,20 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
+		67E3EEF427E9FAC6008CA439 /* OperatorTests */ = {
+			isa = PBXGroup;
+			children = (
+				67E3EEF527E9FAC6008CA439 /* OperatorTests.swift */,
+			);
+			path = OperatorTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				673A21D327E0A79D0090AF86 /* CalculatorItemQueueTests */,
+				67E3EEF427E9FAC6008CA439 /* OperatorTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -148,6 +174,7 @@
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				673A21D227E0A79D0090AF86 /* CalculatorItemQueueTests.xctest */,
+				67E3EEF327E9FAC6008CA439 /* OperatorTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -185,6 +212,24 @@
 			productReference = 673A21D227E0A79D0090AF86 /* CalculatorItemQueueTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		67E3EEF227E9FAC6008CA439 /* OperatorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 67E3EEF927E9FAC7008CA439 /* Build configuration list for PBXNativeTarget "OperatorTests" */;
+			buildPhases = (
+				67E3EEEF27E9FAC6008CA439 /* Sources */,
+				67E3EEF027E9FAC6008CA439 /* Frameworks */,
+				67E3EEF127E9FAC6008CA439 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				67E3EEF827E9FAC7008CA439 /* PBXTargetDependency */,
+			);
+			name = OperatorTests;
+			productName = OperatorTests;
+			productReference = 67E3EEF327E9FAC6008CA439 /* OperatorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -215,6 +260,10 @@
 						CreatedOnToolsVersion = 13.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					67E3EEF227E9FAC6008CA439 = {
+						CreatedOnToolsVersion = 13.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -235,12 +284,20 @@
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				673A21D127E0A79D0090AF86 /* CalculatorItemQueueTests */,
+				67E3EEF227E9FAC6008CA439 /* OperatorTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		673A21D027E0A79D0090AF86 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67E3EEF127E9FAC6008CA439 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -272,6 +329,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		67E3EEEF27E9FAC6008CA439 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				67E3EEF627E9FAC6008CA439 /* OperatorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -294,6 +359,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 673A21D627E0A79D0090AF86 /* PBXContainerItemProxy */;
+		};
+		67E3EEF827E9FAC7008CA439 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 67E3EEF727E9FAC7008CA439 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -358,6 +428,55 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.huhyoonyoung.CalculatorItemQueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		67E3EEFA27E9FAC7008CA439 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.huhyoonyoung.OperatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		67E3EEFB27E9FAC7008CA439 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.huhyoonyoung.OperatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -533,6 +652,15 @@
 			buildConfigurations = (
 				673A21D827E0A79D0090AF86 /* Debug */,
 				673A21D927E0A79D0090AF86 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		67E3EEF927E9FAC7008CA439 /* Build configuration list for PBXNativeTarget "OperatorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				67E3EEFA27E9FAC7008CA439 /* Debug */,
+				67E3EEFB27E9FAC7008CA439 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		67E3EEEC27E9F816008CA439 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEEA27E9F816008CA439 /* StringExtension.swift */; };
 		67E3EEEE27E9F8B4008CA439 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEED27E9F8B4008CA439 /* Operator.swift */; };
 		67E3EEF627E9FAC6008CA439 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEF527E9FAC6008CA439 /* OperatorTests.swift */; };
+		67E3EEFD27EA4316008CA439 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEFC27EA4315008CA439 /* Formula.swift */; };
+		67E3EF0527EA4394008CA439 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EF0427EA4394008CA439 /* FormulaTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -41,6 +43,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		67E3EF0627EA4394008CA439 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -53,6 +62,9 @@
 		67E3EEED27E9F8B4008CA439 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		67E3EEF327E9FAC6008CA439 /* OperatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		67E3EEF527E9FAC6008CA439 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
+		67E3EEFC27EA4315008CA439 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		67E3EF0227EA4394008CA439 /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		67E3EF0427EA4394008CA439 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -72,6 +84,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		67E3EEF027E9FAC6008CA439 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67E3EEFF27EA4394008CA439 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -111,6 +130,7 @@
 			children = (
 				673A21DE27E0AB120090AF86 /* CalculatorItemQueue.swift */,
 				67E3EEED27E9F8B4008CA439 /* Operator.swift */,
+				67E3EEFC27EA4315008CA439 /* Formula.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -159,12 +179,21 @@
 			path = OperatorTests;
 			sourceTree = "<group>";
 		};
+		67E3EF0327EA4394008CA439 /* FormulaTests */ = {
+			isa = PBXGroup;
+			children = (
+				67E3EF0427EA4394008CA439 /* FormulaTests.swift */,
+			);
+			path = FormulaTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				673A21D327E0A79D0090AF86 /* CalculatorItemQueueTests */,
 				67E3EEF427E9FAC6008CA439 /* OperatorTests */,
+				67E3EF0327EA4394008CA439 /* FormulaTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -175,6 +204,7 @@
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				673A21D227E0A79D0090AF86 /* CalculatorItemQueueTests.xctest */,
 				67E3EEF327E9FAC6008CA439 /* OperatorTests.xctest */,
+				67E3EF0227EA4394008CA439 /* FormulaTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -230,6 +260,24 @@
 			productReference = 67E3EEF327E9FAC6008CA439 /* OperatorTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		67E3EF0127EA4394008CA439 /* FormulaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 67E3EF0827EA4394008CA439 /* Build configuration list for PBXNativeTarget "FormulaTests" */;
+			buildPhases = (
+				67E3EEFE27EA4394008CA439 /* Sources */,
+				67E3EEFF27EA4394008CA439 /* Frameworks */,
+				67E3EF0027EA4394008CA439 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				67E3EF0727EA4394008CA439 /* PBXTargetDependency */,
+			);
+			name = FormulaTests;
+			productName = FormulaTests;
+			productReference = 67E3EF0227EA4394008CA439 /* FormulaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -264,6 +312,10 @@
 						CreatedOnToolsVersion = 13.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					67E3EF0127EA4394008CA439 = {
+						CreatedOnToolsVersion = 13.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -285,6 +337,7 @@
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				673A21D127E0A79D0090AF86 /* CalculatorItemQueueTests */,
 				67E3EEF227E9FAC6008CA439 /* OperatorTests */,
+				67E3EF0127EA4394008CA439 /* FormulaTests */,
 			);
 		};
 /* End PBXProject section */
@@ -298,6 +351,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		67E3EEF127E9FAC6008CA439 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67E3EF0027EA4394008CA439 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -337,6 +397,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		67E3EEFE27EA4394008CA439 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				67E3EF0527EA4394008CA439 /* FormulaTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -349,6 +417,7 @@
 				67E3EEEE27E9F8B4008CA439 /* Operator.swift in Sources */,
 				673A21DF27E0AB120090AF86 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				67E3EEFD27EA4316008CA439 /* Formula.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -364,6 +433,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 67E3EEF727E9FAC7008CA439 /* PBXContainerItemProxy */;
+		};
+		67E3EF0727EA4394008CA439 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 67E3EF0627EA4394008CA439 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -477,6 +551,55 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.huhyoonyoung.OperatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		67E3EF0927EA4394008CA439 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.huhyoonyoung.FormulaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		67E3EF0A27EA4394008CA439 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.huhyoonyoung.FormulaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -661,6 +784,15 @@
 			buildConfigurations = (
 				67E3EEFA27E9FAC7008CA439 /* Debug */,
 				67E3EEFB27E9FAC7008CA439 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		67E3EF0827EA4394008CA439 /* Build configuration list for PBXNativeTarget "FormulaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				67E3EF0927EA4394008CA439 /* Debug */,
+				67E3EF0A27EA4394008CA439 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		67E3EEE627E9F508008CA439 /* CalculateItemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEE427E9F507008CA439 /* CalculateItemProtocol.swift */; };
 		67E3EEE827E9F5F6008CA439 /* DoubleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */; };
 		67E3EEE927E9F5F6008CA439 /* DoubleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */; };
+		67E3EEEB27E9F816008CA439 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEEA27E9F816008CA439 /* StringExtension.swift */; };
+		67E3EEEC27E9F816008CA439 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEEA27E9F816008CA439 /* StringExtension.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -38,6 +40,7 @@
 		673A21DE27E0AB120090AF86 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		67E3EEE427E9F507008CA439 /* CalculateItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItemProtocol.swift; sourceTree = "<group>"; };
 		67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtension.swift; sourceTree = "<group>"; };
+		67E3EEEA27E9F816008CA439 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -123,6 +126,7 @@
 			isa = PBXGroup;
 			children = (
 				67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */,
+				67E3EEEA27E9F816008CA439 /* StringExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -259,6 +263,7 @@
 			files = (
 				67E3EEE927E9F5F6008CA439 /* DoubleExtension.swift in Sources */,
 				673A21E027E0AB120090AF86 /* CalculatorItemQueue.swift in Sources */,
+				67E3EEEC27E9F816008CA439 /* StringExtension.swift in Sources */,
 				67E3EEE627E9F508008CA439 /* CalculateItemProtocol.swift in Sources */,
 				673A21D527E0A79D0090AF86 /* CalculatorItemQueueTests.swift in Sources */,
 			);
@@ -269,6 +274,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				67E3EEE827E9F5F6008CA439 /* DoubleExtension.swift in Sources */,
+				67E3EEEB27E9F816008CA439 /* StringExtension.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				67E3EEE527E9F508008CA439 /* CalculateItemProtocol.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		67E3EEF627E9FAC6008CA439 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEF527E9FAC6008CA439 /* OperatorTests.swift */; };
 		67E3EEFD27EA4316008CA439 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEFC27EA4315008CA439 /* Formula.swift */; };
 		67E3EF0527EA4394008CA439 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EF0427EA4394008CA439 /* FormulaTests.swift */; };
+		67E3EF0E27EA4C97008CA439 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EF0D27EA4C97008CA439 /* ExpressionParser.swift */; };
+		67E3EF1627EA4D3F008CA439 /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EF1527EA4D3F008CA439 /* ExpressionParserTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -50,6 +52,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		67E3EF1727EA4D3F008CA439 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -65,6 +74,9 @@
 		67E3EEFC27EA4315008CA439 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		67E3EF0227EA4394008CA439 /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		67E3EF0427EA4394008CA439 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
+		67E3EF0D27EA4C97008CA439 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		67E3EF1327EA4D3F008CA439 /* ExpressionParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		67E3EF1527EA4D3F008CA439 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -91,6 +103,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		67E3EEFF27EA4394008CA439 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67E3EF1027EA4D3F008CA439 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -131,6 +150,7 @@
 				673A21DE27E0AB120090AF86 /* CalculatorItemQueue.swift */,
 				67E3EEED27E9F8B4008CA439 /* Operator.swift */,
 				67E3EEFC27EA4315008CA439 /* Formula.swift */,
+				67E3EF0D27EA4C97008CA439 /* ExpressionParser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -187,6 +207,14 @@
 			path = FormulaTests;
 			sourceTree = "<group>";
 		};
+		67E3EF1427EA4D3F008CA439 /* ExpressionParserTests */ = {
+			isa = PBXGroup;
+			children = (
+				67E3EF1527EA4D3F008CA439 /* ExpressionParserTests.swift */,
+			);
+			path = ExpressionParserTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
@@ -194,6 +222,7 @@
 				673A21D327E0A79D0090AF86 /* CalculatorItemQueueTests */,
 				67E3EEF427E9FAC6008CA439 /* OperatorTests */,
 				67E3EF0327EA4394008CA439 /* FormulaTests */,
+				67E3EF1427EA4D3F008CA439 /* ExpressionParserTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -205,6 +234,7 @@
 				673A21D227E0A79D0090AF86 /* CalculatorItemQueueTests.xctest */,
 				67E3EEF327E9FAC6008CA439 /* OperatorTests.xctest */,
 				67E3EF0227EA4394008CA439 /* FormulaTests.xctest */,
+				67E3EF1327EA4D3F008CA439 /* ExpressionParserTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -278,6 +308,24 @@
 			productReference = 67E3EF0227EA4394008CA439 /* FormulaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		67E3EF1227EA4D3F008CA439 /* ExpressionParserTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 67E3EF1927EA4D3F008CA439 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */;
+			buildPhases = (
+				67E3EF0F27EA4D3F008CA439 /* Sources */,
+				67E3EF1027EA4D3F008CA439 /* Frameworks */,
+				67E3EF1127EA4D3F008CA439 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				67E3EF1827EA4D3F008CA439 /* PBXTargetDependency */,
+			);
+			name = ExpressionParserTests;
+			productName = ExpressionParserTests;
+			productReference = 67E3EF1327EA4D3F008CA439 /* ExpressionParserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -316,6 +364,10 @@
 						CreatedOnToolsVersion = 13.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					67E3EF1227EA4D3F008CA439 = {
+						CreatedOnToolsVersion = 13.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -338,6 +390,7 @@
 				673A21D127E0A79D0090AF86 /* CalculatorItemQueueTests */,
 				67E3EEF227E9FAC6008CA439 /* OperatorTests */,
 				67E3EF0127EA4394008CA439 /* FormulaTests */,
+				67E3EF1227EA4D3F008CA439 /* ExpressionParserTests */,
 			);
 		};
 /* End PBXProject section */
@@ -358,6 +411,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		67E3EF0027EA4394008CA439 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67E3EF1127EA4D3F008CA439 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -405,10 +465,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		67E3EF0F27EA4D3F008CA439 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				67E3EF1627EA4D3F008CA439 /* ExpressionParserTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67E3EF0E27EA4C97008CA439 /* ExpressionParser.swift in Sources */,
 				67E3EEE827E9F5F6008CA439 /* DoubleExtension.swift in Sources */,
 				67E3EEEB27E9F816008CA439 /* StringExtension.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
@@ -438,6 +507,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 67E3EF0627EA4394008CA439 /* PBXContainerItemProxy */;
+		};
+		67E3EF1827EA4D3F008CA439 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 67E3EF1727EA4D3F008CA439 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -600,6 +674,55 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.huhyoonyoung.FormulaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		67E3EF1A27EA4D3F008CA439 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.huhyoonyoung.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		67E3EF1B27EA4D3F008CA439 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.huhyoonyoung.ExpressionParserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -793,6 +916,15 @@
 			buildConfigurations = (
 				67E3EF0927EA4394008CA439 /* Debug */,
 				67E3EF0A27EA4394008CA439 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		67E3EF1927EA4D3F008CA439 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				67E3EF1A27EA4D3F008CA439 /* Debug */,
+				67E3EF1B27EA4D3F008CA439 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		673A21D527E0A79D0090AF86 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673A21D427E0A79D0090AF86 /* CalculatorItemQueueTests.swift */; };
 		673A21DF27E0AB120090AF86 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673A21DE27E0AB120090AF86 /* CalculatorItemQueue.swift */; };
 		673A21E027E0AB120090AF86 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673A21DE27E0AB120090AF86 /* CalculatorItemQueue.swift */; };
+		67E3EEE527E9F508008CA439 /* CalculateItemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEE427E9F507008CA439 /* CalculateItemProtocol.swift */; };
+		67E3EEE627E9F508008CA439 /* CalculateItemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEE427E9F507008CA439 /* CalculateItemProtocol.swift */; };
+		67E3EEE827E9F5F6008CA439 /* DoubleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */; };
+		67E3EEE927E9F5F6008CA439 /* DoubleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -32,6 +36,8 @@
 		673A21D227E0A79D0090AF86 /* CalculatorItemQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		673A21D427E0A79D0090AF86 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
 		673A21DE27E0AB120090AF86 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
+		67E3EEE427E9F507008CA439 /* CalculateItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItemProtocol.swift; sourceTree = "<group>"; };
+		67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtension.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +102,31 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		67E3EEE027E9F4AD008CA439 /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				67E3EEE327E9F4E7008CA439 /* Extension */,
+				67E3EEE127E9F4CE008CA439 /* Protocol */,
+			);
+			path = Util;
+			sourceTree = "<group>";
+		};
+		67E3EEE127E9F4CE008CA439 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				67E3EEE427E9F507008CA439 /* CalculateItemProtocol.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
+		67E3EEE327E9F4E7008CA439 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				67E3EEE727E9F5F6008CA439 /* DoubleExtension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
@@ -117,6 +148,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				67E3EEE027E9F4AD008CA439 /* Util */,
 				673A21DD27E0AAAD0090AF86 /* View */,
 				673A21DC27E0AA8B0090AF86 /* Model */,
 				673A21DB27E0AA750090AF86 /* Controller */,
@@ -225,7 +257,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67E3EEE927E9F5F6008CA439 /* DoubleExtension.swift in Sources */,
 				673A21E027E0AB120090AF86 /* CalculatorItemQueue.swift in Sources */,
+				67E3EEE627E9F508008CA439 /* CalculateItemProtocol.swift in Sources */,
 				673A21D527E0A79D0090AF86 /* CalculatorItemQueueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -234,7 +268,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67E3EEE827E9F5F6008CA439 /* DoubleExtension.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				67E3EEE527E9F508008CA439 /* CalculateItemProtocol.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				673A21DF27E0AB120090AF86 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -1,14 +1,6 @@
 
 import Foundation
 
-protocol CalculateItem {
-    
-}
-
-extension Int: CalculateItem {
-    
-}
-
 struct CalculatorItemQueue<T: CalculateItem> {
     
     private var inputStack:[T] = []

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,0 +1,19 @@
+
+import Foundation
+
+enum ExpressionParser {
+    
+    static func parse(from input: String) -> Formula {
+        var formula = Formula()
+        let components = componentsByOperators(from: input)
+        
+        components.compactMap { Double($0) }.forEach { formula.operands.enqueue($0) }
+        components.filter {$0.count == 1}.compactMap { Operator(rawValue: Character($0)) }.forEach { formula.operators.enqueue($0) }
+        return formula
+    }
+    
+    private static func componentsByOperators(from input: String) -> [String]  {
+       return input.split(with: " ")
+        
+    }
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,0 +1,19 @@
+
+import Foundation
+
+struct Formula {
+    var operands = CalculatorItemQueue<Double>()
+    var operators = CalculatorItemQueue<Operator>()
+    
+    mutating func result() -> Double {
+        var result = operands.dequeue() ?? 0
+        
+        while operands.count != 0 {
+            guard let operand = operands.dequeue(), let `operator` = operators.dequeue() else {
+                return result
+            }
+            result = `operator`.calculate(lhs: result, rhs: operand)
+        }
+        return result
+    }
+}

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -10,7 +10,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
     func calculate(lhs: Double, rhs: Double) -> Double {
         switch self {
         case .add:
-            return add(lhs: lhs, rhs: lhs)
+            return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -1,0 +1,41 @@
+
+import Foundation
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+"
+    case subtract = "-"
+    case divide = "/"
+    case multiply = "*"
+    
+    func calculate(lhs: Double, rhs: Double) -> Double {
+        switch self {
+        case .add:
+            return add(lhs: lhs, rhs: lhs)
+        case .subtract:
+            return subtract(lhs: lhs, rhs: rhs)
+        case .divide:
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
+        }
+    }
+    
+    private func add(lhs: Double, rhs: Double) -> Double {
+        return lhs + rhs
+    }
+    
+    private func subtract(lhs: Double, rhs: Double) -> Double {
+        return lhs - rhs
+    }
+    
+    private func divide(lhs: Double, rhs: Double) -> Double {
+        if rhs == 0 {
+            return Double.nan
+        }
+        return lhs / rhs
+    }
+    
+    private func multiply(lhs: Double, rhs: Double) -> Double {
+        return lhs * rhs
+    }
+}

--- a/Calculator/Calculator/Util/Extension/DoubleExtension.swift
+++ b/Calculator/Calculator/Util/Extension/DoubleExtension.swift
@@ -1,0 +1,6 @@
+
+import Foundation
+
+extension Double: CalculateItem {
+    
+}

--- a/Calculator/Calculator/Util/Extension/StringExtension.swift
+++ b/Calculator/Calculator/Util/Extension/StringExtension.swift
@@ -1,0 +1,8 @@
+
+import Foundation
+
+extension String {
+    func split(with target: Character) -> [String] {
+        return self.split(separator: target).map { String($0) }
+    }
+}

--- a/Calculator/Calculator/Util/Protocol/CalculateItemProtocol.swift
+++ b/Calculator/Calculator/Util/Protocol/CalculateItemProtocol.swift
@@ -1,0 +1,6 @@
+
+import Foundation
+
+protocol CalculateItem {
+    
+}

--- a/Calculator/CalculatorItemQueueTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorItemQueueTests/CalculatorItemQueueTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class CalculatorItemQueueTests: XCTestCase {
     
-    var calculatorQueue = CalculatorItemQueue<Int>()
+    var calculatorQueue = CalculatorItemQueue<Double>()
     
     func test_When_enqueue_3_element_Expect_count_is_3() {
         //when

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -1,0 +1,19 @@
+
+import XCTest
+@testable import Calculator
+
+class ExpressionParserTests: XCTestCase {
+    
+    func test_When_inputString_Expect_Formula_result() {
+        //given
+        let input = "3 + 4 * -2"
+        
+        //when
+        var formula = ExpressionParser.parse(from: input)
+        let result = formula.result()
+        
+        //then
+        XCTAssertEqual(result, -14)
+    }
+    
+}

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -1,0 +1,61 @@
+
+import XCTest
+@testable import Calculator
+
+class FormulaTests: XCTestCase {
+    
+    var formula = Formula()
+    
+    func test_When_operands_empty_Expect_0() {
+        //given
+        formula.operators.enqueue(Operator.add)
+        
+        //when
+        let result = formula.result()
+        
+        //then
+        XCTAssertEqual(result, 0)
+    }
+    
+    func test_When_operators_empty_Expect_first_enqueue_operand() {
+        //given
+        formula.operands.enqueue(3)
+        
+        //when
+        let result = formula.result()
+        
+        //then
+        XCTAssertEqual(result, 3)
+    }
+
+    func test_When_add_multiply_in_operators_Expect_calculate_add_first() {
+        //given
+        formula.operands.enqueue(3)
+        formula.operators.enqueue(Operator.add)
+        formula.operands.enqueue(5)
+        formula.operators.enqueue(Operator.multiply)
+        formula.operands.enqueue(-2)
+        
+        //when
+        let result = formula.result()
+        
+        //then
+        XCTAssertEqual(result, -16)
+    }
+    
+    func test_When_divideByZero_multiply_Expect_isNaN_true() {
+        //given
+        formula.operands.enqueue(3)
+        formula.operators.enqueue(Operator.divide)
+        formula.operands.enqueue(0)
+        formula.operators.enqueue(Operator.add)
+        formula.operands.enqueue(-2)
+        
+        //when
+        let result = formula.result()
+        
+        //then
+        XCTAssertTrue(result.isNaN)
+    }
+
+}

--- a/Calculator/OperatorTests/OperatorTests.swift
+++ b/Calculator/OperatorTests/OperatorTests.swift
@@ -1,0 +1,61 @@
+
+import XCTest
+@testable import Calculator
+
+class OperatorTests: XCTestCase {
+    
+    func test_When_add_opperator_Expect_lhs_add_rhs() {
+        //given
+        let testoperator = Operator.add
+
+        //when
+        let result = testoperator.calculate(lhs: 2, rhs: 3)
+
+        //then
+        XCTAssertEqual(result, 5)
+    }
+    
+    func test_When_subtract_opperator_Expect_lhs_subtract_rhs() {
+        //given
+        let testoperator = Operator.subtract
+
+        //when
+        let result = testoperator.calculate(lhs: 5, rhs: 6)
+        //then
+        XCTAssertEqual(result, -1)
+    }
+
+    func test_When_divide_opperator_Expect_lhs_divide_rhs() {
+        //given
+        let testoperator = Operator.divide
+
+        //when
+        let result = testoperator.calculate(lhs: 7, rhs: 2)
+
+        //then
+        XCTAssertEqual(result, 3.5)
+    }
+
+    func test_When_divide_by_zero_Expect_isNaN_true() {
+        //given
+        let testoperator = Operator.divide
+
+        //when
+        let result = testoperator.calculate(lhs: 7, rhs: 0)
+
+        //then
+        XCTAssertTrue(result.isNaN)
+    }
+
+    func test_When_multiply_opperator_Expect_lhs_multiply_rhs() {
+        //given
+        let testoperator = Operator.multiply
+
+        //when
+        let result = testoperator.calculate(lhs: 4, rhs: 5)
+
+        //then
+        XCTAssertEqual(result, 20)
+    }
+
+}


### PR DESCRIPTION
# 계산기 I [STEP2] papri

@jungseungyeo
안녕하세요 린생!😃 파프리 입니다.
계획보다 늦게 PR를 보내 너무 죄송합니다.🥲 
이번에도 리뷰 잘부탁드립니다!!
평어로 적힌 점 양해부탁드립니다.
늘 감사합니다🥰

## 구현 내용

![](https://i.imgur.com/m8uvcfU.png)



### 《Extension》 String

* `func split(with target: Character) -> [String]` 를 가져 `target`을 기준으로 `String`을 쪼개, 쪼갠 `String`들의` Collection`를 반환하는 함수를 갖도록 확장

---

### 《enum》 Operator
:사칙연산을 수행하는 연산자들의 타입. [CaseIterable](https://developer.apple.com/documentation/swift/caseiterable) 프로토콜을 채택하고 있다. `add`, `subtract`,`divide`, `multiply`의 `case`들을 가지고 있으며 각각 `"+", "-", "/", "*"`의 `rawValue`를 가진다.
* `rawValue`를 설정해 자동으로 `enum`이 [RawRepresentable](https://developer.apple.com/documentation/swift/rawrepresentable) 프로토콜을 채택하도록 하였다. 이 프로토콜을 채택하면 rawValue로 원시값에 접근할 수 있다는 것도 있지만, `자동으로 생성자가 만들어져 원시값으로 enum의 case를 생성해줄 수 있게 된다`. 추후에 해당 원시값이 들어오면 case를 생성할 수 있도록 해야할 것이라 예상되어 `rawValue` 부여했다.

* `func calculate(lhs: Double, rhs: Double) -> Double` : 각 `case`들에 따라 수행할 사칙연산 함수들이 정해져 계산 결과를 얻는다
* 사칙연산 함수들 
    * `func add(lhs: Double, rhs: Double) -> Double` : 덧셈
    * `func subtract(lhs: Double, rhs: Double) -> Double` : 뺄셈
    * `func divide(lhs: Double, rhs: Double) -> Double` : 나눗셈
    * `func multiply(lhs: Double, rhs: Double) -> Double` : 곱셈

* `func divide(lhs: Double, rhs: Double) -> Double` : 0으로 나누게 되는 경우(rhs == 0), Double.nan을 리턴하도록 함. 
[nan](https://developer.apple.com/documentation/swift/floatingpoint/1641652-nan)이란 not a number라는 의미로, 숫자가 아니라서 숫자와의 비교에 무조건적으로 false를 내보낸다. nan일때 .isNaN은 true이다.
---
### 《struct》 Formula
* `var operands = CalculatorItemQueue<Double>()` : 피연산자가 담길 큐
* `var operators = CalculatorItemQueue<Operator>()` : 연산자가 담길 큐
* `func result() -> Double` : 연산자 큐와 피연산자 큐에서 dequeue하여 계산을 진행한다
    * 피연산자 큐가 비어있는 상태에서 계산을 진행하면 0을 리턴한다
    * 연산자 큐가 비어있는 상태에서 계산을 진행하면 첫번째로 입력한 숫자(operand)가 나온다
    *  피연산자 개수 == 연산자 개수( 2 + 3 - )인 상태에서 계산을 진행하면 마지막 계산한 결과값( 2 + 3 ) 까지만 나온다


---

### 《enum》 ExpressionParser

*  `func parse(from input: String) -> Formula` : String을 가지고 `Formula`로 만든다
    *  `Formula`의 `operands 큐`와 `operator 큐`에 숫자와 연산자를 enqueue 한다
*  `func componentsByOperators(from input: String) -> [String]` : `split(with: " ")` 메소드를 사용해 빈칸으로 input String에 있는 숫자와 연산자를 구분해서 그것들의 List를 리턴하도록 했다.




## 고민한 점, 질문

### 1. 계산기 기능, 구현해야하는 범위
    
> 요구사항: 모든 예시 영상은 연산자 우선순위를 따르지만, 우리 프로젝트에서는 연산자 우선순위를 무시합니다

위의 요구사항과 첨부된 이미지들을 살펴 보고 계산기 진행 과정을 요약했다.

1. 숫자(a) 를 누르고
연산자 를 누르면  
a와 해당 연산을 진행할 숫자를 입력받을 준비를 한다.

2. 숫자를 누르지 않고
연산자를 누르면 
0과 해당 연산을 진행할 숫자를 입력받을 준비를 한다. 
    
3. 연산자를 연속으로 누른다면
    마지막으로 누른 연산자, 
    즉 숫자를 입력하기 바로 전의 연산자에 해당하는 연산을 진행한다.   
   
4. = 을 눌러야 그동안 입력 되었던 연산을 한번에 수행한다.
    
5. 숫자의 기호(음수/양수의 표현)을 담당하는 버튼이 따로 있다.
    버튼을 누르면 레이블에 띄워진 숫자가 음수 혹은 양수로 변한다.
    
* ### 시나리오
    ---
1. 사용자가 `3 + * - 5 - + 1 =` 순서로 입력한다면
       1. 3을 입력한다 : 레이블에 3이 나타난다
       2. +를 입력한다 : 레이블의 3이 0으로 바뀐다. `3`이 스크롤뷰에 나타난다. +가 레이블에 나타난다
       3. *를 입력한다 : +가 *로 바뀐다
       4. -를 입력한다 : *가 -로 바뀐다
       5. 5를 입력한다 : 5가 레이블에 나타난다
       6. -를 입력한다 : `- 5`가 스크롤뷰에 추가된다. -가 레이블에 나타난다. 레이블의 5가 0으로 바뀐다.
       7. +를 입력한다 : -가 +로 바뀐다
       8. 1을 입력한다 : 1이 레이블에 나타난다
       9. =을 입력한다 : `+ 1`이 스크롤뷰에 추가된다. 총 연산결과가 레이블에 나온다.
    
    input String: `3 - 5 + 1` 
    (스크롤뷰에 뜬 String을 빈칸과 함께 붙인다.`"3"+" "+"- 5"+" "+"+ 1"`)
    **(스크롤뷰에 추가되는 String또한 연산자와 숫자를 빈칸을 사이에 둬 붙인다)**
    
    ---
2. 사용자가 `+ 1 * =` 순서로 입력한다면
        1. +를 입력한다: 레이블에 + 가 나타난다. `0`이 스크롤뷰에 나타난다
        2. 1을 입력한다: 레이블에 1이 나타난다
        3. *를 입력한다: 레이블에 *이 나타난다. `+ 1`이 스크롤뷰에 추가된다. 레이블의 1이 0으로 변한다.
        4. =을 입력한다: * 0 이 스크롤뷰에 추가된다. 총 연산 결과가 레이블에 나온다.

    input String: `0 + 1 * 0` 
    (스크롤뷰에 뜬 String을 빈칸과 함께 붙인다.`"0"+" "+"+ 1"+" "+"* 0"`)
    
    ---
    
3. 사용자가 `2 + (부호정하기-) 1 =` 순서로 입력한다면
        1. 2를 입력한다: 레이블에 2가 나타난다.
        2. +을 입력한다: 2가 스크롤뷰에 나타난다. +가 레이블에 나타난다. 0이 레이블에 나타난다
        3. (부호정하기-)를 입력한다: 0의 부호가 바뀐다. 0이기 때문에 바뀌어도 그대로이다.
        4. 1을 입력한다: 1이 레이블에 나타난다
        5. =을 입력한다: + 1이 스크롤뷰에 추가된다. 총 연산 결과가 나온다.

    input String: `2 + 1` 
    (스크롤뷰에 뜬 String을 빈칸과 함께 붙인다.`"2"+" "+"+ 1"`)
    
✅**이 프로젝트의 계산기는 = 를 눌러야 연산을 한번에 수행한다.
따라서 사용자가 `3 + * - 5 - + 1` 이렇게 입력을 했어도
현재 단계에서 계산을 진행하는데 필요한 input String은 
스크롤 뷰에 나타난 String들을 합한 `3 - 5 + 1` 이라고 전제를 두기로 한다.**
### 2. 0으로 나누는 경우
* `처음엔 0으로 나눴을때 Error를 던지도록 할까` 했지만, UML 상에서 Error enum이 없어서 다른 방식으로 처리하기로 하였다.
    
* `나누는 수가 0인 경우 Double.nan 을 리턴`하도록 하였다. 
    * 0으로 나눴을때 계산기는 NaN을 표시한다. [NaN]((https://developer.apple.com/documentation/swift/floatingpoint/1641652-nan))에 대해 찾아보니 Not a Number 라는 의미였다. FloatingPoint 프로토콜을 채택하는 Double의 타입프로퍼티의 하나로, 숫자가 아니라서 숫자와의 비교에 무조건적으로 false를 내보낸다. 또한 어떠한 사칙연산을 해도 결과는 nan이다. 
nan일때 .isNaN은 true이기 때문에. 추후에 계산 결과의 isNaN이 true일때 화면에 NaN이 보이도록 구현하면 될 것이다.



### 3. Formula 구현
* 로직에 대해 고민을 많이 했다. 만족해야하는 조건들을 생각하고 이를 따르도록 구현하고자 했다.
    * 피연산자 큐가 비어있는 상태에서 계산을 진행하면 0을 리턴한다
    * 연산자 큐가 비어있는 상태에서 계산을 진행하면 첫번째로 입력한 숫자(operand)가 나온다
    -> (하지만 input String에서는 피연산자 큐가 비어있을 일이 없다)
   
    
### 4. String Extension
    
🤔 이미 `String`에는 `components`나 `split` 같은 문자열 처리 메소드가 있는데, 왜 `func split(with target: Character) -> [String]` 메소드를 갖도록 확장시켜야 할까?
  
#### split, components 메소드
공식문서와 [정리된 게시물](https://velog.io/@minni/Swift-split-VS-components) 참고
* **split 메소드** :`func split(separator: Character, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [Substring]` 
    * 매개변수 3개: separator(구분자) , maxSplits(collection 타입을 잘라주는 최대 횟수) , 
  omittingEmptySubsequences(true 라면 빈 subsequnece는 반환되지 않음)
    * parameter로 Character 를 받고 return을 [Substring] 형태로 반환
    * Swift 표준 라이브러리에 포함, Foundation import하지 않아도 된다
    
* **components 메소드** : `func components(separatedBy separator: String) -> [String]`
    * 매개변수 1개: separator(구분자)
    * parameter로 String 을 받고 return을 [String] 형태로 반환
    * Foundation을 import해야한다
  
    
**🤔 split의 리턴 값이 [Substring]이기 때문에 확장을 시킨 것일까? 그렇다면 Substring과 String의 차이는 무엇일까?**

공식문서와 [정리된 게시물](https://appleceo.github.io/2019/06/20/substring/) 참고

**Substring**
* String에서 사용하는 대부분의 메서드를 가지고 있으며 String과 같은 방법으로 사용가능
* 원래 문자열이나 다른 하위 문자열을 저장하는데 사용되는 메모리의 일부를 다시 사용한다

Substring을 다른 함수의 매개변수로 보내거나 사용하면, **메모리에 해당 Substring만 저장되는 것이 아니라 원래 String을 계속 가지고 있어야 하기 때문에**, 이러한 상황이 반복되면 쓸데없이 메모리를 차지하게 된다.

이와같은 이유로 String을 확장한 것이라고 생각된다.

>**Q. 린생이 생각하는 String 확장 이유가 무엇인지 궁금합니다**
    
### 5. 왜 `Operator`는 [CaseIterable](https://developer.apple.com/documentation/swift/caseiterable)을 채택할까?

CaseIterable을 채택하면, allCases 프로퍼티로 타입의 모든 case들의 collection에 접근할 수 있다.

그렇다면 사칙연산 연산자의 collection이 쓰일 일이 있다는 것인데.. 어디에서 쓰이는 걸까? 
    
> **Q. 왜 CaseIterable을 채택하라고 UML에 적혀있을까요?**
    
### 6. ExpressionParser 구현
* `private func componentsByOperators(from input: String) -> [String]` 가 무엇을 수행하는 지 도통 알 수 없는 네이밍이었다.

* **1. 만약에 연산자를 기준으로 input String을 쪼개는 함수라면?**
    `"1+2*3"` -> `["1","2","3"] `
    * 함수 안에서 실행되어야 하는 게 문자열을 쪼개는 메소드인 split(with: )일 것이다. 하지만 split은 Character를 구분자로 가지기 때문에, `["+", "-", "*", "/"]` 의 collection을 구분자로 가질 수 없고
    
    * components() 메소드를 아래와 같이 사용해도, Cannot convert value of type '[Character]' to expected argument type 'CharacterSet' 라는 에러 메시지와 함께 실행되지 않는다.
    ```swift
    private func componentsByOperators(from input: String) -> [String] {
        return input.components(seperatedBy: Operator.allCases.map { $0.rawValue })
    } // 에러 메시지 뜸 - Cannot convert value of type '[Character]' to expected argument type 'CharacterSet'
    ``` 
    
* **2. 만약에 빈칸을 구분자로 String을 쪼개는 함수라면?**
`"1 + 2 * 3"` -> `["1", "+", "2", "*", "*3"] `

    * 모든 곳에서 split(with: " ")을 사용할 수 있는데 왜 굳이 private으로 접근제어자를 설정해둔, 똑같은 역할을 하는 함수를 만든 것인지 이해가 가지 않는다.
    
* **3. 만약에 연산자가 달린 피연산자를 뽑아내는 함수라면?**
`"1 + -2 * -3"` -> `["-2","-3"] `
  * input String이 `"1+-2*3"`일때 이런 역할을 한다면, -나 + 연산자가 음수/양수의 표현인지 연산자인건지 구분할 수 있겠지만, 내가 전제로 둔 input String의 상태는 이미 빈칸으로 숫자와 연산자가 구분되어있기 때문에, 굳이 이럴 필요가 없다... 

우선 2번 역할을 수행하는 함수라고 생각하고 구현했다.
    
> **Q. 린생은 저 함수가 무슨 역할을 해야한다고 생각하시나요?**




