### PR TITLE
계산기 I [STEP3] 두두

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		9492861B27E21C960012F0B8 /* LinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9492861A27E21C960012F0B8 /* LinkedListTest.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
-		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
+		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
@@ -92,7 +92,7 @@
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C713D9452570E5EB001C3AFC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorViewController.swift; sourceTree = "<group>"; };
 		C713D9482570E5EB001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -213,7 +213,7 @@
 			children = (
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
-				C713D9452570E5EB001C3AFC /* ViewController.swift */,
+				C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -536,7 +536,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9476536827DF726D00646A7F /* CalculatorItemQueue.swift in Sources */,
-				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				946FAE3B27E398EF0058F4DE /* Double+Extension.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				946FAE3927E398B50058F4DE /* CalculateItem.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		94184E3427E227C6000C17C0 /* CalculatorItemQueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94184E3327E227C6000C17C0 /* CalculatorItemQueueTest.swift */; };
+		9438727A27E9B1E20013501F /* UIScrollView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9438727927E9B1E20013501F /* UIScrollView+Extension.swift */; };
 		946FAE2727E3925D0058F4DE /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946FAE2627E3925D0058F4DE /* Operator.swift */; };
 		946FAE2F27E393070058F4DE /* OperatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946FAE2E27E393070058F4DE /* OperatorTest.swift */; };
 		946FAE3927E398B50058F4DE /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946FAE3827E398B50058F4DE /* CalculateItem.swift */; };
@@ -70,6 +71,7 @@
 /* Begin PBXFileReference section */
 		94184E3127E227C6000C17C0 /* CalculatorItemQueueTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		94184E3327E227C6000C17C0 /* CalculatorItemQueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTest.swift; sourceTree = "<group>"; };
+		9438727927E9B1E20013501F /* UIScrollView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Extension.swift"; sourceTree = "<group>"; };
 		946FAE2627E3925D0058F4DE /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		946FAE2C27E393070058F4DE /* OperatorTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperatorTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		946FAE2E27E393070058F4DE /* OperatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTest.swift; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 			children = (
 				946FAE3A27E398EF0058F4DE /* Double+Extension.swift */,
 				946FAE3C27E399610058F4DE /* String+Extension.swift */,
+				9438727927E9B1E20013501F /* UIScrollView+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -540,6 +543,7 @@
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				946FAE2727E3925D0058F4DE /* Operator.swift in Sources */,
 				946FAE4C27E39A600058F4DE /* Formula.swift in Sources */,
+				9438727A27E9B1E20013501F /* UIScrollView+Extension.swift in Sources */,
 				9476536427DF6D1E00646A7F /* Node.swift in Sources */,
 				946FAE3D27E399610058F4DE /* String+Extension.swift in Sources */,
 				946FAE4E27E3A1070058F4DE /* ExpressionParser.swift in Sources */,

--- a/Calculator/Calculator/Controller/AppDelegate.swift
+++ b/Calculator/Calculator/Controller/AppDelegate.swift
@@ -21,8 +21,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-
-    }
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
 }
 

--- a/Calculator/Calculator/Controller/CalculateViewController.swift
+++ b/Calculator/Calculator/Controller/CalculateViewController.swift
@@ -1,12 +1,12 @@
 //
-//  Calculator - ViewController.swift
+//  Calculator - CalculateViewController.swift
 //  Created by DuDu
 //
 
 import UIKit
 
