### PR TITLE
계산기 I [STEP 3] Lingo

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B02EA7A127EAD259002B559A /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02EA7A027EAD259002B559A /* Observable.swift */; };
+		B02EA7A327EAD308002B559A /* CalculatorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02EA7A227EAD308002B559A /* CalculatorViewModel.swift */; };
+		B02EA7A527EADAD0002B559A /* UIStackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02EA7A427EADAD0002B559A /* UIStackView+Extension.swift */; };
 		B04E97BE27E8CA2E001442DF /* FormulaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04E97BD27E8CA2E001442DF /* FormulaError.swift */; };
 		B0A47D8227E37337003CD7E5 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A47D8127E37337003CD7E5 /* OperatorTests.swift */; };
 		B0A47D8427E376AF003CD7E5 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A47D8327E376AF003CD7E5 /* Operator.swift */; };
@@ -41,6 +44,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B02EA7A027EAD259002B559A /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		B02EA7A227EAD308002B559A /* CalculatorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorViewModel.swift; sourceTree = "<group>"; };
+		B02EA7A427EADAD0002B559A /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
 		B04E97BD27E8CA2E001442DF /* FormulaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaError.swift; sourceTree = "<group>"; };
 		B0A47D8127E37337003CD7E5 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		B0A47D8327E376AF003CD7E5 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
@@ -124,6 +130,7 @@
 			children = (
 				B0E177AD27DF90DB00620996 /* Double+Extension.swift */,
 				B0A47D8D27E38F9C003CD7E5 /* String+Extension.swift */,
+				B02EA7A427EADAD0002B559A /* UIStackView+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -152,6 +159,7 @@
 		B0EE794127DF309A0075DE95 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				B02EA7A227EAD308002B559A /* CalculatorViewModel.swift */,
 				C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */,
 			);
 			path = Presentation;
@@ -174,6 +182,7 @@
 			children = (
 				B04E97BC27E8CA02001442DF /* Error */,
 				B0E177AC27DF90B000620996 /* Extension */,
+				B02EA7A027EAD259002B559A /* Observable.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -335,13 +344,16 @@
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				B0E177AE27DF90DB00620996 /* Double+Extension.swift in Sources */,
 				B04E97BE27E8CA2E001442DF /* FormulaError.swift in Sources */,
+				B02EA7A327EAD308002B559A /* CalculatorViewModel.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				B0A47D8E27E38F9C003CD7E5 /* String+Extension.swift in Sources */,
 				B0E177B027DF99E200620996 /* CalculatorLinkedList.swift in Sources */,
 				B0E177A227DF5C0000620996 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				B0A47D8427E376AF003CD7E5 /* Operator.swift in Sources */,
+				B02EA7A127EAD259002B559A /* Observable.swift in Sources */,
 				B0A47D8827E382FE003CD7E5 /* Formula.swift in Sources */,
+				B02EA7A527EADAD0002B559A /* UIStackView+Extension.swift in Sources */,
 				B0A47D8C27E38B25003CD7E5 /* ExpressionParser.swift in Sources */,
 				B0E177B327DF9F5E00620996 /* CalculatorNode.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		B02EA7A127EAD259002B559A /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02EA7A027EAD259002B559A /* Observable.swift */; };
 		B02EA7A327EAD308002B559A /* CalculatorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02EA7A227EAD308002B559A /* CalculatorViewModel.swift */; };
 		B02EA7A527EADAD0002B559A /* UIStackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02EA7A427EADAD0002B559A /* UIStackView+Extension.swift */; };
+		B02EA7A727EB947E002B559A /* CalculatorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02EA7A627EB947E002B559A /* CalculatorViewModelTests.swift */; };
 		B04E97BE27E8CA2E001442DF /* FormulaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04E97BD27E8CA2E001442DF /* FormulaError.swift */; };
 		B0A47D8227E37337003CD7E5 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A47D8127E37337003CD7E5 /* OperatorTests.swift */; };
 		B0A47D8427E376AF003CD7E5 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A47D8327E376AF003CD7E5 /* Operator.swift */; };
@@ -47,6 +48,7 @@
 		B02EA7A027EAD259002B559A /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		B02EA7A227EAD308002B559A /* CalculatorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorViewModel.swift; sourceTree = "<group>"; };
 		B02EA7A427EADAD0002B559A /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
+		B02EA7A627EB947E002B559A /* CalculatorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorViewModelTests.swift; sourceTree = "<group>"; };
 		B04E97BD27E8CA2E001442DF /* FormulaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaError.swift; sourceTree = "<group>"; };
 		B0A47D8127E37337003CD7E5 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		B0A47D8327E376AF003CD7E5 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 			children = (
 				B0EE793927DF30730075DE95 /* CalculatorLinkedListTests.swift */,
 				B0EE794527DF582D0075DE95 /* CalculatorItemQueueTests.swift */,
+				B02EA7A627EB947E002B559A /* CalculatorViewModelTests.swift */,
 				B0A47D8927E38892003CD7E5 /* ExpressionParserTests.swift */,
 				B0A47D8527E3801C003CD7E5 /* FormulaTests.swift */,
 				B0A47D8127E37337003CD7E5 /* OperatorTests.swift */,
@@ -330,6 +333,7 @@
 			files = (
 				B0EE794627DF582D0075DE95 /* CalculatorItemQueueTests.swift in Sources */,
 				B0A47D8227E37337003CD7E5 /* OperatorTests.swift in Sources */,
+				B02EA7A727EB947E002B559A /* CalculatorViewModelTests.swift in Sources */,
 				B0A47D8627E3801C003CD7E5 /* FormulaTests.swift in Sources */,
 				B0A47D8A27E38892003CD7E5 /* ExpressionParserTests.swift in Sources */,
 				B0EE793A27DF30730075DE95 /* CalculatorLinkedListTests.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B04E97BE27E8CA2E001442DF /* FormulaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04E97BD27E8CA2E001442DF /* FormulaError.swift */; };
 		B0A47D8227E37337003CD7E5 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A47D8127E37337003CD7E5 /* OperatorTests.swift */; };
 		B0A47D8427E376AF003CD7E5 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A47D8327E376AF003CD7E5 /* Operator.swift */; };
 		B0A47D8627E3801C003CD7E5 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A47D8527E3801C003CD7E5 /* FormulaTests.swift */; };
@@ -40,6 +41,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B04E97BD27E8CA2E001442DF /* FormulaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaError.swift; sourceTree = "<group>"; };
 		B0A47D8127E37337003CD7E5 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		B0A47D8327E376AF003CD7E5 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		B0A47D8527E3801C003CD7E5 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
@@ -83,6 +85,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B04E97BC27E8CA02001442DF /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				B04E97BD27E8CA2E001442DF /* FormulaError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		B06FD63A27E23035007BD380 /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -162,6 +172,7 @@
 		B0EE794327DF30A50075DE95 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				B04E97BC27E8CA02001442DF /* Error */,
 				B0E177AC27DF90B000620996 /* Extension */,
 			);
 			path = Util;
@@ -323,6 +334,7 @@
 				B0E177AB27DF909F00620996 /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				B0E177AE27DF90DB00620996 /* Double+Extension.swift in Sources */,
+				B04E97BE27E8CA2E001442DF /* FormulaError.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				B0A47D8E27E38F9C003CD7E5 /* String+Extension.swift in Sources */,
 				B0E177B027DF99E200620996 /* CalculatorLinkedList.swift in Sources */,