-final class ViewController: UIViewController {
-    private var currentNumber: String = ""
+final class CalculateViewController: UIViewController {
+    private var currentStringNumber: String = ""
     private var expression: [String?] = []
     private var isInputExist: Bool = false
     private var isCalculateValue: Bool = false
@@ -36,13 +36,13 @@ final class ViewController: UIViewController {
             return
         }
         
-        if String(currentNumber).count >= 20 {
+        if currentStringNumber.count >= 20 {
             return
         }
         
         if isCalculateValue {
             isCalculateValue = false
-            //acButtonDidTapped(nil)
+            resetCalculator()
         }
         
         guard let inputNumber = sender.titleLabel?.text else {
@@ -55,21 +55,17 @@ final class ViewController: UIViewController {
         }
         
         isInputExist = true
-        currentNumber += inputNumber
-        numberLabel.text = currentNumber
+        currentStringNumber += inputNumber
+        numberLabel.text = currentStringNumber
     }
     
     @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
-        operatorLabel.text = sender.titleLabel?.text
-        writeCalculateLog()
-    }
-    
-    private func writeCalculateLog() {
         if numberLabel.text == "NaN" {
             return
         }
         
         if isInputExist == false {
+            operatorLabel.text = sender.titleLabel?.text
             return
         }
         
@@ -89,8 +85,9 @@ final class ViewController: UIViewController {
         expression.append(contentsOf: [operatorLabel.text, doubleNumber])
     
         isInputExist = false
-        currentNumber = ""
+        currentStringNumber = ""
         numberLabel.text = "0"
+        operatorLabel.text = sender.titleLabel?.text
     }
     
     private func makeLabel(with text: String?) -> UILabel {
@@ -105,7 +102,7 @@ final class ViewController: UIViewController {
             return
         }
         
-        if currentNumber.contains(".") {
+        if currentStringNumber.contains(".") {
             return
         }
         
@@ -113,26 +110,26 @@ final class ViewController: UIViewController {
             return
         }
         
-        if String(currentNumber).count >= 20 {
+        if String(currentStringNumber).count >= 20 {
             return
         }
 
-        if currentNumber.isEmpty {
-            currentNumber = "0"
+        if currentStringNumber.isEmpty {
+            currentStringNumber = "0"
         }
         
-        currentNumber += "."
-        numberLabel.text = currentNumber
+        currentStringNumber += "."
+        numberLabel.text = currentStringNumber
     }
     
-    @IBAction private func acButtonDidTapped(_ sender: UIButton) {
+    @IBAction private func allClearButtonDidTapped(_ sender: UIButton) {
         resetCalculator()
     }
     
     private func resetCalculator() {
         expression.removeAll()
         isInputExist = false
-        currentNumber = ""
+        currentStringNumber = ""
         numberLabel.text = "0"
         operatorLabel.text = ""
         
@@ -142,12 +139,12 @@ final class ViewController: UIViewController {
         }
     }
     
-    @IBAction private func ceButtonDidTapped(_ sender: UIButton) {
+    @IBAction private func clearEntryButtonDidTapped(_ sender: UIButton) {
         if numberLabel.text == "NaN" {
             return
         }
         
-        currentNumber = ""
+        currentStringNumber = ""
         numberLabel.text = "0"
         isInputExist = false
     }
@@ -157,30 +154,32 @@ final class ViewController: UIViewController {
             return
         }
         
-        guard let number = Double(currentNumber) else {
+        guard let number = Double(currentStringNumber) else {
             return
         }
         
         if number < 0 {
-            currentNumber.removeFirst()
+            currentStringNumber.removeFirst()
         } else {
-            currentNumber.insert("-", at: currentNumber.startIndex)
+            currentStringNumber.insert("-", at: currentStringNumber.startIndex)
         }
         
-        numberLabel.text = currentNumber
+        numberLabel.text = currentStringNumber
     }
     
     @IBAction private func calculateButtonDidTapped(_ sender: UIButton) {
-
+        print(#function)
+        
         if expression.isEmpty {
             return
         }
                 
-        writeCalculateLog()
+        //operatorButtonDidTapped(nil)
         
         let expressionString = expression.compactMap{$0}.joined(separator: " ")
         expression.removeAll()
-        currentNumber = ""
+        print(expressionString)
+        currentStringNumber = ""
         
         do {
             let calculateResult = try ExpressionParser.parse(from: expressionString).result()

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -79,7 +79,7 @@ private extension CalculatorViewController {
         
         expression.append(contentsOf: [operatorLabel.text, doubleNumber])
         calculateLogStackView.addArrangedSubview(stackView)
-        logScrollView.scroll()
+        logScrollView.scrollToBottom()
         resetElements()
     }
     

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -31,6 +31,8 @@ final class CalculatorViewController: UIViewController {
     private lazy var numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = -2
+        formatter.maximumIntegerDigits = -2
         return formatter
     }()
     

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -1,5 +1,5 @@
 //
-//  Calculator - ViewController.swift
+//  Calculator - CalculatorViewController.swift
 //  Created by DuDu
 //
 
@@ -16,7 +16,7 @@ private enum NumberString {
     static let nan = "NaN"
 }
 
-final class ViewController: UIViewController {
+final class CalculatorViewController: UIViewController {
     private var currentStringNumber: String = NumberString.empty
     private var expression: [String?] = []
     private var isInputExist: Bool = false
@@ -151,7 +151,7 @@ final class ViewController: UIViewController {
 
 }
 
-private extension ViewController {
+private extension CalculatorViewController {
     
     func setUpAttribute() {
         numberLabel.text = NumberString.zero

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -73,18 +73,17 @@ private extension CalculatorViewController {
     func writeCalculateLog() {
         guard isInputExist else { return }
         
-        let doubleNumber = numberLabel.text?.replacingOccurrences(of: ",", with: "")
+        let doubleNumber = numberLabel.text?.removeComma()
         let stackView = logStackView()
         
+        expression.append(contentsOf: [operatorLabel.text, doubleNumber])
         calculateLogStackView.addArrangedSubview(stackView)
         logScrollView.scroll()
-        expression.append(contentsOf: [operatorLabel.text, doubleNumber])
-        
         resetElements()
     }
     
     func logStackView() -> UIStackView {
-        let doubleNumber = numberLabel.text?.replacingOccurrences(of: ",", with: "")
+        let doubleNumber = numberLabel.text?.removeComma()
         let numberLogLabel = logLabel(with: doubleNumber)
         let operatorLogLabel = logLabel(with: operatorLabel.text)
         

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -31,8 +31,6 @@ final class CalculatorViewController: UIViewController {
     private lazy var numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = Digit.limitDigit
-        formatter.roundingMode = .floor
         return formatter
     }()
     

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -70,6 +70,7 @@ final class CalculatorViewController: UIViewController {
 //MARK: - Method
 
 private extension CalculatorViewController {
+    
     func writeCalculateLog() {
         guard isInputExist else { return }
         
@@ -130,21 +131,18 @@ private extension CalculatorViewController {
     
     @IBAction private func numberButtonDidTapped(_ sender: UIButton) {
         guard currentStringNumber.count < Digit.limitDigit,
-              let inputNumber = sender.titleLabel?.text else {
-            
+            let inputNumber = sender.titleLabel?.text else {
             return
         }
         
         if isCalculateValue ||
             numberLabel.text == NumberString.nan {
-            
             isCalculateValue = false
             resetCalculator()
         }
         
         if ["00","0"].contains(inputNumber),
            numberLabel.text == NumberString.zero {
-            
             isInputExist = true
             return
         }
@@ -155,9 +153,7 @@ private extension CalculatorViewController {
     }
     
     @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
-        guard numberLabel.text != NumberString.nan else {
-            return
-        }
+        guard numberLabel.text != NumberString.nan else { return }
         
         writeCalculateLog()
         updateOperatorLabel(to: sender.titleLabel?.text)
@@ -165,10 +161,9 @@ private extension CalculatorViewController {
     
     @IBAction private func dotButtonDidTapped(_ sender: UIButton) {
         guard numberLabel.text != NumberString.nan,
-              !currentStringNumber.contains("."),
-              isCalculateValue == false,
-              currentStringNumber.count < Digit.limitDigit else {
-            
+            !currentStringNumber.contains("."),
+            isCalculateValue == false,
+            currentStringNumber.count < Digit.limitDigit else {
             return
         }
         
@@ -185,9 +180,7 @@ private extension CalculatorViewController {
     }
     
     @IBAction private func clearEntryButtonDidTapped(_ sender: UIButton) {
-        guard numberLabel.text != NumberString.nan else {
-            return
-        }
+        guard numberLabel.text != NumberString.nan else { return }
         
         updateCurrentStringNumber(to: NumberString.empty)
         updateNumberLabel(to: NumberString.zero)
@@ -196,8 +189,7 @@ private extension CalculatorViewController {
     
     @IBAction private func signButtonDidTapped(_ sender: UIButton) {
         guard let number = Double(currentStringNumber),
-              numberLabel.text != NumberString.zero else {
-            
+            numberLabel.text != NumberString.zero else {
             return
         }
         
@@ -211,25 +203,18 @@ private extension CalculatorViewController {
     }
     
     @IBAction private func calculateButtonDidTapped(_ sender: UIButton) {
-        guard expression.isEmpty == false else {
-            return
-        }
+        guard expression.isEmpty == false else { return }
         
         writeCalculateLog()
         
-        let expressionString = expression
-            .compactMap{$0}
-            .joined(separator: " ")
+        let expressionString = expression.compactMap { $0 }.joined(separator: " ")
         expression.removeAll()
         updateCurrentStringNumber(to: NumberString.empty)
         
         do {
-            let calculateResult = try ExpressionParser
-                .parse(from: expressionString)
-                .result()
+            let calculateResult = try ExpressionParser.parse(from: expressionString).result()
             
             updateNumberLabel(to: adjust(number: calculateResult))
-            
             isCalculateValue = true
             isInputExist = true
         } catch {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -112,7 +112,7 @@ private extension CalculatorViewController {
         }
     }
     
-    func adjust(number: Double) -> String? {
+    func addComma(to number: Double) -> String? {
         let splitedNumber = String(number).split(with: ".")
         let integerDigits = splitedNumber[0]
         
@@ -129,7 +129,7 @@ private extension CalculatorViewController {
 
 private extension CalculatorViewController {
     
-    @IBAction private func numberButtonDidTapped(_ sender: UIButton) {
+    @IBAction func numberButtonDidTapped(_ sender: UIButton) {
         guard currentStringNumber.count < Digit.limitDigit,
             let inputNumber = sender.titleLabel?.text else {
             return
@@ -146,20 +146,20 @@ private extension CalculatorViewController {
             isInputExist = true
             return
         }
-        
+    
         isInputExist = true
         updateCurrentStringNumber(to: currentStringNumber + inputNumber)
         updateNumberLabel(to: currentStringNumber)
     }
     
-    @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
+    @IBAction func operatorButtonDidTapped(_ sender: UIButton) {
         guard numberLabel.text != NumberString.nan else { return }
         
         writeCalculateLog()
         updateOperatorLabel(to: sender.titleLabel?.text)
     }
     
-    @IBAction private func dotButtonDidTapped(_ sender: UIButton) {
+    @IBAction func dotButtonDidTapped(_ sender: UIButton) {
         guard numberLabel.text != NumberString.nan,
             !currentStringNumber.contains("."),
             isCalculateValue == false,
@@ -175,11 +175,11 @@ private extension CalculatorViewController {
         updateNumberLabel(to: currentStringNumber)
     }
     
-    @IBAction private func allClearButtonDidTapped(_ sender: UIButton) {
+    @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
         resetCalculator()
     }
     
-    @IBAction private func clearEntryButtonDidTapped(_ sender: UIButton) {
+    @IBAction func clearEntryButtonDidTapped(_ sender: UIButton) {
         guard numberLabel.text != NumberString.nan else { return }
         
         updateCurrentStringNumber(to: NumberString.empty)
@@ -187,7 +187,7 @@ private extension CalculatorViewController {
         isInputExist = false
     }
     
-    @IBAction private func signButtonDidTapped(_ sender: UIButton) {
+    @IBAction func signButtonDidTapped(_ sender: UIButton) {
         guard let number = Double(currentStringNumber),
             numberLabel.text != NumberString.zero else {
             return
@@ -202,7 +202,7 @@ private extension CalculatorViewController {
         updateNumberLabel(to: currentStringNumber)
     }
     
-    @IBAction private func calculateButtonDidTapped(_ sender: UIButton) {
+    @IBAction func calculateButtonDidTapped(_ sender: UIButton) {
         guard expression.isEmpty == false else { return }
         
         writeCalculateLog()
@@ -214,7 +214,7 @@ private extension CalculatorViewController {
         do {
             let calculateResult = try ExpressionParser.parse(from: expressionString).result()
             
-            updateNumberLabel(to: adjust(number: calculateResult))
+            updateNumberLabel(to: addComma(to: calculateResult))
             isCalculateValue = true
             isInputExist = true
         } catch {

--- a/Calculator/Calculator/Controller/SceneDelegate.swift
+++ b/Calculator/Calculator/Controller/SceneDelegate.swift
@@ -14,24 +14,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 
-    func sceneDidDisconnect(_ scene: UIScene) {
-        
-    }
+    func sceneDidDisconnect(_ scene: UIScene) {}
 
-    func sceneDidBecomeActive(_ scene: UIScene) {
+    func sceneDidBecomeActive(_ scene: UIScene) {}
 
-    }
+    func sceneWillResignActive(_ scene: UIScene) {}
 
-    func sceneWillResignActive(_ scene: UIScene) {
-        
-    }
+    func sceneWillEnterForeground(_ scene: UIScene) {}
 
-    func sceneWillEnterForeground(_ scene: UIScene) {
-
-    }
-
-    func sceneDidEnterBackground(_ scene: UIScene) {
-
-    }
+    func sceneDidEnterBackground(_ scene: UIScene) {}
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -20,6 +20,7 @@ final class ViewController: UIViewController {
     private lazy var numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 20
         formatter.roundingMode = .floor
         return formatter
     }()
@@ -27,6 +28,7 @@ final class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         numberLabel.text = "0"
+        logScrollView.showsVerticalScrollIndicator = false
     }
     
     @IBAction private func numberButtonDidTapped(_ sender: UIButton) {
@@ -43,7 +45,9 @@ final class ViewController: UIViewController {
             acButtonDidTapped(nil)
         }
         
-        let inputNumber = sender.titleLabel?.text
+        guard let inputNumber = sender.titleLabel?.text else {
+            return
+        }
         
         if ["00","0"].contains(inputNumber), numberLabel.text == "0" {
             isInputExist = true
@@ -51,7 +55,7 @@ final class ViewController: UIViewController {
         }
         
         isInputExist = true
-        currentNumber += inputNumber ?? ""
+        currentNumber += inputNumber
         numberLabel.text = currentNumber
     }
     
@@ -68,14 +72,8 @@ final class ViewController: UIViewController {
         isCalculateValue = false
         
         let doubleNumber = numberLabel.text?.replacingOccurrences(of: ",", with: "")
-        
-        let numberLogLabel = UILabel()
-        numberLogLabel.text = doubleNumber
-        numberLogLabel.textColor = .white
-        
-        let operatorLogLabel = UILabel()
-        operatorLogLabel.text = operatorLabel.text
-        operatorLogLabel.textColor = .white
+        let numberLogLabel = makeLabel(with: doubleNumber)
+        let operatorLogLabel = makeLabel(with: operatorLabel.text)
         
         let stackView = UIStackView(arrangedSubviews: [operatorLogLabel, numberLogLabel])
         stackView.axis = .horizontal
@@ -84,13 +82,19 @@ final class ViewController: UIViewController {
         
         calculateLogStackView.addArrangedSubview(stackView)
         logScrollView.scroll()
-    
         expression.append(contentsOf: [operatorLabel.text, doubleNumber])
     
         isInputExist = false
         currentNumber = ""
-        operatorLabel.text = sender?.titleLabel?.text
         numberLabel.text = "0"
+        operatorLabel.text = sender?.titleLabel?.text
+    }
+    
+    private func makeLabel(with text: String?) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.textColor = .white
+        return label
     }
     
     @IBAction private func dotButtonDidTapped(_ sender: Any) {
@@ -120,10 +124,11 @@ final class ViewController: UIViewController {
     
     @IBAction private func acButtonDidTapped(_ sender: Any?) {
         expression.removeAll()
+        isInputExist = false
         currentNumber = ""
         numberLabel.text = "0"
         operatorLabel.text = ""
-        isInputExist = false
+        
         
         calculateLogStackView.arrangedSubviews.forEach { subView in
             subView.removeFromSuperview()
@@ -167,16 +172,16 @@ final class ViewController: UIViewController {
         
         let expressionString = expression.compactMap{$0}.joined(separator: " ")
         expression.removeAll()
+        currentNumber = ""
         
         do {
             let calculateResult = try ExpressionParser.parse(from: expressionString).result()
             numberLabel.text = adjust(number: calculateResult)
-            currentNumber = ""
+            
             isCalculateValue = true
             isInputExist = true
         } catch {
             numberLabel.text = "NaN"
-            currentNumber = ""
         }
     }
     

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+final class ViewController: UIViewController {
     @IBOutlet private var calculateLogStackView: UIStackView!
     
     @IBOutlet private var currentOperator: UILabel!

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -1,15 +1,54 @@
 //
 //  Calculator - ViewController.swift
-//  Created by yagom. 
-//  Copyright © yagom. All rights reserved.
-// 
+//  Created by DuDu
+//
 
 import UIKit
 
 class ViewController: UIViewController {
+    @IBOutlet private var calculateLogStackView: UIStackView!
+    
+    @IBOutlet private var currentOperator: UILabel!
+    @IBOutlet private var currentOperand: UILabel!
+    
+    @IBOutlet private var oneZeroButton: UIButton!
+    @IBOutlet private var twoZeroButton: UIButton!
+    @IBOutlet private var oneButton: UIButton!
+    @IBOutlet private var twoButton: UIButton!
+    @IBOutlet private var threeButton: UIButton!
+    @IBOutlet private var fourButton: UIButton!
+    @IBOutlet private var fiveButton: UIButton!
+    @IBOutlet private var sixButton: UIButton!
+    @IBOutlet private var sevenButton: UIButton!
+    @IBOutlet private var eightButton: UIButton!
+    @IBOutlet private var nineButton: UIButton!
+    
+    @IBOutlet private var plusButton: UIButton!
+    @IBOutlet private var minusButton: UIButton!
+    @IBOutlet private var multiplyButton: UIButton!
+    @IBOutlet private var divideButton: UIButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()
     }
+    
+    @IBAction private func numberButtonDidTapped(_ sender: UIButton) {
+        
+    }
+    
+    @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
+    }
+    
+    @IBAction private func dotButtonDidTapped(_ sender: Any) {
+    }
+    @IBAction private func acButtonDidTapped(_ sender: Any) {
+    }
+    @IBAction private func ceButtonDidTapped(_ sender: Any) {
+    }
+    @IBAction private func signButtonDidTapped(_ sender: Any) {
+    }
+    @IBAction private func calculateButtonDidTapped(_ sender: Any) {
+    }
+    
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -17,22 +17,7 @@ final class ViewController: UIViewController {
     @IBOutlet private var numberLabel: UILabel!
     @IBOutlet private var operatorLabel: UILabel!
     
-    @IBOutlet private var oneZeroButton: UIButton!
-    @IBOutlet private var twoZeroButton: UIButton!
-    @IBOutlet private var oneButton: UIButton!
-    @IBOutlet private var twoButton: UIButton!
-    @IBOutlet private var threeButton: UIButton!
-    @IBOutlet private var fourButton: UIButton!
-    @IBOutlet private var fiveButton: UIButton!
-    @IBOutlet private var sixButton: UIButton!
-    @IBOutlet private var sevenButton: UIButton!
-    @IBOutlet private var eightButton: UIButton!
-    @IBOutlet private var nineButton: UIButton!
-    
-    @IBOutlet private var plusButton: UIButton!
-    @IBOutlet private var minusButton: UIButton!
-    @IBOutlet private var multiplyButton: UIButton!
-    @IBOutlet private var divideButton: UIButton!
+
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,7 +34,7 @@ final class ViewController: UIViewController {
             acButtonDidTapped(nil)
         }
         
-        let inputNumber = findNumber(of: sender)
+        let inputNumber = sender.titleLabel?.text
         
         if ["00","0"].contains(inputNumber) && numberLabel.text == "0" {
             isInputExist = true
@@ -57,7 +42,7 @@ final class ViewController: UIViewController {
         }
         
         isInputExist = true
-        currentNumber += inputNumber
+        currentNumber += inputNumber ?? ""
         numberLabel.text = currentNumber
     }
     
@@ -67,7 +52,7 @@ final class ViewController: UIViewController {
         }
         
         if isInputExist == false {
-            operatorLabel.text = findOperator(of: sender)
+            operatorLabel.text = sender?.titleLabel?.text
             return
         }
         
@@ -96,7 +81,7 @@ final class ViewController: UIViewController {
     
         isInputExist = false
         currentNumber = ""
-        operatorLabel.text = findOperator(of: sender)
+        operatorLabel.text = sender?.titleLabel?.text
         numberLabel.text = "0"
     }
     
@@ -180,50 +165,6 @@ final class ViewController: UIViewController {
         } catch {
             numberLabel.text = "NaN"
             currentNumber = ""
-        }
-    }
-    
-    private func findNumber(of button: UIButton) -> String {
-        switch button {
-        case oneZeroButton:
-            return "0"
-        case twoZeroButton:
-            return "00"
-        case oneButton:
-            return "1"
-        case twoButton:
-            return "2"
-        case threeButton:
-            return "3"
-        case fourButton:
-            return "4"
-        case fiveButton:
-            return "5"
-        case sixButton:
-            return "6"
-        case sevenButton:
-            return "7"
-        case eightButton:
-            return "8"
-        case nineButton:
-            return "9"
-        default:
-            return ""
-        }
-    }
-    
-    private func findOperator(of button: UIButton?) -> String? {
-        switch button {
-        case plusButton:
-            return "+"
-        case minusButton:
-            return "-"
-        case multiplyButton:
-            return "×"
-        case divideButton:
-            return "÷"
-        default:
-            return ""
         }
     }
     

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -6,10 +6,12 @@
 import UIKit
 
 final class ViewController: UIViewController {
+    private var currentNumber: String = ""
+    
     @IBOutlet private var calculateLogStackView: UIStackView!
     
-    @IBOutlet private var currentOperator: UILabel!
-    @IBOutlet private var currentOperand: UILabel!
+    @IBOutlet private var numberLabel: UILabel!
+    @IBOutlet private var operatorLabel: UILabel!
     
     @IBOutlet private var oneZeroButton: UIButton!
     @IBOutlet private var twoZeroButton: UIButton!
@@ -30,23 +32,60 @@ final class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        numberLabel.text = "0"
     }
     
     @IBAction private func numberButtonDidTapped(_ sender: UIButton) {
+        let inputNumber = findNumber(of: sender)
         
+        if ["00","0"].contains(inputNumber) && numberLabel.text == "0" {
+            return
+        }
+        
+        currentNumber += inputNumber
+        numberLabel.text = currentNumber
     }
     
     @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
     }
     
     @IBAction private func dotButtonDidTapped(_ sender: Any) {
+        if currentNumber.contains(".") {
+            return
+        }
+        
+        if currentNumber.isEmpty {
+            currentNumber = "0"
+        }
+        
+        currentNumber += "."
+        numberLabel.text = currentNumber
     }
+    
     @IBAction private func acButtonDidTapped(_ sender: Any) {
     }
+    
     @IBAction private func ceButtonDidTapped(_ sender: Any) {
     }
+    
     @IBAction private func signButtonDidTapped(_ sender: Any) {
+        if numberLabel.text == "0" {
+            return
+        }
+        
+        guard let number = Double(currentNumber) else {
+            return
+        }
+        
+        if number < 0 {
+            currentNumber.removeFirst()
+        } else {
+            currentNumber.insert("-", at: currentNumber.startIndex)
+        }
+        
+        numberLabel.text = currentNumber
     }
+    
     @IBAction private func calculateButtonDidTapped(_ sender: Any) {
     }
     

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -42,24 +42,22 @@ final class ViewController: UIViewController {
     }
 
     @IBAction private func numberButtonDidTapped(_ sender: UIButton) {
-        if numberLabel.text == NumberString.nan {
+        guard currentStringNumber.count < Digit.limitDigit,
+              let inputNumber = sender.titleLabel?.text else {
+            
             return
         }
         
-        if currentStringNumber.count >= Digit.limitDigit {
-            return
-        }
-        
-        if isCalculateValue {
+        if isCalculateValue ||
+            numberLabel.text == NumberString.nan {
+            
             isCalculateValue = false
             resetCalculator()
         }
         
-        guard let inputNumber = sender.titleLabel?.text else {
-            return
-        }
-        
-        if ["00","0"].contains(inputNumber), numberLabel.text == NumberString.nan {
+        if ["00","0"].contains(inputNumber),
+            numberLabel.text == NumberString.zero {
+            
             isInputExist = true
             return
         }
@@ -70,24 +68,20 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
+        guard numberLabel.text != NumberString.nan else {
+            return
+        }
+        
         writeCalculateLog()
         operatorLabel.text = sender.titleLabel?.text
     }
     
     @IBAction private func dotButtonDidTapped(_ sender: UIButton) {
-        if numberLabel.text == NumberString.nan {
-            return
-        }
-        
-        if currentStringNumber.contains(".") {
-            return
-        }
-        
-        if isCalculateValue {
-            return
-        }
-        
-        if currentStringNumber.count >= Digit.limitDigit {
+        guard numberLabel.text != NumberString.nan,
+              !currentStringNumber.contains("."),
+              isCalculateValue == false,
+              currentStringNumber.count < Digit.limitDigit else {
+            
             return
         }
 
@@ -104,7 +98,7 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func clearEntryButtonDidTapped(_ sender: UIButton) {
-        if numberLabel.text == NumberString.nan {
+        guard numberLabel.text != NumberString.nan else {
             return
         }
         
@@ -114,11 +108,9 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func signButtonDidTapped(_ sender: UIButton) {
-        if numberLabel.text == NumberString.zero {
-            return
-        }
-        
-        guard let number = Double(currentStringNumber) else {
+        guard let number = Double(currentStringNumber),
+              numberLabel.text != NumberString.zero else {
+            
             return
         }
         
@@ -132,19 +124,22 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func calculateButtonDidTapped(_ sender: UIButton) {
-
-        if expression.isEmpty {
+        guard expression.isEmpty == false else {
             return
         }
                 
         writeCalculateLog()
         
-        let expressionString = expression.compactMap{$0}.joined(separator: " ")
+        let expressionString = expression
+                                .compactMap{$0}
+                                .joined(separator: " ")
         expression.removeAll()
         currentStringNumber = NumberString.empty
         
         do {
-            let calculateResult = try ExpressionParser.parse(from: expressionString).result()
+            let calculateResult = try ExpressionParser
+                                    .parse(from: expressionString)
+                                    .result()
             numberLabel.text = adjust(number: calculateResult)
             
             isCalculateValue = true
@@ -164,11 +159,7 @@ private extension ViewController {
     }
     
     func writeCalculateLog() {
-        if numberLabel.text == NumberString.nan {
-            return
-        }
-        
-        if isInputExist == false {
+        guard isInputExist else {
             return
         }
         

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -38,10 +38,9 @@ final class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        numberLabel.text = NumberString.zero
-        logScrollView.showsVerticalScrollIndicator = false
+        setUpAttribute()
     }
-    
+
     @IBAction private func numberButtonDidTapped(_ sender: UIButton) {
         if numberLabel.text == NumberString.nan {
             return
@@ -75,44 +74,6 @@ final class ViewController: UIViewController {
         operatorLabel.text = sender.titleLabel?.text
     }
     
-    private func writeCalculateLog() {
-        if numberLabel.text == NumberString.nan {
-            return
-        }
-        
-        if isInputExist == false {
-            return
-        }
-        
-        
-        
-        let doubleNumber = numberLabel.text?.replacingOccurrences(of: ",", with: "")
-        let numberLogLabel = makeLabel(with: doubleNumber)
-        let operatorLogLabel = makeLabel(with: operatorLabel.text)
-        
-        let stackView = UIStackView(arrangedSubviews: [operatorLogLabel, numberLogLabel])
-        stackView.axis = .horizontal
-        stackView.alignment = .trailing
-        stackView.spacing = 10
-        
-        calculateLogStackView.addArrangedSubview(stackView)
-        logScrollView.scroll()
-        expression.append(contentsOf: [operatorLabel.text, doubleNumber])
-    
-        isCalculateValue = false
-        isInputExist = false
-        currentStringNumber = NumberString.empty
-        numberLabel.text = NumberString.zero
-        operatorLabel.text = NumberString.empty
-    }
-    
-    private func makeLabel(with text: String?) -> UILabel {
-        let label = UILabel()
-        label.text = text
-        label.textColor = .white
-        return label
-    }
-    
     @IBAction private func dotButtonDidTapped(_ sender: UIButton) {
         if numberLabel.text == NumberString.nan {
             return
@@ -138,24 +99,11 @@ final class ViewController: UIViewController {
         numberLabel.text = currentStringNumber
     }
     
-    @IBAction private func acButtonDidTapped(_ sender: UIButton) {
+    @IBAction private func allClearButtonDidTapped(_ sender: UIButton) {
         resetCalculator()
     }
     
-    private func resetCalculator() {
-        expression.removeAll()
-        isInputExist = false
-        currentStringNumber = NumberString.empty
-        numberLabel.text = NumberString.zero
-        operatorLabel.text = NumberString.empty
-        
-        
-        calculateLogStackView.arrangedSubviews.forEach { subView in
-            subView.removeFromSuperview()
-        }
-    }
-    
-    @IBAction private func ceButtonDidTapped(_ sender: UIButton) {
+    @IBAction private func clearEntryButtonDidTapped(_ sender: UIButton) {
         if numberLabel.text == NumberString.nan {
             return
         }
@@ -205,17 +153,74 @@ final class ViewController: UIViewController {
             numberLabel.text = NumberString.nan
         }
     }
+
+}
+
+private extension ViewController {
     
-    private func adjust(number: Double) -> String? {
+    func setUpAttribute() {
+        numberLabel.text = NumberString.zero
+        logScrollView.showsVerticalScrollIndicator = false
+    }
+    
+    func writeCalculateLog() {
+        if numberLabel.text == NumberString.nan {
+            return
+        }
+        
+        if isInputExist == false {
+            return
+        }
+        
+        let doubleNumber = numberLabel.text?.replacingOccurrences(of: ",", with: "")
+        let numberLogLabel = makeLabel(with: doubleNumber)
+        let operatorLogLabel = makeLabel(with: operatorLabel.text)
+        
+        let stackView = UIStackView(arrangedSubviews: [operatorLogLabel, numberLogLabel])
+        stackView.axis = .horizontal
+        stackView.alignment = .trailing
+        stackView.spacing = 10
+        
+        calculateLogStackView.addArrangedSubview(stackView)
+        logScrollView.scroll()
+        expression.append(contentsOf: [operatorLabel.text, doubleNumber])
+    
+        isCalculateValue = false
+        isInputExist = false
+        currentStringNumber = NumberString.empty
+        numberLabel.text = NumberString.zero
+        operatorLabel.text = NumberString.empty
+    }
+    
+    func makeLabel(with text: String?) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.textColor = .white
+        return label
+    }
+    
+    func resetCalculator() {
+        expression.removeAll()
+        isInputExist = false
+        currentStringNumber = NumberString.empty
+        numberLabel.text = NumberString.zero
+        operatorLabel.text = NumberString.empty
+        
+        calculateLogStackView.arrangedSubviews.forEach { subView in
+            subView.removeFromSuperview()
+        }
+    }
+    
+    func adjust(number: Double) -> String? {
         let splitedNumber = String(number).split(with: ".")
         let integerDigits = splitedNumber[0]
         
-        if integerDigits.count > Digit.limitDigit || number >= Digit.limitNumber {
+        if integerDigits.count > Digit.limitDigit ||
+           number >= Digit.limitNumber {
             return NumberString.nan
         } else {
             return numberFormatter.string(from: number as NSNumber)
         }
     }
-    
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -60,6 +60,7 @@ final class ViewController: UIViewController {
         
         let stackView = UIStackView()
         stackView.axis = .horizontal
+        stackView.alignment = .trailing
         stackView.spacing = 10
         
         let numberLogLabel = UILabel()

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -94,9 +94,19 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func acButtonDidTapped(_ sender: Any) {
+        currentNumber = ""
+        numberLabel.text = "0"
+        isInputExist = false
+        
+        calculateLogStackView.arrangedSubviews.forEach { subView in
+            subView.removeFromSuperview()
+        }
     }
     
     @IBAction private func ceButtonDidTapped(_ sender: Any) {
+        currentNumber = ""
+        numberLabel.text = "0"
+        isInputExist = false
     }
     
     @IBAction private func signButtonDidTapped(_ sender: Any) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 
 final class ViewController: UIViewController {
     private var currentNumber: String = ""
-    private var expression: String = ""
+    private var expression: [String?] = []
     private var isInputExist: Bool = false
     
     @IBOutlet private var logScrollView: UIScrollView!
@@ -39,6 +39,10 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func numberButtonDidTapped(_ sender: UIButton) {
+        if numberLabel.text == "NaN" {
+            return
+        }
+        
         let inputNumber = findNumber(of: sender)
         
         if ["00","0"].contains(inputNumber) && numberLabel.text == "0" {
@@ -52,6 +56,10 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func operatorButtonDidTapped(_ sender: UIButton?) {
+        if numberLabel.text == "NaN" {
+            return
+        }
+        
         if isInputExist == false {
             operatorLabel.text = findOperator(of: sender)
             return
@@ -75,6 +83,9 @@ final class ViewController: UIViewController {
         calculateLogStackView.addArrangedSubview(stackView)
         logScrollView.scroll()
         
+        expression.append(operatorLabel.text)
+        expression.append(numberLabel.text)
+    
         isInputExist = false
         currentNumber = ""
         operatorLabel.text = findOperator(of: sender)
@@ -82,6 +93,10 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func dotButtonDidTapped(_ sender: Any) {
+        if numberLabel.text == "NaN" {
+            return
+        }
+        
         if currentNumber.contains(".") {
             return
         }
@@ -95,6 +110,7 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func acButtonDidTapped(_ sender: Any) {
+        expression.removeAll()
         currentNumber = ""
         numberLabel.text = "0"
         operatorLabel.text = ""
@@ -106,6 +122,10 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func ceButtonDidTapped(_ sender: Any) {
+        if numberLabel.text == "NaN" {
+            return
+        }
+        
         currentNumber = ""
         numberLabel.text = "0"
         isInputExist = false
@@ -130,32 +150,23 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func calculateButtonDidTapped(_ sender: Any) {
-        var expression = ""
-        operatorButtonDidTapped(nil)
-        
-        guard let logStackViews = calculateLogStackView.arrangedSubviews as? [UIStackView] else {
+        if expression.isEmpty {
             return
         }
         
-        for logStackView in logStackViews where logStackView.arrangedSubviews.count == 2 {
-            if let operatorView = logStackView.arrangedSubviews[0] as? UILabel {
-                expression += operatorView.text ?? ""
-                expression += " "
-            }
-            
-            if let operandView = logStackView.arrangedSubviews[1] as? UILabel {
-                expression += operandView.text ?? ""
-                expression += " "
-            }
-        }
+        operatorButtonDidTapped(nil)
+        
+        let expressionString = expression.compactMap{$0}.joined(separator: " ")
+        expression.removeAll()
         
         do {
-            let calculateResult = try ExpressionParser.parse(from: expression).result()
-            
+            let calculateResult = try ExpressionParser.parse(from: expressionString).result()
             numberLabel.text = "\(calculateResult)"
-            
+            currentNumber = "\(calculateResult)"
+            isInputExist = true
         } catch {
             numberLabel.text = "NaN"
+            currentNumber = ""
         }
     }
     

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -17,7 +17,7 @@ private enum NumberString {
 }
 
 final class ViewController: UIViewController {
-    private var currentNumber: String = NumberString.empty
+    private var currentStringNumber: String = NumberString.empty
     private var expression: [String?] = []
     private var isInputExist: Bool = false
     private var isCalculateValue: Bool = false
@@ -47,7 +47,7 @@ final class ViewController: UIViewController {
             return
         }
         
-        if String(currentNumber).count >= Digit.limitDigit {
+        if currentStringNumber.count >= Digit.limitDigit {
             return
         }
         
@@ -66,8 +66,8 @@ final class ViewController: UIViewController {
         }
         
         isInputExist = true
-        currentNumber += inputNumber
-        numberLabel.text = currentNumber
+        currentStringNumber += inputNumber
+        numberLabel.text = currentStringNumber
     }
     
     @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
@@ -84,7 +84,7 @@ final class ViewController: UIViewController {
             return
         }
         
-        isCalculateValue = false
+        
         
         let doubleNumber = numberLabel.text?.replacingOccurrences(of: ",", with: "")
         let numberLogLabel = makeLabel(with: doubleNumber)
@@ -99,8 +99,9 @@ final class ViewController: UIViewController {
         logScrollView.scroll()
         expression.append(contentsOf: [operatorLabel.text, doubleNumber])
     
+        isCalculateValue = false
         isInputExist = false
-        currentNumber = NumberString.empty
+        currentStringNumber = NumberString.empty
         numberLabel.text = NumberString.zero
         operatorLabel.text = NumberString.empty
     }
@@ -117,7 +118,7 @@ final class ViewController: UIViewController {
             return
         }
         
-        if currentNumber.contains(".") {
+        if currentStringNumber.contains(".") {
             return
         }
         
@@ -125,16 +126,16 @@ final class ViewController: UIViewController {
             return
         }
         
-        if String(currentNumber).count >= Digit.limitDigit {
+        if currentStringNumber.count >= Digit.limitDigit {
             return
         }
 
-        if currentNumber.isEmpty {
-            currentNumber = NumberString.zero
+        if currentStringNumber.isEmpty {
+            currentStringNumber = NumberString.zero
         }
         
-        currentNumber += "."
-        numberLabel.text = currentNumber
+        currentStringNumber += "."
+        numberLabel.text = currentStringNumber
     }
     
     @IBAction private func acButtonDidTapped(_ sender: UIButton) {
@@ -144,7 +145,7 @@ final class ViewController: UIViewController {
     private func resetCalculator() {
         expression.removeAll()
         isInputExist = false
-        currentNumber = NumberString.empty
+        currentStringNumber = NumberString.empty
         numberLabel.text = NumberString.zero
         operatorLabel.text = NumberString.empty
         
@@ -159,7 +160,7 @@ final class ViewController: UIViewController {
             return
         }
         
-        currentNumber = NumberString.empty
+        currentStringNumber = NumberString.empty
         numberLabel.text = NumberString.zero
         isInputExist = false
     }
@@ -169,17 +170,17 @@ final class ViewController: UIViewController {
             return
         }
         
-        guard let number = Double(currentNumber) else {
+        guard let number = Double(currentStringNumber) else {
             return
         }
         
         if number < .zero {
-            currentNumber.removeFirst()
+            currentStringNumber.removeFirst()
         } else {
-            currentNumber.insert("-", at: currentNumber.startIndex)
+            currentStringNumber.insert("-", at: currentStringNumber.startIndex)
         }
         
-        numberLabel.text = currentNumber
+        numberLabel.text = currentStringNumber
     }
     
     @IBAction private func calculateButtonDidTapped(_ sender: UIButton) {
@@ -192,7 +193,7 @@ final class ViewController: UIViewController {
         
         let expressionString = expression.compactMap{$0}.joined(separator: " ")
         expression.removeAll()
-        currentNumber = NumberString.empty
+        currentStringNumber = NumberString.empty
         
         do {
             let calculateResult = try ExpressionParser.parse(from: expressionString).result()

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -50,5 +50,49 @@ final class ViewController: UIViewController {
     @IBAction private func calculateButtonDidTapped(_ sender: Any) {
     }
     
+    private func findNumber(of button: UIButton) -> String {
+        switch button {
+        case oneZeroButton:
+            return "0"
+        case twoZeroButton:
+            return "00"
+        case oneButton:
+            return "1"
+        case twoButton:
+            return "2"
+        case threeButton:
+            return "3"
+        case fourButton:
+            return "4"
+        case fiveButton:
+            return "5"
+        case sixButton:
+            return "6"
+        case sevenButton:
+            return "7"
+        case eightButton:
+            return "8"
+        case nineButton:
+            return "9"
+        default:
+            return ""
+        }
+    }
+    
+    private func findOperator(of button: UIButton) -> String? {
+        switch button {
+        case plusButton:
+            return "+"
+        case minusButton:
+            return "-"
+        case multiplyButton:
+            return "×"
+        case divideButton:
+            return "÷"
+        default:
+            return ""
+        }
+    }
+    
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -7,7 +7,9 @@ import UIKit
 
 final class ViewController: UIViewController {
     private var currentNumber: String = ""
+    private var isInputExist: Bool = false
     
+    @IBOutlet private var logScrollView: UIScrollView!
     @IBOutlet private var calculateLogStackView: UIStackView!
     
     @IBOutlet private var numberLabel: UILabel!
@@ -39,14 +41,43 @@ final class ViewController: UIViewController {
         let inputNumber = findNumber(of: sender)
         
         if ["00","0"].contains(inputNumber) && numberLabel.text == "0" {
+            isInputExist = true
             return
         }
         
+        isInputExist = true
         currentNumber += inputNumber
         numberLabel.text = currentNumber
     }
     
     @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
+        if isInputExist == false {
+            operatorLabel.text = findOperator(of: sender)
+            return
+        }
+        
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        
+        let numberLogLabel = UILabel()
+        numberLogLabel.text = numberLabel.text
+        numberLogLabel.textColor = .white
+        
+        let operatorLogLabel = UILabel()
+        operatorLogLabel.text = operatorLabel.text
+        operatorLogLabel.textColor = .white
+        
+        stackView.addArrangedSubview(operatorLogLabel)
+        stackView.addArrangedSubview(numberLogLabel)
+        
+        calculateLogStackView.addArrangedSubview(stackView)
+        logScrollView.scroll()
+        
+        isInputExist = false
+        currentNumber = ""
+        operatorLabel.text = findOperator(of: sender)
+        numberLabel.text = "0"
     }
     
     @IBAction private func dotButtonDidTapped(_ sender: Any) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -9,6 +9,7 @@ final class ViewController: UIViewController {
     private var currentNumber: String = ""
     private var expression: [String?] = []
     private var isInputExist: Bool = false
+    private var isCalculateValue: Bool = false
     
     @IBOutlet private var logScrollView: UIScrollView!
     @IBOutlet private var calculateLogStackView: UIStackView!
@@ -43,6 +44,11 @@ final class ViewController: UIViewController {
             return
         }
         
+        if isCalculateValue {
+            isCalculateValue = false
+            acButtonDidTapped(nil)
+        }
+        
         let inputNumber = findNumber(of: sender)
         
         if ["00","0"].contains(inputNumber) && numberLabel.text == "0" {
@@ -64,6 +70,8 @@ final class ViewController: UIViewController {
             operatorLabel.text = findOperator(of: sender)
             return
         }
+        
+        isCalculateValue = false
         
         let stackView = UIStackView()
         stackView.axis = .horizontal
@@ -101,6 +109,10 @@ final class ViewController: UIViewController {
             return
         }
         
+        if isCalculateValue {
+            return
+        }
+        
         if currentNumber.isEmpty {
             currentNumber = "0"
         }
@@ -109,7 +121,7 @@ final class ViewController: UIViewController {
         numberLabel.text = currentNumber
     }
     
-    @IBAction private func acButtonDidTapped(_ sender: Any) {
+    @IBAction private func acButtonDidTapped(_ sender: Any?) {
         expression.removeAll()
         currentNumber = ""
         numberLabel.text = "0"
@@ -162,7 +174,8 @@ final class ViewController: UIViewController {
         do {
             let calculateResult = try ExpressionParser.parse(from: expressionString).result()
             numberLabel.text = "\(calculateResult)"
-            currentNumber = "\(calculateResult)"
+            currentNumber = ""
+            isCalculateValue = true
             isInputExist = true
         } catch {
             numberLabel.text = "NaN"

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -189,7 +189,8 @@ final class ViewController: UIViewController {
         let splitedNumber = String(number).split(with: ".")
         let integerDigits = splitedNumber[0]
         
-        if integerDigits.count > 20 {
+        
+        if integerDigits.count > 20 || number >= 1.0e19{
             return "NaN"
         } else {
             return numberFormatter.string(from: number as NSNumber)

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 
 final class ViewController: UIViewController {
     private var currentNumber: String = ""
+    private var expression: String = ""
     private var isInputExist: Bool = false
     
     @IBOutlet private var logScrollView: UIScrollView!
@@ -50,7 +51,7 @@ final class ViewController: UIViewController {
         numberLabel.text = currentNumber
     }
     
-    @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
+    @IBAction private func operatorButtonDidTapped(_ sender: UIButton?) {
         if isInputExist == false {
             operatorLabel.text = findOperator(of: sender)
             return
@@ -96,6 +97,7 @@ final class ViewController: UIViewController {
     @IBAction private func acButtonDidTapped(_ sender: Any) {
         currentNumber = ""
         numberLabel.text = "0"
+        operatorLabel.text = ""
         isInputExist = false
         
         calculateLogStackView.arrangedSubviews.forEach { subView in
@@ -128,6 +130,33 @@ final class ViewController: UIViewController {
     }
     
     @IBAction private func calculateButtonDidTapped(_ sender: Any) {
+        var expression = ""
+        operatorButtonDidTapped(nil)
+        
+        guard let logStackViews = calculateLogStackView.arrangedSubviews as? [UIStackView] else {
+            return
+        }
+        
+        for logStackView in logStackViews where logStackView.arrangedSubviews.count == 2 {
+            if let operatorView = logStackView.arrangedSubviews[0] as? UILabel {
+                expression += operatorView.text ?? ""
+                expression += " "
+            }
+            
+            if let operandView = logStackView.arrangedSubviews[1] as? UILabel {
+                expression += operandView.text ?? ""
+                expression += " "
+            }
+        }
+        
+        do {
+            let calculateResult = try ExpressionParser.parse(from: expression).result()
+            
+            numberLabel.text = "\(calculateResult)"
+            
+        } catch {
+            numberLabel.text = "NaN"
+        }
     }
     
     private func findNumber(of button: UIButton) -> String {
@@ -159,7 +188,7 @@ final class ViewController: UIViewController {
         }
     }
     
-    private func findOperator(of button: UIButton) -> String? {
+    private func findOperator(of button: UIButton?) -> String? {
         switch button {
         case plusButton:
             return "+"

--- a/Calculator/Calculator/Extension/String+Extension.swift
+++ b/Calculator/Calculator/Extension/String+Extension.swift
@@ -9,4 +9,8 @@ extension String {
     func split(with target: Character) -> [String] {
         split(separator: target).map{String($0)}
     }
+    
+    func removeComma() -> String {
+        replacingOccurrences(of: ",", with: "")
+    }
 }

--- a/Calculator/Calculator/Extension/UIScrollView+Extension.swift
+++ b/Calculator/Calculator/Extension/UIScrollView+Extension.swift
@@ -8,17 +8,12 @@
 import UIKit
 
 extension UIScrollView {
-    func scroll() {
-        DispatchQueue.main.async {[weak self] in
-            guard let self = self else {
-                return
-            }
-            
-            let bottomOffset = CGPoint(x: 0, y: self.contentSize.height - self.bounds.size.height + self.contentInset.bottom)
-
-            if bottomOffset.y > 0 {
-                self.setContentOffset(bottomOffset, animated: true)
-            }
+    func scrollToBottom() {
+        let bottomOffset = CGPoint(x: 0, y: contentSize.height - bounds.size.height)
+        
+        if bottomOffset.y > 0 {
+            setContentOffset(bottomOffset, animated: true)
+            layoutIfNeeded()
         }
     }
 }

--- a/Calculator/Calculator/Extension/UIScrollView+Extension.swift
+++ b/Calculator/Calculator/Extension/UIScrollView+Extension.swift
@@ -15,12 +15,7 @@ extension UIScrollView {
             }
             
             let bottomOffset = CGPoint(x: 0, y: self.contentSize.height - self.bounds.size.height + self.contentInset.bottom)
-            print(self.contentSize.height)
-            print(self.bounds.size.height)
-            print(self.contentInset.bottom)
-            
-            print(bottomOffset)
-            
+
             if bottomOffset.y > 0 {
                 self.setContentOffset(bottomOffset, animated: true)
             }

--- a/Calculator/Calculator/Extension/UIScrollView+Extension.swift
+++ b/Calculator/Calculator/Extension/UIScrollView+Extension.swift
@@ -1,0 +1,29 @@
+//
+//  UIScrollView+Extension.swift
+//  Calculator
+//
+//  Created by DuDu on 2022/03/22.
+//
+
+import UIKit
+
+extension UIScrollView {
+    func scroll() {
+        DispatchQueue.main.async {[weak self] in
+            guard let self = self else {
+                return
+            }
+            
+            let bottomOffset = CGPoint(x: 0, y: self.contentSize.height - self.bounds.size.height + self.contentInset.bottom)
+            print(self.contentSize.height)
+            print(self.bounds.size.height)
+            print(self.contentInset.bottom)
+            
+            print(bottomOffset)
+            
+            if bottomOffset.y > 0 {
+                self.setContentOffset(bottomOffset, animated: true)
+            }
+        }
+    }
+}

--- a/Calculator/Calculator/Extension/UIScrollView+Extension.swift
+++ b/Calculator/Calculator/Extension/UIScrollView+Extension.swift
@@ -9,11 +9,11 @@ import UIKit
 
 extension UIScrollView {
     func scrollToBottom() {
+        layoutIfNeeded()
         let bottomOffset = CGPoint(x: 0, y: contentSize.height - bounds.size.height)
         
         if bottomOffset.y > 0 {
             setContentOffset(bottomOffset, animated: true)
-            layoutIfNeeded()
         }
     }
 }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -12,7 +12,7 @@ enum CalculateError: Error {
 
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
-    case subtract = "-"
+    case subtract = "−"
     case divide = "÷"
     case multiply = "×"
     

--- a/Calculator/Calculator/View/Base.lproj/LaunchScreen.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/LaunchScreen.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -29,14 +28,14 @@
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dudu's Calculator" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nsZ-kJ-FJj">
                                         <rect key="frame" x="46" y="237" width="115.5" height="17"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <nil key="textColor"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="vNJ-ks-Xk2" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="PEh-MW-pau"/>
                             <constraint firstItem="vNJ-ks-Xk2" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="Q7w-98-Yxu"/>
@@ -51,8 +50,5 @@
     </scenes>
     <resources>
         <image name="LaunchImage" width="512" height="512"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Calculator View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="CalculatorViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -17,47 +17,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                                <rect key="frame" x="16" y="252" width="382" height="20.5"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -326,19 +290,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
+                                <rect key="frame" x="16" y="292.5" width="382" height="50"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
+                                                <rect key="frame" x="58" y="0.0" width="324" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -333,6 +333,7 @@
                         <outlet property="eightButton" destination="xgT-2D-A49" id="fKj-ja-nP5"/>
                         <outlet property="fiveButton" destination="vpW-df-OLm" id="0Bt-jp-INS"/>
                         <outlet property="fourButton" destination="hQm-yz-XvG" id="bHU-QA-pIJ"/>
+                        <outlet property="logScrollView" destination="BOT-7g-vxv" id="Oil-2W-tZG"/>
                         <outlet property="minusButton" destination="nTe-Sn-Pvd" id="St9-L3-yUN"/>
                         <outlet property="multiplyButton" destination="811-Pz-An6" id="Gq4-9T-ef5"/>
                         <outlet property="nineButton" destination="zcj-xJ-ruw" id="nBJ-Ds-zSc"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -50,7 +50,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="acButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qWD-R5-Y6D"/>
+                                                    <action selector="allClearButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="eUN-aa-UgB"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
@@ -61,7 +61,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="ceButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="TRl-Nc-pma"/>
+                                                    <action selector="clearEntryButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="V40-QW-fbi"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -329,8 +329,6 @@
                     </view>
                     <connections>
                         <outlet property="calculateLogStackView" destination="XRe-QE-UJf" id="8Sv-N5-EOt"/>
-                        <outlet property="currentOperand" destination="Lwz-OF-XHD" id="eHS-YG-rXR"/>
-                        <outlet property="currentOperator" destination="HPC-iy-qdm" id="kfh-oo-DB2"/>
                         <outlet property="divideButton" destination="Tfz-eM-jll" id="z3q-XP-9jB"/>
                         <outlet property="eightButton" destination="xgT-2D-A49" id="fKj-ja-nP5"/>
                         <outlet property="fiveButton" destination="vpW-df-OLm" id="0Bt-jp-INS"/>
@@ -338,8 +336,10 @@
                         <outlet property="minusButton" destination="nTe-Sn-Pvd" id="St9-L3-yUN"/>
                         <outlet property="multiplyButton" destination="811-Pz-An6" id="Gq4-9T-ef5"/>
                         <outlet property="nineButton" destination="zcj-xJ-ruw" id="nBJ-Ds-zSc"/>
+                        <outlet property="numberLabel" destination="Lwz-OF-XHD" id="UK3-UZ-p18"/>
                         <outlet property="oneButton" destination="nCE-qB-NiN" id="B9x-gE-p6j"/>
                         <outlet property="oneZeroButton" destination="mSz-Y3-r5Z" id="ATQ-Fl-VvZ"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="4fW-3q-XX9"/>
                         <outlet property="plusButton" destination="sbh-wC-koF" id="xDg-5x-8A1"/>
                         <outlet property="sevenButton" destination="L6z-2G-Gar" id="RT1-OK-6DH"/>
                         <outlet property="sixButton" destination="OaY-Mw-CPv" id="QIJ-jH-Do0"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -329,24 +329,9 @@
                     </view>
                     <connections>
                         <outlet property="calculateLogStackView" destination="XRe-QE-UJf" id="8Sv-N5-EOt"/>
-                        <outlet property="divideButton" destination="Tfz-eM-jll" id="z3q-XP-9jB"/>
-                        <outlet property="eightButton" destination="xgT-2D-A49" id="fKj-ja-nP5"/>
-                        <outlet property="fiveButton" destination="vpW-df-OLm" id="0Bt-jp-INS"/>
-                        <outlet property="fourButton" destination="hQm-yz-XvG" id="bHU-QA-pIJ"/>
                         <outlet property="logScrollView" destination="BOT-7g-vxv" id="Oil-2W-tZG"/>
-                        <outlet property="minusButton" destination="nTe-Sn-Pvd" id="St9-L3-yUN"/>
-                        <outlet property="multiplyButton" destination="811-Pz-An6" id="Gq4-9T-ef5"/>
-                        <outlet property="nineButton" destination="zcj-xJ-ruw" id="nBJ-Ds-zSc"/>
                         <outlet property="numberLabel" destination="Lwz-OF-XHD" id="UK3-UZ-p18"/>
-                        <outlet property="oneButton" destination="nCE-qB-NiN" id="B9x-gE-p6j"/>
-                        <outlet property="oneZeroButton" destination="mSz-Y3-r5Z" id="ATQ-Fl-VvZ"/>
                         <outlet property="operatorLabel" destination="HPC-iy-qdm" id="4fW-3q-XX9"/>
-                        <outlet property="plusButton" destination="sbh-wC-koF" id="xDg-5x-8A1"/>
-                        <outlet property="sevenButton" destination="L6z-2G-Gar" id="RT1-OK-6DH"/>
-                        <outlet property="sixButton" destination="OaY-Mw-CPv" id="QIJ-jH-Do0"/>
-                        <outlet property="threeButton" destination="X8H-iH-tSd" id="b1H-cM-ui7"/>
-                        <outlet property="twoButton" destination="Rif-2S-UU2" id="ANp-E2-2ga"/>
-                        <outlet property="twoZeroButton" destination="sH6-8l-kje" id="eFi-iR-fj8"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -336,7 +336,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="140.57971014492756" y="138.61607142857142"/>
+            <point key="canvasLocation" x="164" y="99"/>
         </scene>
     </scenes>
     <resources>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="acButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qWD-R5-Y6D"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -93,6 +96,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="ceButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="TRl-Nc-pma"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -101,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="signButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ADo-Rf-pmT"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -109,6 +118,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="IDq-2p-AUR"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -122,6 +134,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6vJ-HO-Eol"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -130,6 +145,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QNF-7M-iQQ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -138,6 +156,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0bW-YU-qRk"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -146,6 +167,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="E9O-gb-60M"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -159,6 +183,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bCy-aG-MvN"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -167,6 +194,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2YA-qC-zCR"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -175,6 +205,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="DrP-MK-sKE"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -183,6 +216,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vjn-Wa-oR2"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -196,6 +232,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UzL-1e-lNc"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -204,6 +243,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vqf-Nd-zMo"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -212,6 +254,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mIb-ZO-hq6"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -220,6 +265,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="McS-0B-FWF"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -233,6 +281,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="d1v-hO-Ffd"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -241,6 +292,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cpi-Hk-k1T"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -249,6 +303,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="dotButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Umb-LY-gwB"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -260,6 +317,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="calculateButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YNH-ng-2PU"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -303,6 +363,26 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="calculateLogStackView" destination="XRe-QE-UJf" id="8Sv-N5-EOt"/>
+                        <outlet property="currentOperand" destination="Lwz-OF-XHD" id="eHS-YG-rXR"/>
+                        <outlet property="currentOperator" destination="HPC-iy-qdm" id="kfh-oo-DB2"/>
+                        <outlet property="divideButton" destination="Tfz-eM-jll" id="z3q-XP-9jB"/>
+                        <outlet property="eightButton" destination="xgT-2D-A49" id="fKj-ja-nP5"/>
+                        <outlet property="fiveButton" destination="vpW-df-OLm" id="0Bt-jp-INS"/>
+                        <outlet property="fourButton" destination="hQm-yz-XvG" id="bHU-QA-pIJ"/>
+                        <outlet property="minusButton" destination="nTe-Sn-Pvd" id="St9-L3-yUN"/>
+                        <outlet property="multiplyButton" destination="811-Pz-An6" id="Gq4-9T-ef5"/>
+                        <outlet property="nineButton" destination="zcj-xJ-ruw" id="nBJ-Ds-zSc"/>
+                        <outlet property="oneButton" destination="nCE-qB-NiN" id="B9x-gE-p6j"/>
+                        <outlet property="oneZeroButton" destination="mSz-Y3-r5Z" id="ATQ-Fl-VvZ"/>
+                        <outlet property="plusButton" destination="sbh-wC-koF" id="xDg-5x-8A1"/>
+                        <outlet property="sevenButton" destination="L6z-2G-Gar" id="RT1-OK-6DH"/>
+                        <outlet property="sixButton" destination="OaY-Mw-CPv" id="QIJ-jH-Do0"/>
+                        <outlet property="threeButton" destination="X8H-iH-tSd" id="b1H-cM-ui7"/>
+                        <outlet property="twoButton" destination="Rif-2S-UU2" id="ANp-E2-2ga"/>
+                        <outlet property="twoZeroButton" destination="sH6-8l-kje" id="eFi-iR-fj8"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -17,10 +17,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
                                 <rect key="frame" x="16" y="252" width="382" height="20.5"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
+                                    <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="382" placeholderIntrinsicHeight="20.5" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>
                                     </stackView>
                                 </subviews>

--- a/README.md
+++ b/README.md
@@ -179,7 +179,57 @@ operator를 변수이름으로 쓰고 싶었는데 예약어라서 쓰지 못한
 
 ## STEP 3
 
+STEP 3는 앞서 구현했던 계산기능을 UI와 연동시켜서 온전히 작동하는 계산기를 만드는 것이었습니다  
+사실, scrollView가 이미 오토레이아웃이 다 잡혀있어서, 해당 부분에서 크게 어려운 점은 없었던것 같습니다! (직접 잡으라고 했으면 많이 어려웠을것 같습니다)
+
 ### 고민한 점
+
+#### ScrollView를 코드로 scroll시키는 방법
+
+당연히 delegate를 통해서 이미 만들어져 있을줄 알았는데, 없어서 조금 당황했습니다..  
+scrollView의 contentSize.height - bounds.size.height 을 통해서, 이동해야할 수직 거리를 구한다음 setContentOffset으로 bounds의 origin의 y좌표를 변경해서 하단으로 scroll이 되게 구현하였습니다
+
+#### 계산기의 각종 예외상황을 어떻게 처리할지
+
+대부분은 명세서에 나와있는대로 구현했지만, 나와있지 않은 부분도 있어서 해당 부분 처리를 고민했습니다
+
+#### if 조건들을 한번에 써도 괜찮은지
+
+여러 조건들을 한번에 쓸지, 따로따로 써줘야할지 고민했습니다  
+스타일 차이인지, 더 선호되는 방법이 있는지 궁금합니다.
+
+```swift
+//방법1
+
+if condition1 {
+    return
+}
+
+if condition2 {
+    return
+}
+
+//방법2
+
+if condition1 || condition2 {
+    return
+}
+
+```
+
+#### 수식 문자열을 어떻게 만들지
+
+처음에는 StackView에 연산자, 피연산자 형태로 기록이 남아있으니, 해당 stackView를 순회하면서 문자열을 만들어줄 생각이었습니다.  
+그러나, 이미 계산된 결과 역시 다시 피연산자로 쓰일수가 있기에, 해당 방법은 사용하지 않고, StackView와 완전 별개로 계산결과를 따로 저장하도록 리팩터링 하였습니다.
+
+
 ### 배운 개념
+
+- frame과 bounds의 제대로된 이해 (특히 bounds)
+- contentInset와 contentOffset
+- ScrollView를 코드로 scroll하는 방법
+
+
 ### 피드백 후 개선한 점
+
 

--- a/README.md
+++ b/README.md
@@ -170,9 +170,12 @@ operator를 변수이름으로 쓰고 싶었는데 예약어라서 쓰지 못한
 
 그래도 oneOperator 이런식으로라도 쓰는게 좋을까요?
 
-
 ### 배운 개념
+
 ### 피드백 후 개선한 점
+
+- 오류 테스트를 위한 XCAssertThrowsError(), XCTAssertNoThrow()
+- 테스트 함수 네이밍 방법(검증하고 싶은 내용을 적어주기)
 
 ## STEP 3
 


### PR DESCRIPTION
안녕하세요 @hyunable !

마지막 STEP3 완료하여 PR 보냅니다!  
이번 스탭을 진행하면서 코드가 깔끔하지 않다는 느낌을 많이 받았습니다.. 😵‍💫😵‍💫  
많은 지적/ 조언 부탁드립니다!!  

STEP3는 만들어둔 로직을 UI와 연동하여 동작하게 하는것이었습니다.  
주어진 요구사항들을 만족하게끔 코드를 짜봤습니다

### 완성된 계산기
![img_last](https://user-images.githubusercontent.com/69573768/159610452-ee14d5ec-fde9-4b9b-8f82-fd0825bfa8b4.gif)


## 코드이해를 돕기 위한 프로퍼티설명

- `currentNumber: String` : 숫자가 입력되면 currentNumber에 값을 누적시킵니다
- `expression: [String?]` : 계산기록들을 저장하여 마지막에 input문자열을 만들어 주기 위한 배열입니다
- `isInputExist: Bool`: 현재 연산자 값이 있는지 없는지 구분하기 위한 변수입니다. 프로젝트의 계산기에서는 무조건 값이 0으로 초기화 되는데, 비어있는0과 직접 눌러준 0,00과 구분할 필요성이 있어서 만들었습니다
- `isCalculateValue: Bool`: 계산된 값인지 아닌지 구분하기 위한 변수입니다. =을 누른후, 해당 값에 이어서 연산을 하기위해 만들었습니다

- `logScrollView: UIScrollView`: 계산과정/결과가 기록될 스크롤 뷰 입니다
- `calculateLogStackView: UIStackView`: scollView를 꽉 채우고 있는 StackView입니다
- `numberLabel: UILabel`: 현재 입력되어있는 숫자를 표시합니다
- `operatorLabel: UILabel`: 현재 입력되어있는 연산자를 표시합니다

## 요구사항 구현

### AC는 모든 연산내역을 초기화합니다
`acButtonDidTapped(_ sender: Any?)` 함수가 호출되며, 모든 기록들을 초기화합니다

ex)  
2+3-4+5 를 입력하고 AC를 누르면 모든 수식이 초기화되고 0의 상태가 됩니다  
2+3-4+5= 을 입력하고 AC를 누르면 모든 수식이 초기화되고 0의 상태가 됩니다

![](https://i.imgur.com/1K5mVvj.gif)

### CE는 현재 입력하던 숫자 혹은 연산결과만 삭제합니다
`ceButtonDidTapped(_ sender: Any)` 함수가 호출되며, 현재 입력되어있는 피 연산자만 초기화 합니다

ex)  
2+3-4+5를 입력하고 CE를 누르면 2+3-4+의 상태가 됩니다  
2+3-4+ 를 입력하고 CE를 누르면 2+3-4+의 상태가 됩니다  
2+3-4+5= 을 입력하고 CE를 누르면 0의 상태가 됩니다  

![](https://i.imgur.com/U0hLL2z.gif)

### ⁺⁄₋ 버튼은 현재 입력한 숫자의 부호를 변환합니다. 입력된 숫자가 0인경우 부호를 표시하지 않고 변경하지도 않습니다
`signButtonDidTapped(_ sender: Any)` 함수가 호출되며 0일때는 아무동작을 하지 않고, 음수를 양수로, 양수를 음수로 바꿔줍니다

![](https://i.imgur.com/XLpdrG3.gif)


### 숫자입력 중에 연산자(÷, ×, -, +)를 누르게 되면 숫자입력을 중지하고 다음 숫자를 입력받습니다

`operatorButtonDidTapped(_ sender: UIButton?)` 함수가 호출됩니다

- 현재 숫자입력이 없는 상태인 0에서는 연산자를 반복해서 누르더라도 연산이 이뤄지지 않습니다
- 현재 숫자입력이 없는 상태인 0에서는 연산자의 종류만 변경합니다

![](https://i.imgur.com/YYtqHsj.gif)

### = 버튼을 누르면 입력된 연산을 한 번에 수행합니다
`calculateButtonDidTapped(_ sender: Any)` 함수가 호출됩니다

- = 버튼을 누르기 전에는 실제 연산을 수행하지 않습니다
- 연산은 연산자 우선순위를 무시하고 앞에서부터 순서대로 계산합니다

ex)  
2+3*3-1 의 연산결과는 14입니다  
3/3+2-1 의 연산결과는 2입니다  
1+2-3*2-3/6 의 연산결과는 -0.5입니다  
= 버튼을 눌러 연산을 마친 후 다시 =을 눌러도 이전 연산을 다시 연산하지 않습니다

![](https://i.imgur.com/FxpclLo.gif)


### 사용자에게 표시하는 숫자는 뒤에 0000 등 불필요한 숫자가 나타나지 않도록 합니다

NumberFormatter를 이용하여 해결했습니다

예) 0.123000000 → 0.123 / 1.22340000 → 1.2234  
- 숫자는 최대 20자리까지만 표현합니다
- 잘리는 숫자는 반올림합니다
- 숫자는 3자리마다 쉼표(,)를 표기해줍니다


![](https://i.imgur.com/bkxPZ1t.gif) ![](https://i.imgur.com/7YkYFLH.gif)

### 0으로 나누기에 대해서는 결과값을 NaN으로 표기합니다

나누기 때문에 error가 나는경우 NaN으로 표시하였습니다

![](https://i.imgur.com/a3tRRLE.gif)

### 계산내역이 상단 공간을 넘어 이어지는 경우, 사용자에게 제대로 보일 수 있도록 새로 추가될 때 최하단으로 자동 스크롤 할 수 있도록 합니다

ScrollView의 Extension으로 scroll 함수를 구현하여 해결하였습니다

![](https://i.imgur.com/mPMDkAg.gif)

## 추가구현 사항

요구사항에 명확하게 나와있지 않은건 적당히 처리했습니다

### 숫자는 20자리가 넘어간다면?

계산 결과의 정수부분이 20자리가 넘어가면 범위초과로 판단하여 NaN을 출력하였습니다

### 궁금한점

#### if문의 가독성

1번
```swift
if numberLabel.text == "NaN" {
    return
}

if currentNumber.contains(".") {
    return
}

if isCalculateValue {
    return
}

if String(currentNumber).count >= 20 {
    return
}

```

2번
```swift
if numberLabel.text == "NaN" ||
   currentNumber.contains(".") || 
   isCalculateValue ||
   String(currentNumber).count >= 20 {
    return
}
```

1번이 더 명확하다고 생각해서 1번으로 작성하였는데, 너무 난잡한것 같습니다.  
2번으로 바꿔도 가독성에 큰 문제가 없을까요?

#### Storyboard에서 ScrollView의 제약

런타임에 stackView가 ScrollView에 들어가는 형태다보니, storyboard에서는 ScrollView제약에 Missing Constraint 에러가 뜹니다  
해결를 해야하는걸까요, 상관없는걸까요?  
해결을 해야한다면 어떤식으로 할 수 있을지 궁금합니다..!

<img width="241" alt="스크린샷 2022-03-23 오전 11 13 15" src="https://user-images.githubusercontent.com/69573768/159610251-0f6088c4-47b8-49db-a4dd-685c2152686b.png">