--- a/Calculator/Calculator/Domain/CalculatorItemQueue/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Domain/CalculatorItemQueue/CalculatorItemQueue.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct CalculatorItemQueue<Element: CalculateItem> {
 
-  private(set) var list: CalculatorLinkedList<Element> = .init()
+  private(set) var list = CalculatorLinkedList<Element>()
   
   var elements: [Element] {
     return self.list.allElements()

--- a/Calculator/Calculator/Domain/Formula.swift
+++ b/Calculator/Calculator/Domain/Formula.swift
@@ -16,7 +16,7 @@ struct Formula {
     guard var total = self.operands.dequeue(),
           self.operands.count == self.operators.count
     else {
-      throw FormulaError.inCompletedFormula
+      throw FormulaError.inValidFormula
     }
     while let operand = self.operands.dequeue(), let operatorType = self.operators.dequeue() {
       total = operatorType.calculate(lhs: total, rhs: operand)

--- a/Calculator/Calculator/Domain/Formula.swift
+++ b/Calculator/Calculator/Domain/Formula.swift
@@ -9,8 +9,8 @@ import Foundation
 
 struct Formula {
   
-  var operands: CalculatorItemQueue<Double> = .init()
-  var operators: CalculatorItemQueue<Operator> = .init()
+  var operands = CalculatorItemQueue<Double>()
+  var operators = CalculatorItemQueue<Operator>()
   
   mutating func result() -> Double {
     guard var total = self.operands.dequeue(),

--- a/Calculator/Calculator/Domain/Formula.swift
+++ b/Calculator/Calculator/Domain/Formula.swift
@@ -12,11 +12,11 @@ struct Formula {
   var operands = CalculatorItemQueue<Double>()
   var operators = CalculatorItemQueue<Operator>()
   
-  mutating func result() -> Double {
+  mutating func result() throws -> Double {
     guard var total = self.operands.dequeue(),
           self.operands.count == self.operators.count
     else {
-      return .nan
+      throw FormulaError.inCompletedFormula
     }
     while let operand = self.operands.dequeue(), let operatorType = self.operators.dequeue() {
       total = operatorType.calculate(lhs: total, rhs: operand)

--- a/Calculator/Calculator/Domain/Operator.swift
+++ b/Calculator/Calculator/Domain/Operator.swift
@@ -7,7 +7,7 @@
 
 enum Operator: Character, CaseIterable, CalculateItem {
   case add = "+"
-  case subtract = "-"
+  case subtract = "−"
   case divide = "÷"
   case multiply = "×"
   

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -64,6 +64,7 @@ private extension CalculatorViewController {
     self.operandLabel.text = Double.zero.formatString()
     self.resultStackView.arrangedSubviews.forEach {
       self.resultStackView.removeArrangedSubview($0)
+      $0.removeFromSuperview()
     }
   }
   

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -38,10 +38,8 @@ final class CalculatorViewController: UIViewController {
   }
   
   @IBAction private func didTapCalculateButton(_ sender: UIButton) {
-    let operand = self.operandLabel.text
-    let operatorType = self.operatorLabel.text
+    let stackView = self.viewModel.makeSubResultStackView()
     if self.viewModel.didTapCalculateButton() {
-      let stackView = UIStackView.create(type: operatorType, operand: operand)
       self.resultStackView.addArrangedSubview(stackView)
     }
   }
@@ -50,10 +48,8 @@ final class CalculatorViewController: UIViewController {
     guard let operatorString = sender.titleLabel?.text else {
       return
     }
-    let operand = self.operandLabel.text
-    let operatorType = self.operatorLabel.text
+    let stackView = self.viewModel.makeSubResultStackView()
     if self.viewModel.didTapOperatorButton(of: operatorString) {
-      let stackView = UIStackView.create(type: operatorType, operand: operand)
       self.resultStackView.addArrangedSubview(stackView)
     }
   }

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -38,7 +38,7 @@ final class CalculatorViewController: UIViewController {
   }
   
   @IBAction private func didTapCalculateButton(_ sender: UIButton) {
-    guard let stackView = self.viewModel.makeSubResultStackView() else {
+    guard let stackView = self.makeSubResultStackView() else {
       return
     }
     if self.viewModel.didTapCalculateButton() {
@@ -48,7 +48,7 @@ final class CalculatorViewController: UIViewController {
   
   @IBAction private func didTapOperatorButton(_ sender: UIButton) {
     guard let operatorString = sender.titleLabel?.text,
-          let stackView = self.viewModel.makeSubResultStackView()
+          let stackView = self.makeSubResultStackView()
     else {
       return
     }
@@ -119,5 +119,14 @@ private extension CalculatorViewController {
       let contentOffset = CGPoint(x: 0, y: pointY)
       self.resultScrollView.setContentOffset(contentOffset, animated: true)
     }
+  }
+  
+  func makeSubResultStackView() -> UIStackView? {
+    guard let operand = Double(self.viewModel.operandValue.value) else {
+      return nil
+    }
+    let operatorType = self.viewModel.operatorType.value
+    let stackView = UIStackView(type: operatorType, operand: operand.formatString())
+    return stackView
   }
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -18,6 +18,7 @@ final class CalculatorViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
+    self.clearAll()
   }
   
   @IBAction private func didTapKeyOperationButton(_ sender: UIButton) {
@@ -26,7 +27,7 @@ final class CalculatorViewController: UIViewController {
     }
     switch keyOperation {
     case "AC":
-      self.clear()
+      self.clearAll()
     case "CE": break
     case "⁺⁄₋": break
     default: break
@@ -41,7 +42,7 @@ final class CalculatorViewController: UIViewController {
 
 private extension CalculatorViewController {
   
-  func clear() {
+  func clearAll() {
     self.formulas.removeAll()
     self.operatorLabel.text = nil
     self.operandLabel.text = Double.zero.formatString()

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -36,8 +36,9 @@ final class CalculatorViewController: UIViewController {
     }
   }
   
-  @IBAction private func didTapOperatorButton(_ sender: UIButton) {}
   @IBAction private func didTapNumberButton(_ sender: UIButton) {}
+  @IBAction private func didTapOperatorButton(_ sender: UIButton) {}
+  @IBAction private func didTapCalculateButton(_ sender: UIButton) {}
 }
 
 // MARK: - Private Extension

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -18,6 +18,7 @@ final class CalculatorViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
+    self.configureUI()
     self.bindUI()
     self.clearAll()
   }
@@ -56,6 +57,7 @@ final class CalculatorViewController: UIViewController {
     if self.viewModel.didTapOperatorButton(of: operatorString) {
       self.resultStackView.addArrangedSubview(stackView)
     }
+    self.scrollToDown()
   }
   
   @IBAction private func didTapNumberButton(_ sender: UIButton) {
@@ -73,6 +75,10 @@ final class CalculatorViewController: UIViewController {
 // MARK: - Private Extension
 
 private extension CalculatorViewController {
+  
+  func configureUI() {
+    self.resultScrollView.showsVerticalScrollIndicator = false
+  }
   
   func bindUI() {
     self.viewModel.operatorType.bind { [weak self] operatorType in
@@ -108,5 +114,16 @@ private extension CalculatorViewController {
 
   func convertSign() {
     self.viewModel.convertSign()
+  }
+  
+  func scrollToDown() {
+    let contentSizeHeight = self.resultScrollView.contentSize.height
+    let boundsHeight = self.resultScrollView.bounds.size.height
+    let contentInsetBottom = self.resultScrollView.contentInset.bottom
+    let pointY = contentSizeHeight - boundsHeight + contentInsetBottom
+    if pointY > 0 {
+      let contentOffset = CGPoint(x: 0, y: pointY + 24)
+      self.resultScrollView.setContentOffset(contentOffset, animated: true)
+    }
   }
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -28,7 +28,8 @@ final class CalculatorViewController: UIViewController {
     switch keyOperation {
     case "AC":
       self.clearAll()
-    case "CE": break
+    case "CE":
+      self.clearEntry()
     case "⁺⁄₋": break
     default: break
     }
@@ -49,5 +50,9 @@ private extension CalculatorViewController {
     self.resultStackView.arrangedSubviews.forEach {
       self.resultStackView.removeArrangedSubview($0)
     }
+  }
+  
+  func clearEntry() {
+    self.operandLabel.text = Double.zero.formatString()
   }
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -47,10 +47,9 @@ final class CalculatorViewController: UIViewController {
   }
   
   @IBAction private func didTapOperatorButton(_ sender: UIButton) {
-    guard let operatorString = sender.titleLabel?.text else {
-      return
-    }
-    guard let stackView = self.viewModel.makeSubResultStackView() else {
+    guard let operatorString = sender.titleLabel?.text,
+          let stackView = self.viewModel.makeSubResultStackView()
+    else {
       return
     }
     if self.viewModel.didTapOperatorButton(of: operatorString) {
@@ -85,11 +84,10 @@ private extension CalculatorViewController {
   }
   
   func changeOperandLabel(of operand: String) {
-    guard self.viewModel.isResult == true else {
+    guard self.viewModel.isResult,
+          let operand = Double(operand)
+    else {
       self.operandLabel.text = operand
-      return
-    }
-    guard let operand = Double(operand) else {
       return
     }
     self.operandLabel.text = operand.formatString()

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -36,7 +36,20 @@ final class CalculatorViewController: UIViewController {
     }
   }
   
-  @IBAction private func didTapNumberButton(_ sender: UIButton) {}
+  @IBAction private func didTapNumberButton(_ sender: UIButton) {
+    guard let number = sender.titleLabel?.text,
+          let oldNumber = self.operandLabel.text
+    else {
+      return
+    }
+    if oldNumber == "0" {
+      self.operandLabel.text = number
+    } else {
+      let newNumber = oldNumber + number
+      self.operandLabel.text = newNumber
+    }
+  }
+  
   @IBAction private func didTapOperatorButton(_ sender: UIButton) {}
   @IBAction private func didTapCalculateButton(_ sender: UIButton) {}
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -79,16 +79,20 @@ private extension CalculatorViewController {
       self?.operatorLabel.text = operatorType
     }
     self.viewModel.operandValue.bind { [weak self] operand in
-      if let isResult = self?.viewModel.isResult, isResult == true {
-        guard let operand = Double(operand) else {
-          return
-        }
-        self?.operandLabel.text = operand.formatString()
-        self?.viewModel.isResult = false
-      } else {
-        self?.operandLabel.text = operand
-      }
+      self?.changeOperandLabel(of: operand)
     }
+  }
+  
+  func changeOperandLabel(of operand: String) {
+    guard self.viewModel.isResult == true else {
+      self.operandLabel.text = operand
+      return
+    }
+    guard let operand = Double(operand) else {
+      return
+    }
+    self.operandLabel.text = operand.formatString()
+    self.viewModel.isResult = false
   }
   
   func clearAll() {

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -14,15 +14,39 @@ final class CalculatorViewController: UIViewController {
   @IBOutlet private weak var operatorLabel: UILabel!
   @IBOutlet private weak var operandLabel: UILabel!
   
+  private var formulas: [String] = []
+  
   override func viewDidLoad() {
     super.viewDidLoad()
   }
   
-  @IBAction private func didTapKeyOperationButton(_ sender: UIButton) {}
+  @IBAction private func didTapKeyOperationButton(_ sender: UIButton) {
+    guard let keyOperation = sender.titleLabel?.text else {
+      return
+    }
+    switch keyOperation {
+    case "AC":
+      self.clear()
+    case "CE": break
+    case "⁺⁄₋": break
+    default: break
+    }
+  }
+  
   @IBAction private func didTapOperatorButton(_ sender: UIButton) {}
   @IBAction private func didTapNumberButton(_ sender: UIButton) {}
 }
 
 // MARK: - Private Extension
 
-private extension CalculatorViewController {}
+private extension CalculatorViewController {
+  
+  func clear() {
+    self.formulas.removeAll()
+    self.operatorLabel.text = nil
+    self.operandLabel.text = Double.zero.formatString()
+    self.resultStackView.arrangedSubviews.forEach {
+      self.resultStackView.removeArrangedSubview($0)
+    }
+  }
+}

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -82,4 +82,27 @@ private extension CalculatorViewController {
     let result = newNumber == .zero ? .zero : newNumber
     self.operandLabel.text = result.formatString()
   }
+  
+  func makeResultSubStackView(operatorType: String?, operand: String?) -> UIStackView? {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.distribution = .fill
+    stackView.alignment = .fill
+    stackView.spacing = 8
+    
+    let operatorResultLabel = UILabel()
+    operatorResultLabel.font = .preferredFont(forTextStyle: .title3)
+    operatorResultLabel.textColor = .white
+    operatorResultLabel.text = operatorType
+    
+    let operandResultLabel = UILabel()
+    operandResultLabel.font = .preferredFont(forTextStyle: .title3)
+    operandResultLabel.textColor = .white
+    operandResultLabel.text = operand
+    
+    stackView.addArrangedSubview(operatorResultLabel)
+    stackView.addArrangedSubview(operandResultLabel)
+    
+    return stackView
+  }
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -41,7 +41,7 @@ final class CalculatorViewController: UIViewController {
     guard let stackView = self.makeSubResultStackView() else {
       return
     }
-    if self.viewModel.didTapCalculateButton() {
+    if self.viewModel.calculate() {
       self.resultStackView.addArrangedSubview(stackView)
     }
   }
@@ -52,7 +52,7 @@ final class CalculatorViewController: UIViewController {
     else {
       return
     }
-    if self.viewModel.didTapOperatorButton(of: operatorString) {
+    if self.viewModel.addOperator(of: operatorString) {
       self.resultStackView.addArrangedSubview(stackView)
       self.scrollToDown()
     }
@@ -62,11 +62,11 @@ final class CalculatorViewController: UIViewController {
     guard let numberString = sender.titleLabel?.text else {
       return
     }
-    self.viewModel.didTapNumberButton(of: numberString)
+    self.viewModel.addOperand(of: numberString)
   }
   
   @IBAction private func didTapDotButton(_ sender: UIButton) {
-    self.viewModel.didTapDotButton()
+    self.viewModel.addDot()
   }
 }
 

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -18,7 +18,6 @@ final class CalculatorViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.configureUI()
     self.bindUI()
     self.clearAll()
   }
@@ -75,10 +74,6 @@ final class CalculatorViewController: UIViewController {
 // MARK: - Private Extension
 
 private extension CalculatorViewController {
-  
-  func configureUI() {
-    self.resultScrollView.showsVerticalScrollIndicator = false
-  }
   
   func bindUI() {
     self.viewModel.operatorType.bind { [weak self] operatorType in

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -30,7 +30,8 @@ final class CalculatorViewController: UIViewController {
       self.clearAll()
     case "CE":
       self.clearEntry()
-    case "⁺⁄₋": break
+    case "⁺⁄₋":
+      self.convertSign()
     default: break
     }
   }
@@ -54,5 +55,16 @@ private extension CalculatorViewController {
   
   func clearEntry() {
     self.operandLabel.text = Double.zero.formatString()
+  }
+  
+  func convertSign() {
+    guard let operand = self.operandLabel.text,
+          let number = Double(operand)
+    else {
+      return
+    }
+    let newNumber = number * -1
+    let result = newNumber == .zero ? .zero : newNumber
+    self.operandLabel.text = result.formatString()
   }
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -38,7 +38,9 @@ final class CalculatorViewController: UIViewController {
   }
   
   @IBAction private func didTapCalculateButton(_ sender: UIButton) {
-    let stackView = self.viewModel.makeSubResultStackView()
+    guard let stackView = self.viewModel.makeSubResultStackView() else {
+      return
+    }
     if self.viewModel.didTapCalculateButton() {
       self.resultStackView.addArrangedSubview(stackView)
     }
@@ -48,7 +50,9 @@ final class CalculatorViewController: UIViewController {
     guard let operatorString = sender.titleLabel?.text else {
       return
     }
-    let stackView = self.viewModel.makeSubResultStackView()
+    guard let stackView = self.viewModel.makeSubResultStackView() else {
+      return
+    }
     if self.viewModel.didTapOperatorButton(of: operatorString) {
       self.resultStackView.addArrangedSubview(stackView)
     }

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -9,7 +9,20 @@ import UIKit
 
 final class CalculatorViewController: UIViewController {
   
+  @IBOutlet private weak var resultScrollView: UIScrollView!
+  @IBOutlet private weak var resultStackView: UIStackView!
+  @IBOutlet private weak var operatorLabel: UILabel!
+  @IBOutlet private weak var operandLabel: UILabel!
+  
   override func viewDidLoad() {
     super.viewDidLoad()
   }
+  
+  @IBAction private func didTapKeyOperationButton(_ sender: UIButton) {}
+  @IBAction private func didTapOperatorButton(_ sender: UIButton) {}
+  @IBAction private func didTapNumberButton(_ sender: UIButton) {}
 }
+
+// MARK: - Private Extension
+
+private extension CalculatorViewController {}

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -50,7 +50,33 @@ final class CalculatorViewController: UIViewController {
     }
   }
   
-  @IBAction private func didTapOperatorButton(_ sender: UIButton) {}
+  @IBAction private func didTapOperatorButton(_ sender: UIButton) {
+    guard let newOperatorType = sender.titleLabel?.text else {
+      return
+    }
+    guard let number = self.operandLabel.text,
+          Double(number) != 0
+    else {
+      self.operatorLabel.text = newOperatorType
+      return
+    }
+    
+    let stackView = self.makeResultSubStackView(
+      operatorType: self.operatorLabel.text,
+      operand: number
+    )
+    if let stackView = stackView {
+      self.resultStackView.addArrangedSubview(stackView)
+    }
+    
+    if let operatorType = self.operatorLabel.text {
+      self.formulas.append(operatorType)
+    }
+    self.formulas.append(number)
+    self.operatorLabel.text = newOperatorType
+    self.operandLabel.text = "\(Int.zero)"
+  }
+  
   @IBAction private func didTapCalculateButton(_ sender: UIButton) {}
 }
 

--- a/Calculator/Calculator/Presentation/CalculatorViewController.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewController.swift
@@ -56,8 +56,8 @@ final class CalculatorViewController: UIViewController {
     }
     if self.viewModel.didTapOperatorButton(of: operatorString) {
       self.resultStackView.addArrangedSubview(stackView)
+      self.scrollToDown()
     }
-    self.scrollToDown()
   }
   
   @IBAction private func didTapNumberButton(_ sender: UIButton) {
@@ -117,12 +117,13 @@ private extension CalculatorViewController {
   }
   
   func scrollToDown() {
+    self.resultScrollView.layoutIfNeeded()
     let contentSizeHeight = self.resultScrollView.contentSize.height
     let boundsHeight = self.resultScrollView.bounds.size.height
     let contentInsetBottom = self.resultScrollView.contentInset.bottom
     let pointY = contentSizeHeight - boundsHeight + contentInsetBottom
     if pointY > 0 {
-      let contentOffset = CGPoint(x: 0, y: pointY + 24)
+      let contentOffset = CGPoint(x: 0, y: pointY)
       self.resultScrollView.setContentOffset(contentOffset, animated: true)
     }
   }

--- a/Calculator/Calculator/Presentation/CalculatorViewModel.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewModel.swift
@@ -77,7 +77,7 @@ final class CalculatorViewModel {
   }
   
   func didTapCalculateButton() -> Bool {
-    if self.operandValue.value == "0" {
+    if self.operandValue.value == "0" && self.operatorType.value == nil {
       return false
     }
     

--- a/Calculator/Calculator/Presentation/CalculatorViewModel.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewModel.swift
@@ -100,4 +100,11 @@ final class CalculatorViewModel {
     self.formulas.removeAll()
     return true
   }
+  
+  func makeSubResultStackView() -> UIStackView {
+    let operand = self.operandValue.value
+    let operatorType = self.operatorType.value
+    let stackView = UIStackView.create(type: operatorType, operand: operand)
+    return stackView
+  }
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewModel.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewModel.swift
@@ -101,13 +101,4 @@ final class CalculatorViewModel {
     self.formulas.removeAll()
     return true
   }
-  
-  func makeSubResultStackView() -> UIStackView? {
-    guard let operand = Double(self.operandValue.value) else {
-      return nil
-    }
-    let operatorType = self.operatorType.value
-    let stackView = UIStackView(type: operatorType, operand: operand.formatString())
-    return stackView
-  }
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewModel.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewModel.swift
@@ -29,7 +29,7 @@ final class CalculatorViewModel {
   
   func convertSign() {
     var value = self.operandValue.value
-    if value.contains("-") {
+    if value.hasPrefix("-") {
       value.removeFirst()
     } else if let number = Double(value), number > 0 {
       value = "-\(value)"
@@ -37,7 +37,7 @@ final class CalculatorViewModel {
     self.operandValue.next(value)
   }
   
-  func didTapNumberButton(of numberString: String) {
+  func addOperand(of numberString: String) {
     guard self.operandValue.value.count <= 19 else {
       return
     }
@@ -52,7 +52,7 @@ final class CalculatorViewModel {
     self.operandValue.next(value)
   }
   
-  func didTapDotButton() {
+  func addDot() {
     guard self.isDotted == false else {
       return
     }
@@ -60,7 +60,7 @@ final class CalculatorViewModel {
     self.operandValue.next(value)
   }
   
-  func didTapOperatorButton(of operatorString: String) -> Bool {
+  func addOperator(of operatorString: String) -> Bool {
     if self.operandValue.value == "0" && self.operatorType.value == nil {
       return false
     }
@@ -77,7 +77,7 @@ final class CalculatorViewModel {
     return true
   }
   
-  func didTapCalculateButton() -> Bool {
+  func calculate() -> Bool {
     if self.operandValue.value == "0" && self.operatorType.value == nil {
       return false
     }

--- a/Calculator/Calculator/Presentation/CalculatorViewModel.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewModel.swift
@@ -107,7 +107,7 @@ final class CalculatorViewModel {
       return nil
     }
     let operatorType = self.operatorType.value
-    let stackView = UIStackView.create(type: operatorType, operand: operand.formatString())
+    let stackView = UIStackView(type: operatorType, operand: operand.formatString())
     return stackView
   }
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewModel.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewModel.swift
@@ -1,0 +1,103 @@
+//
+//  CalculatorViewModel.swift
+//  Calculator
+//
+//  Created by Lingo on 2022/03/23.
+//
+
+import UIKit
+
+final class CalculatorViewModel {
+  
+  private(set) var operatorType = Observable<String?>(nil)
+  private(set) var operandValue = Observable<String>("0")
+  private var formulas = [String]()
+  private var isDotted: Bool {
+    self.operandValue.value.contains(".")
+  }
+  var isResult: Bool = false
+  
+  func clearAll() {
+    self.formulas.removeAll()
+    self.operatorType.next(nil)
+    self.operandValue.next("0")
+  }
+  
+  func clearEntry() {
+    self.operandValue.next("0")
+  }
+  
+  func convertSign() {
+    var value = self.operandValue.value
+    if value.contains("-") {
+      value.removeFirst()
+    } else if let number = Double(value), number > 0 {
+      value = "-\(number)"
+    }
+    self.operandValue.next(value)
+  }
+  
+  func didTapNumberButton(of numberString: String) {
+    guard self.operandValue.value.count <= 19 else {
+      return
+    }
+    var newValue: String
+    let oldValue = self.operandValue.value
+    if oldValue == "0" {
+      newValue = numberString
+    } else {
+      newValue = oldValue + numberString
+    }
+    self.operandValue.next(newValue)
+  }
+  
+  func didTapDotButton() {
+    guard self.isDotted == false else {
+      return
+    }
+    let newValue = self.operandValue.value + "."
+    self.operandValue.next(newValue)
+  }
+  
+  func didTapOperatorButton(of operatorString: String) -> Bool {
+    if self.operandValue.value == "0" && self.operatorType.value == nil {
+      return false
+    }
+    if self.operandValue.value == "0" && self.operatorType.value != nil {
+      self.operatorType.next(operatorString)
+      return false
+    }
+    if let operatorType = self.operatorType.value {
+      self.formulas.append(operatorType)
+    }
+    self.formulas.append(self.operandValue.value)
+    self.operatorType.next(operatorString)
+    self.operandValue.next("0")
+    return true
+  }
+  
+  func didTapCalculateButton() -> Bool {
+    if self.operandValue.value == "0" {
+      return false
+    }
+    
+    if self.formulas.count == Int.zero {
+      return false
+    }
+    
+    if let operatorType = self.operatorType.value {
+      self.formulas.append(operatorType)
+    }
+    self.formulas.append(self.operandValue.value)
+    let inputString = self.formulas.joined(separator: " ")
+    var formula = ExpressionParser.parse(from: inputString)
+    guard let result = try? formula.result() else {
+      return false
+    }
+    self.isResult = true
+    self.operatorType.next(nil)
+    self.operandValue.next("\(result)")
+    self.formulas.removeAll()
+    return true
+  }
+}

--- a/Calculator/Calculator/Presentation/CalculatorViewModel.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewModel.swift
@@ -41,22 +41,17 @@ final class CalculatorViewModel {
     guard self.operandValue.value.count <= 19 else {
       return
     }
-    var newValue: String
-    let oldValue = self.operandValue.value
-    if oldValue == "0" {
-      newValue = numberString
-    } else {
-      newValue = oldValue + numberString
-    }
-    self.operandValue.next(newValue)
+    var value = self.operandValue.value
+    value = (value == "0" ? numberString : value + numberString)
+    self.operandValue.next(value)
   }
   
   func didTapDotButton() {
     guard self.isDotted == false else {
       return
     }
-    let newValue = self.operandValue.value + "."
-    self.operandValue.next(newValue)
+    let value = self.operandValue.value + "."
+    self.operandValue.next(value)
   }
   
   func didTapOperatorButton(of operatorString: String) -> Bool {
@@ -81,7 +76,7 @@ final class CalculatorViewModel {
       return false
     }
     
-    if self.formulas.count == Int.zero {
+    if self.formulas.isEmpty {
       return false
     }
     

--- a/Calculator/Calculator/Presentation/CalculatorViewModel.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewModel.swift
@@ -101,10 +101,12 @@ final class CalculatorViewModel {
     return true
   }
   
-  func makeSubResultStackView() -> UIStackView {
-    let operand = self.operandValue.value
+  func makeSubResultStackView() -> UIStackView? {
+    guard let operand = Double(self.operandValue.value) else {
+      return nil
+    }
     let operatorType = self.operatorType.value
-    let stackView = UIStackView.create(type: operatorType, operand: operand)
+    let stackView = UIStackView.create(type: operatorType, operand: operand.formatString())
     return stackView
   }
 }

--- a/Calculator/Calculator/Presentation/CalculatorViewModel.swift
+++ b/Calculator/Calculator/Presentation/CalculatorViewModel.swift
@@ -32,7 +32,7 @@ final class CalculatorViewModel {
     if value.contains("-") {
       value.removeFirst()
     } else if let number = Double(value), number > 0 {
-      value = "-\(number)"
+      value = "-\(value)"
     }
     self.operandValue.next(value)
   }
@@ -42,7 +42,13 @@ final class CalculatorViewModel {
       return
     }
     var value = self.operandValue.value
-    value = (value == "0" ? numberString : value + numberString)
+    if value == "0" && numberString == "00" {
+      value = "0"
+    } else if value == "0" && numberString != "00" {
+      value = numberString
+    } else {
+      value += numberString
+    }
     self.operandValue.next(value)
   }
   

--- a/Calculator/Calculator/Resource/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Resource/Base.lproj/Main.storyboard
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -12,26 +14,26 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="CalculatorViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="181" width="568" height="45"/>
+                                <rect key="frame" x="16" y="219" width="358" height="44.666666666666686"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="568" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="358" height="44.666666666666664"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="453" y="0.0" width="115" height="20.5"/>
+                                                <rect key="frame" x="243.66666666666671" y="0.0" width="114.33333333333334" height="20.333333333333332"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="7.666666666666667" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
+                                                        <rect key="frame" x="15.666666666666636" y="0.0" width="98.666666666666686" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -39,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="453" y="24.5" width="115" height="20.5"/>
+                                                <rect key="frame" x="243.66666666666671" y="24.333333333333343" width="114.33333333333334" height="20.333333333333329"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="7.666666666666667" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
+                                                        <rect key="frame" x="15.666666666666636" y="0.0" width="98.666666666666686" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -71,185 +73,242 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="gA2-7M-FxF"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YKH-82-hZC">
-                                <rect key="frame" x="16" y="303" width="568" height="277"/>
+                                <rect key="frame" x="16" y="340.66666666666674" width="358" height="449.33333333333326"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="AP2-25-h5E">
-                                        <rect key="frame" x="0.0" y="0.0" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="358" height="83.333333333333329"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ped-N8-JbY">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="83.666666666666671" height="83.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapKeyOperationButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="r5h-ew-TXf"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="91.666666666666686" y="0.0" width="83.333333333333314" height="83.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapKeyOperationButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VRX-gt-zab"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="183" y="0.0" width="83.666666666666686" height="83.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapKeyOperationButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UMM-aF-cQb"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="274.66666666666669" y="0.0" width="83.333333333333314" height="83.333333333333329"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="y0Q-MK-tTU"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="35B-Om-mGh">
-                                        <rect key="frame" x="0.0" y="57" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="91.333333333333314" width="358" height="83.666666666666686"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L6z-2G-Gar">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="83.666666666666671" height="83.666666666666671"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WZz-mo-kQ5"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="91.666666666666686" y="0.0" width="83.333333333333314" height="83.666666666666671"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uBt-Dw-ZpD"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="183" y="0.0" width="83.666666666666686" height="83.666666666666671"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UeF-a4-f6e"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="274.66666666666669" y="0.0" width="83.333333333333314" height="83.666666666666671"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kIJ-uN-32m"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="e7N-N0-vb2">
-                                        <rect key="frame" x="0.0" y="114" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="182.99999999999994" width="358" height="83.333333333333314"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-yz-XvG">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="83.666666666666671" height="83.333333333333329"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xey-tk-ro3"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="91.666666666666686" y="0.0" width="83.333333333333314" height="83.333333333333329"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RnK-l5-Gf3"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="183" y="0.0" width="83.666666666666686" height="83.333333333333329"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="q4m-BP-LmE"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="274.66666666666669" y="0.0" width="83.333333333333314" height="83.333333333333329"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="TmL-YU-jrA"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="NpY-aR-Nd4">
-                                        <rect key="frame" x="0.0" y="171" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="274.33333333333331" width="358" height="83.666666666666686"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nCE-qB-NiN">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="83.666666666666671" height="83.666666666666671"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MmF-K9-Gyw"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="91.666666666666686" y="0.0" width="83.333333333333314" height="83.666666666666671"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wlF-XJ-pw1"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="183" y="0.0" width="83.666666666666686" height="83.666666666666671"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kKw-LA-zDd"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="274.66666666666669" y="0.0" width="83.333333333333314" height="83.666666666666671"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aZg-eg-Reg"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="R7j-41-DOy">
-                                        <rect key="frame" x="0.0" y="228" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="365.99999999999994" width="358" height="83.333333333333314"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mSz-Y3-r5Z">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="83.666666666666671" height="83.333333333333329"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="apz-uQ-Vdr"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="91.666666666666686" y="0.0" width="83.333333333333314" height="83.333333333333329"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zQP-Tv-1ba"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="183" y="0.0" width="83.666666666666686" height="83.333333333333329"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rzi-Dx-sR5"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="274.66666666666669" y="0.0" width="83.333333333333314" height="83.333333333333329"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Daw-iX-Owl" secondAttribute="height" multiplier="1:1" id="t9i-OQ-WFF"/>
@@ -258,25 +317,28 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AMa-Un-fbS"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="246" width="568" height="37"/>
+                                <rect key="frame" x="16" y="283.66666666666669" width="358" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="568" height="37"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="358" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="19.333333333333332" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="27.5" y="0.0" width="540.5" height="37"/>
+                                                <rect key="frame" x="27.333333333333343" y="0.0" width="330.66666666666663" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -301,6 +363,12 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="c1c-Kg-YXA"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="dxY-1N-FxS"/>
+                        <outlet property="resultScrollView" destination="BOT-7g-vxv" id="qL1-Of-Nwi"/>
+                        <outlet property="resultStackView" destination="XRe-QE-UJf" id="VpN-C4-w8e"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/Resource/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Resource/Base.lproj/Main.storyboard
@@ -304,7 +304,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="didTapNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rzi-Dx-sR5"/>
+                                                    <action selector="didTapDotButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rtB-qq-9yA"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
@@ -318,7 +318,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="didTapCalculateButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vlq-xx-rJ8"/>
+                                                    <action selector="didTapCalculateButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Nln-3A-RqV"/>
                                                 </connections>
                                             </button>
                                         </subviews>

--- a/Calculator/Calculator/Resource/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Resource/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -71,6 +71,9 @@
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="K6N-nC-kaV"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="gA2-7M-FxF"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showsVerticalScrollIndicator" value="NO"/>
+                                </userDefinedRuntimeAttributes>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YKH-82-hZC">
                                 <rect key="frame" x="16" y="340.66666666666674" width="358" height="449.33333333333326"/>

--- a/Calculator/Calculator/Resource/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Resource/Base.lproj/Main.storyboard
@@ -318,7 +318,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="didTapOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AMa-Un-fbS"/>
+                                                    <action selector="didTapCalculateButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vlq-xx-rJ8"/>
                                                 </connections>
                                             </button>
                                         </subviews>

--- a/Calculator/Calculator/Util/Error/FormulaError.swift
+++ b/Calculator/Calculator/Util/Error/FormulaError.swift
@@ -1,0 +1,12 @@
+//
+//  FormulaError.swift
+//  Calculator
+//
+//  Created by Lingo on 2022/03/21.
+//
+
+import Foundation
+
+enum FormulaError: Error {
+  case inCompletedFormula
+}

--- a/Calculator/Calculator/Util/Error/FormulaError.swift
+++ b/Calculator/Calculator/Util/Error/FormulaError.swift
@@ -5,8 +5,6 @@
 //  Created by Lingo on 2022/03/21.
 //
 
-import Foundation
-
 enum FormulaError: Error {
   case inValidFormula
 }

--- a/Calculator/Calculator/Util/Error/FormulaError.swift
+++ b/Calculator/Calculator/Util/Error/FormulaError.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum FormulaError: Error {
-  case inCompletedFormula
+  case inValidFormula
 }

--- a/Calculator/Calculator/Util/Extension/Double+Extension.swift
+++ b/Calculator/Calculator/Util/Extension/Double+Extension.swift
@@ -5,4 +5,13 @@
 //  Created by Lingo on 2022/03/15.
 //
 
-extension Double: CalculateItem {}
+import Foundation
+
+extension Double: CalculateItem {
+  
+  func formatString() -> String? {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    return formatter.string(for: self)
+  }
+}

--- a/Calculator/Calculator/Util/Extension/Double+Extension.swift
+++ b/Calculator/Calculator/Util/Extension/Double+Extension.swift
@@ -12,6 +12,8 @@ extension Double: CalculateItem {
   func formatString() -> String? {
     let formatter = NumberFormatter()
     formatter.numberStyle = .decimal
+    formatter.maximumFractionDigits = 20
+    formatter.roundingMode = .halfUp
     return formatter.string(for: self)
   }
 }

--- a/Calculator/Calculator/Util/Extension/UIStackView+Extension.swift
+++ b/Calculator/Calculator/Util/Extension/UIStackView+Extension.swift
@@ -9,12 +9,12 @@ import UIKit
 
 extension UIStackView {
   
-  static func create(type: String?, operand: String?) -> UIStackView {
-    let stackView = UIStackView()
-    stackView.axis = .horizontal
-    stackView.distribution = .fill
-    stackView.alignment = .fill
-    stackView.spacing = 8
+  convenience init(frame: CGRect = .zero, type: String?, operand: String?) {
+    self.init(frame: frame)
+    self.distribution = .fill
+    self.alignment = .fill
+    self.axis = .horizontal
+    self.spacing = 8
     
     let operatorLabel = UILabel()
     operatorLabel.font = .preferredFont(forTextStyle: .title3)
@@ -26,8 +26,7 @@ extension UIStackView {
     operandLabel.textColor = .white
     operandLabel.text = operand
     
-    stackView.addArrangedSubview(operatorLabel)
-    stackView.addArrangedSubview(operandLabel)
-    return stackView
+    self.addArrangedSubview(operatorLabel)
+    self.addArrangedSubview(operandLabel)
   }
 }

--- a/Calculator/Calculator/Util/Extension/UIStackView+Extension.swift
+++ b/Calculator/Calculator/Util/Extension/UIStackView+Extension.swift
@@ -1,0 +1,33 @@
+//
+//  UIStackView+Extension.swift
+//  Calculator
+//
+//  Created by Lingo on 2022/03/23.
+//
+
+import UIKit
+
+extension UIStackView {
+  
+  static func create(type: String?, operand: String?) -> UIStackView {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.distribution = .fill
+    stackView.alignment = .fill
+    stackView.spacing = 8
+    
+    let operatorLabel = UILabel()
+    operatorLabel.font = .preferredFont(forTextStyle: .title3)
+    operatorLabel.textColor = .white
+    operatorLabel.text = type
+    
+    let operandLabel = UILabel()
+    operandLabel.font = .preferredFont(forTextStyle: .title3)
+    operandLabel.textColor = .white
+    operandLabel.text = operand
+    
+    stackView.addArrangedSubview(operatorLabel)
+    stackView.addArrangedSubview(operandLabel)
+    return stackView
+  }
+}

--- a/Calculator/Calculator/Util/Observable.swift
+++ b/Calculator/Calculator/Util/Observable.swift
@@ -1,0 +1,30 @@
+//
+//  Observable.swift
+//  Calculator
+//
+//  Created by Lingo on 2022/03/23.
+//
+
+import Foundation
+
+final class Observable<T> {
+  private var subscriber: ((T) -> Void)?
+  private(set) var value: T {
+    didSet {
+      subscriber?(value)
+    }
+  }
+  
+  init(_ value: T) {
+    self.value = value
+  }
+  
+  func bind(_ subscriber: @escaping (T) -> Void) {
+    subscriber(self.value)
+    self.subscriber = subscriber
+  }
+  
+  func next(_ value: T) {
+    self.value = value
+  }
+}

--- a/Calculator/CalculatorTests/CalculatorViewModelTests.swift
+++ b/Calculator/CalculatorTests/CalculatorViewModelTests.swift
@@ -102,7 +102,7 @@ final class CalculatorViewModelTests: XCTestCase {
     // given
     self.sut?.operandValue.next("1")
     // when
-    self.sut?.didTapDotButton()
+    self.sut?.addDot()
     let output = self.sut?.operandValue.value
     // then
     XCTAssertEqual(output, "1.")

--- a/Calculator/CalculatorTests/CalculatorViewModelTests.swift
+++ b/Calculator/CalculatorTests/CalculatorViewModelTests.swift
@@ -1,0 +1,110 @@
+//
+//  CalculatorViewModelTests.swift
+//  CalculatorTests
+//
+//  Created by Lingo on 2022/03/24.
+//
+
+import XCTest
+@testable import Calculator
+
+final class CalculatorViewModelTests: XCTestCase {
+  
+  private var sut: CalculatorViewModel?
+  
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    self.sut = CalculatorViewModel()
+  }
+  
+  override func tearDownWithError() throws {
+    try super.tearDownWithError()
+    self.sut = nil
+  }
+  
+  func testClearAll_WhenCalled_OperatorTypeShouldReturnNil() {
+    // given
+    self.sut?.operandValue.next("1")
+    self.sut?.operatorType.next("+")
+    self.sut?.operatorType.next("1")
+    // when
+    self.sut?.clearAll()
+    // then
+    XCTAssertNil(self.sut?.operatorType.value)
+  }
+  
+  func testClearAll_WhenCalled_OperandValueShouldReturnZero() {
+    // given
+    self.sut?.operandValue.next("1")
+    self.sut?.operatorType.next("+")
+    self.sut?.operatorType.next("1")
+    // when
+    self.sut?.clearAll()
+    let output = self.sut?.operandValue.value
+    // then
+    XCTAssertEqual(output, "0")
+  }
+  
+  func testClearEntry_WhenCalled_OperatorTypeShouldNotReturnNil() {
+    // given
+    self.sut?.operandValue.next("1")
+    self.sut?.operatorType.next("+")
+    self.sut?.operatorType.next("1")
+    // when
+    self.sut?.clearEntry()
+    // then
+    XCTAssertNotNil(self.sut?.operatorType.value)
+  }
+  
+  func testClearEntry_WhenCalled_OperandValueShouldReturnZero() {
+    // given
+    self.sut?.operandValue.next("1")
+    self.sut?.operatorType.next("+")
+    self.sut?.operatorType.next("1")
+    // when
+    self.sut?.clearEntry()
+    let output = self.sut?.operandValue.value
+    // then
+    XCTAssertEqual(output, "0")
+  }
+  
+  func testConvertSign_WhenCalled_OperandValueShouldReturnWithMinus() {
+    // given
+    self.sut?.operandValue.next("1234.0")
+    // when
+    self.sut?.convertSign()
+    let output = self.sut?.operandValue.value
+    // then
+    XCTAssertEqual(output, "-1234.0")
+  }
+  
+  func testConvertSign_WhenCalled_OperandValueShouldReturnZero() {
+    // given
+    self.sut?.operandValue.next("0")
+    // when
+    self.sut?.convertSign()
+    let output = self.sut?.operandValue.value
+    // then
+    XCTAssertEqual(output, "0")
+  }
+  
+  func testConvertSign_WhenDoubleZeroProvided_OperandValueShouldReturnDoubleZero() {
+    // given
+    self.sut?.operandValue.next("00")
+    // when
+    self.sut?.convertSign()
+    let output = self.sut?.operandValue.value
+    // then
+    XCTAssertEqual(output, "00")
+  }
+  
+  func testDidTapDotButton_WhenCalled_OperandValueShouldReturnWithDot() {
+    // given
+    self.sut?.operandValue.next("1")
+    // when
+    self.sut?.didTapDotButton()
+    let output = self.sut?.operandValue.value
+    // then
+    XCTAssertEqual(output, "1.")
+  }
+}

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -52,7 +52,7 @@ final class ExpressionParserTests: XCTestCase {
   
   func test_parse_미완성된_사용자_입력후_호출시_formula의_result는_Error를_던져야한다() {
     // given
-    let input = "1 + 2 - "
+    let input = "1 + 2 − "
     // when
     var formula = ExpressionParser.parse(from: input)
     // then

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -10,13 +10,6 @@ import XCTest
 
 final class ExpressionParserTests: XCTestCase {
   
-  func test_parse를_호출시_Formula타입을_반환해야한다() {
-    // given when
-    let output = ExpressionParser.parse(from: "")
-    // then
-    XCTAssertTrue(type(of: output) == Formula.self)
-  }
-  
   func test_parse_주어진_입력후_호출시_formula_operands_elements는_1_2_음수1의_배열을_반환해야한다() {
     // given
     let input = "1 + 2 × -1"

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -35,7 +35,7 @@ final class ExpressionParserTests: XCTestCase {
     let input = "1 + 2 × -1"
     // when
     var formula = ExpressionParser.parse(from: input)
-    let output = formula.result()
+    let output = try! formula.result()
     // then
     XCTAssertEqual(output, -3.0)
   }
@@ -45,18 +45,17 @@ final class ExpressionParserTests: XCTestCase {
     let input = "1 + 2 ÷ 0"
     // when
     var formula = ExpressionParser.parse(from: input)
-    let output = formula.result()
+    let output = try! formula.result()
     // then
     XCTAssertTrue(output.isNaN)
   }
   
-  func test_parse_미완성된_사용자_입력후_호출시_formula의_result는_NaN을_반환해야한다() {
+  func test_parse_미완성된_사용자_입력후_호출시_formula의_result는_Error를_던져야한다() {
     // given
     let input = "1 + 2 - "
     // when
     var formula = ExpressionParser.parse(from: input)
-    let output = formula.result()
     // then
-    XCTAssertTrue(output.isNaN)
+    XCTAssertThrowsError(try formula.result())
   }
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -28,7 +28,7 @@ final class FormulaTests: XCTestCase {
     self.sut.operands.enqueue(2.0)
     self.sut.operators.enqueue(Operator.add)
     // when
-    let output = self.sut.result()
+    let output = try! self.sut.result()
     // then
     XCTAssertEqual(output, 3.0)
   }
@@ -39,7 +39,7 @@ final class FormulaTests: XCTestCase {
     self.sut.operands.enqueue(10.0)
     self.sut.operators.enqueue(Operator.subtract)
     // when
-    let output = self.sut.result()
+    let output = try! self.sut.result()
     // then
     XCTAssertNotEqual(output, .zero)
   }
@@ -50,7 +50,7 @@ final class FormulaTests: XCTestCase {
     self.sut.operands.enqueue(5.0)
     self.sut.operators.enqueue(Operator.multiply)
     // when
-    let output = self.sut.result()
+    let output = try! self.sut.result()
     // then
     XCTAssertEqual(output, 10.0)
   }
@@ -63,7 +63,7 @@ final class FormulaTests: XCTestCase {
     self.sut.operators.enqueue(Operator.divide)
     self.sut.operators.enqueue(Operator.add)
     // when
-    let output = self.sut.result()
+    let output = try! self.sut.result()
     // then
     XCTAssertTrue(output.isNaN)
   }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 ### STEP 2 UML
 <img width="800" alt="6189d7537c82755a83c68a7d" src="https://user-images.githubusercontent.com/94151993/158860793-b0c46671-50be-4dc7-ad6b-534f1a9917fc.jpeg">
 
+### STEP 3 UML (통합)
+![계산기I UML](https://user-images.githubusercontent.com/94151993/159829422-d2133937-ddc6-4f8e-a369-bb57784f78b3.png)
+
 ---
 
 ## [STEP 1]
@@ -170,7 +173,118 @@ static func parse(from input: String) -> Formula {
 ## [STEP 3]
 ### 고민 및 해결한 점
 
-`TBD`
+### 기능 구현
+### AC 버튼
+|2+3-4+5 입력 후 AC 클릭|2+3-4+5= 입력 후 AC 클릭|
+|:---:|:---:|
+|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159833554-4f082b7d-e2c4-487a-bead-635428c44b27.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159833811-ccba6ed6-2084-4dfb-a7f8-3f0141447d1b.gif">|
+
+### CE 버튼
+|2+3-4+5 입력 후 CE 클릭|2+3-4+ 입력 후 CE 클릭|2+3-4+5= 입력 후 CE 클릭|
+|:---:|:---:|:---:|
+|<img width="300" alt="" src="https://user-images.githubusercontent.com/94151993/159834266-825eb6f8-3ada-4e6b-bf95-f81c48f799c1.gif">|<img width="300" alt="" src="https://user-images.githubusercontent.com/94151993/159834275-c6eed4d4-d625-4308-a1f9-71fc1dd15464.gif">|<img width="300" alt="" src="https://user-images.githubusercontent.com/94151993/159834282-c7cf97a8-9660-41c7-9d2b-67ffcd690aa9.gif">|
+
+### +/- 버튼
+|입력 후 +/- 클릭 (0일때는 부호를 변경하지 않는다)|
+|:---:|
+|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834358-72f0aa2d-9189-40f3-83b8-c2fe2192864c.gif">|
+
+### 사칙연산 버튼
+|연산자(÷, ×, -, +)를 누르게 되면 숫자입력을 중지하고 다음 숫자를 입력|숫자입력이 없는 상태인 0에서는 연산자를 반복해도 연산하지 않고 종류만 변경|
+|:---:|:---:|
+|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834649-d1ee707b-621b-4c19-8b6d-f5db7ee530aa.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834672-6bc66522-eb4a-46f1-a4f3-abdaa6842050.gif">|
+
+### 계산 버튼
+|= 버튼을 누르면 입력된 연산을 한 번에 수행|연산 후 다시 =을 눌러도 이전 연산을 다시 연산 X|
+|:---:|:---:|
+|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834753-e09c71ea-cbb7-4ff2-9d78-3dd77ab513e9.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159835001-1c969580-f0e8-45ac-97b2-721ffc0b99ad.gif">|
+
+|2+3*3-1 의 연산결과는 14|3/3+2-1 의 연산결과는 2|1+2-3*2-3/6 의 연산결과는 -0.5|
+|:---:|:---:|:---:|
+|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834763-21db5b15-eaf2-4e32-9bc8-1378b06b274b.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834758-1b9fdfd5-e071-47d7-806b-a29ba2b03525.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834770-c2158c9d-0b39-4eb1-bca7-73366244eda4.gif">|
+
+### 보여주는 화면
+|0.123000000 → 0.123 / 1.22340000 → 1.2234|숫자는 3자리마다 쉼표(,)를 표기|
+|:---:|:---:|
+|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159835322-3531da93-0f07-46e9-8900-c36cc8870aa4.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159835330-e034130e-1b38-4544-a743-80ae4a92011e.gif">|
+
+### 0으로 나누는 경우
+|0으로 나누기에 대해서는 결과값을 NaN으로 표기|
+|:---:|
+|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159835346-1ca7a613-f426-431e-ac76-a6cde4a37acc.gif">|
+
+## 고민 및 해결한 점
+### 1. 테스트 가능하도록 설계하는 것에 대해
+이번 프로젝트는 **TDD 방법론의 사용과 XCTest를 사용하여 테스트 가능한 코드를 만드는 것**이 중요하다고 생각했습니다. 
+STEP 1, 2 의 경우 테스트하기 쉬운 환경이었지만 CalculatorViewController의 경우 UI 요소와의 연결로 인해 복잡하게 얽혀있는 환경이라 테스트 코드를 작성하는데 어려움이 있었습니다.
+
+CalculatorViewModel 이라는 클래스를 두어 화면에 보여줄 데이터에 대한 변환을 진행하고 CalculatorViewController는 오직 ViewModel에서 오는 데이터를 UI로 보여주는 역할만 하도록하여 CalculatorViewModel 에 대한 테스트 코드를 작성하여 UI 요소와 얽혀있었던 문제를 해결했습니다.
+
+CalculatorViewController 에서 CalculatorViewModel의 데이터를 bind 함수를 통해 데이터가 변경되면 실행될 클로저를 정의해주고 next 함수를 통해 값을 보내주면 subscriber에 저장되어있던 클로저가 실행되면서 CalculatorViewController의 UI 요소를 변경하도록 했습니다.
+```swift
+final class Observable<T> {
+  private var subscriber: ((T) -> Void)?
+  private(set) var value: T {
+    didSet {
+      subscriber?(value)
+    }
+  }
+  
+  init(_ value: T) {
+    self.value = value
+  }
+  
+  func bind(_ subscriber: @escaping (T) -> Void) {
+    subscriber(self.value)
+    self.subscriber = subscriber
+  }
+  
+  func next(_ value: T) {
+    self.value = value
+  }
+}
+```
+이렇게 구현하는 것이 MVVM 패턴과 비슷한 것 같은데 .. 아직 공부가 필요할 것 같습니다 😅
+
+### 2. 결과가 보여질 ScrollView의 자동 스크롤
+<img width="800" alt="" src="https://user-images.githubusercontent.com/94151993/159837627-8cc80866-ff3f-43f5-b71e-7ac1bb62d9d8.png">
+
+위의 그림처럼 resultScrollView의`contentOffset` 값을 변경하여 자동으로 아래로 스크롤하도록 변경했습니다.
+```swift
+func scrollToDown() {
+  let contentSizeHeight = self.resultScrollView.contentSize.height
+  let boundsHeight = self.resultScrollView.bounds.size.height
+  let contentInsetBottom = self.resultScrollView.contentInset.bottom
+  let pointY = contentSizeHeight - boundsHeight + contentInsetBottom
+  if pointY > 0 {
+    let contentOffset = CGPoint(x: 0, y: pointY + 24)
+    self.resultScrollView.setContentOffset(contentOffset, animated: true)
+  }
+}
+```
+하지만, 생각한 것과 달리 약간의 오차가 발생했습니다. 이를 보정하기 위해 +24를 추가로 해주었는데 아직 근본적인 문제를 해결하지 못했습니다 🥲 
+|기존 에러|+24로 보정|
+|:---:|:---:|
+|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159838308-24b73f98-96ce-46da-9fde-20216f1aaf09.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159838361-e2a5f8ff-e6bf-49bb-83e1-e908b604d15c.gif">|
+
+**+ 수정 (2022.03.25)**
+resultScrollView 내부의 resultStackView에 addArrangedSubview 한 후에 scrollDown 함수가 불릴때 아직 Layout 반영되는 사이클이 오지 않아 문제가 발생했던 것이었습니다. (아직 Main Run Loop의 Update Cycle이 오지 않아서 생긴 문제)
+
+따라서, scrollDown 함수가 호출될때 layout을 즉시 하도록 `layoutIfNeeded`를 사용하여 수정했습니다!
+```swift
+func scrollToDown() {
+  self.resultScrollView.layoutIfNeeded()
+  let contentSizeHeight = self.resultScrollView.contentSize.height
+  let boundsHeight = self.resultScrollView.bounds.size.height
+  let contentInsetBottom = self.resultScrollView.contentInset.bottom
+  let pointY = contentSizeHeight - boundsHeight + contentInsetBottom
+  if pointY > 0 {
+    let contentOffset = CGPoint(x: 0, y: pointY)
+    self.resultScrollView.setContentOffset(contentOffset, animated: true)
+  }
+}
+```
+
 
 ---
 


### PR DESCRIPTION
@lina0322 
안녕하세요 엘림 😃 
계산기 I [STEP 3] PR 보냅니다. 잘 부탁드립니다!

## UML
> 모든 STEP의 UML를 통합해봤습니다 :)

![계산기I UML](https://user-images.githubusercontent.com/94151993/159829422-d2133937-ddc6-4f8e-a369-bb57784f78b3.png)

## 기능 구현
### AC 버튼
|2+3-4+5 입력 후 AC 클릭|2+3-4+5= 입력 후 AC 클릭|
|:---:|:---:|
|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159833554-4f082b7d-e2c4-487a-bead-635428c44b27.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159833811-ccba6ed6-2084-4dfb-a7f8-3f0141447d1b.gif">|

### CE 버튼
|2+3-4+5 입력 후 CE 클릭|2+3-4+ 입력 후 CE 클릭|2+3-4+5= 입력 후 CE 클릭|
|:---:|:---:|:---:|
|<img width="300" alt="" src="https://user-images.githubusercontent.com/94151993/159834266-825eb6f8-3ada-4e6b-bf95-f81c48f799c1.gif">|<img width="300" alt="" src="https://user-images.githubusercontent.com/94151993/159834275-c6eed4d4-d625-4308-a1f9-71fc1dd15464.gif">|<img width="300" alt="" src="https://user-images.githubusercontent.com/94151993/159834282-c7cf97a8-9660-41c7-9d2b-67ffcd690aa9.gif">|

### +/- 버튼
|입력 후 +/- 클릭 (0일때는 부호를 변경하지 않는다)|
|:---:|
|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834358-72f0aa2d-9189-40f3-83b8-c2fe2192864c.gif">|

### 사칙연산 버튼
|연산자(÷, ×, -, +)를 누르게 되면 숫자입력을 중지하고 다음 숫자를 입력|숫자입력이 없는 상태인 0에서는 연산자를 반복해도 연산하지 않고 종류만 변경|
|:---:|:---:|
|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834649-d1ee707b-621b-4c19-8b6d-f5db7ee530aa.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834672-6bc66522-eb4a-46f1-a4f3-abdaa6842050.gif">|

### 계산 버튼
|= 버튼을 누르면 입력된 연산을 한 번에 수행|연산 후 다시 =을 눌러도 이전 연산을 다시 연산 X|
|:---:|:---:|
|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834753-e09c71ea-cbb7-4ff2-9d78-3dd77ab513e9.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159835001-1c969580-f0e8-45ac-97b2-721ffc0b99ad.gif">|

|2+3*3-1 의 연산결과는 14|3/3+2-1 의 연산결과는 2|1+2-3*2-3/6 의 연산결과는 -0.5|
|:---:|:---:|:---:|
|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834763-21db5b15-eaf2-4e32-9bc8-1378b06b274b.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834758-1b9fdfd5-e071-47d7-806b-a29ba2b03525.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159834770-c2158c9d-0b39-4eb1-bca7-73366244eda4.gif">|

### 보여주는 화면
|0.123000000 → 0.123 / 1.22340000 → 1.2234|숫자는 3자리마다 쉼표(,)를 표기|
|:---:|:---:|
|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159835322-3531da93-0f07-46e9-8900-c36cc8870aa4.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159835330-e034130e-1b38-4544-a743-80ae4a92011e.gif">|

### 0으로 나누는 경우
|0으로 나누기에 대해서는 결과값을 NaN으로 표기|
|:---:|
|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159835346-1ca7a613-f426-431e-ac76-a6cde4a37acc.gif">|

## 고민 및 해결한 점
### 1. 테스트 가능하도록 설계하는 것에 대해
이번 프로젝트는 **TDD 방법론의 사용과 XCTest를 사용하여 테스트 가능한 코드를 만드는 것**이 중요하다고 생각했습니다. 
STEP 1, 2 의 경우 테스트하기 쉬운 환경이었지만 CalculatorViewController의 경우 UI 요소와의 연결로 인해 복잡하게 얽혀있는 환경이라 테스트 코드를 작성하는데 어려움이 있었습니다.

CalculatorViewModel 이라는 클래스를 두어 화면에 보여줄 데이터에 대한 변환을 진행하고 CalculatorViewController는 오직 ViewModel에서 오는 데이터를 UI로 보여주는 역할만 하도록하여 CalculatorViewModel 에 대한 테스트 코드를 작성하여 UI 요소와 얽혀있었던 문제를 해결했습니다.

CalculatorViewController 에서 CalculatorViewModel의 데이터를 bind 함수를 통해 데이터가 변경되면 실행될 클로저를 정의해주고 next 함수를 통해 값을 보내주면 subscriber에 저장되어있던 클로저가 실행되면서 CalculatorViewController의 UI 요소를 변경하도록 했습니다.
```swift
final class Observable<T> {
  private var subscriber: ((T) -> Void)?
  private(set) var value: T {
    didSet {
      subscriber?(value)
    }
  }
  
  init(_ value: T) {
    self.value = value
  }
  
  func bind(_ subscriber: @escaping (T) -> Void) {
    subscriber(self.value)
    self.subscriber = subscriber
  }
  
  func next(_ value: T) {
    self.value = value
  }
}
```
이렇게 구현하는 것이 MVVM 패턴과 비슷한 것 같은데 .. 아직 공부가 필요할 것 같습니다 😅

### 2. 결과가 보여질 ScrollView의 자동 스크롤
<img width="800" alt="" src="https://user-images.githubusercontent.com/94151993/159837627-8cc80866-ff3f-43f5-b71e-7ac1bb62d9d8.png">

위의 그림처럼 resultScrollView의`contentOffset` 값을 변경하여 자동으로 아래로 스크롤하도록 변경했습니다.
```swift
func scrollToDown() {
  let contentSizeHeight = self.resultScrollView.contentSize.height
  let boundsHeight = self.resultScrollView.bounds.size.height
  let contentInsetBottom = self.resultScrollView.contentInset.bottom
  let pointY = contentSizeHeight - boundsHeight + contentInsetBottom
  if pointY > 0 {
    let contentOffset = CGPoint(x: 0, y: pointY + 24)
    self.resultScrollView.setContentOffset(contentOffset, animated: true)
  }
}
```
하지만, 생각한 것과 달리 약간의 오차가 발생했습니다. 이를 보정하기 위해 +24를 추가로 해주었는데 아직 근본적인 문제를 해결하지 못했습니다 🥲 
|기존 에러|+24로 보정|
|:---:|:---:|
|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159838308-24b73f98-96ce-46da-9fde-20216f1aaf09.gif">|<img width="250" alt="" src="https://user-images.githubusercontent.com/94151993/159838361-e2a5f8ff-e6bf-49bb-83e1-e908b604d15c.gif">|

**+ 수정 (2022.03.25)**
resultScrollView 내부의 resultStackView에 addArrangedSubview 한 후에 scrollDown 함수가 불릴때 아직 Layout 반영되는 사이클이 오지 않아 문제가 발생했던 것이었습니다. (아직 Main Run Loop의 Update Cycle이 오지 않아서 생긴 문제)

따라서, scrollDown 함수가 호출될때 layout을 즉시 하도록 `layoutIfNeeded`를 사용하여 수정했습니다!
```swift
func scrollToDown() {
  self.resultScrollView.layoutIfNeeded()
  let contentSizeHeight = self.resultScrollView.contentSize.height
  let boundsHeight = self.resultScrollView.bounds.size.height
  let contentInsetBottom = self.resultScrollView.contentInset.bottom
  let pointY = contentSizeHeight - boundsHeight + contentInsetBottom
  if pointY > 0 {
    let contentOffset = CGPoint(x: 0, y: pointY)
    self.resultScrollView.setContentOffset(contentOffset, animated: true)
  }
}
```
