### PR TITLE
계산기 [STEP 2] 나이든별

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4F54F1D6283628B80095171B /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1D5283628B80095171B /* Double+Extensions.swift */; };
+		4F54F1D8283636E00095171B /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1D7283636E00095171B /* Operator.swift */; };
 		4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83D82832F7200023B8E8 /* Queue.swift */; };
 		4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */; };
 		4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */; };
@@ -32,6 +33,7 @@
 
 /* Begin PBXFileReference section */
 		4F54F1D5283628B80095171B /* Double+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extensions.swift"; sourceTree = "<group>"; };
+		4F54F1D7283636E00095171B /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		4FAB83D82832F7200023B8E8 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 			isa = PBXGroup;
 			children = (
 				4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */,
+				4F54F1D7283636E00095171B /* Operator.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -310,6 +313,7 @@
 				4F54F1D6283628B80095171B /* Double+Extensions.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				4F54F1D8283636E00095171B /* Operator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		4F54F1D6283628B80095171B /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1D5283628B80095171B /* Double+Extensions.swift */; };
 		4F54F1D8283636E00095171B /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1D7283636E00095171B /* Operator.swift */; };
 		4F54F1E0283637980095171B /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1DF283637980095171B /* OperatorTests.swift */; };
+		4F54F1E728366C800095171B /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1E628366C800095171B /* String+Extensions.swift */; };
 		4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83D82832F7200023B8E8 /* Queue.swift */; };
 		4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */; };
 		4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */; };
@@ -44,6 +45,7 @@
 		4F54F1D7283636E00095171B /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		4F54F1DD283637980095171B /* OperatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F54F1DF283637980095171B /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
+		4F54F1E628366C800095171B /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		4FAB83D82832F7200023B8E8 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
@@ -88,6 +90,7 @@
 			isa = PBXGroup;
 			children = (
 				4F54F1D5283628B80095171B /* Double+Extensions.swift */,
+				4F54F1E628366C800095171B /* String+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -377,6 +380,7 @@
 				4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */,
 				4F54F1D6283628B80095171B /* Double+Extensions.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
+				4F54F1E728366C800095171B /* String+Extensions.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				4F54F1D8283636E00095171B /* Operator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */; };
 		4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */; };
 		4FAB83F52832FD060023B8E8 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83F42832FD060023B8E8 /* CalculatorItemQueueTests.swift */; };
+		4FDE6480283BA5E100D9554E /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDE647F283BA5E100D9554E /* CalculatorError.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
@@ -55,6 +56,7 @@
 		4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		4FAB83F22832FD060023B8E8 /* CalculatorItemQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FAB83F42832FD060023B8E8 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
+		4FDE647F283BA5E100D9554E /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 			children = (
 				4FAB83D52832F62B0023B8E8 /* Models */,
 				4FAB83D72832F6FF0023B8E8 /* Protocols */,
+				4FDE647E283BA5D000D9554E /* Errors */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -203,6 +206,14 @@
 				4FAB83F42832FD060023B8E8 /* CalculatorItemQueueTests.swift */,
 			);
 			path = CalculatorItemQueueTests;
+			sourceTree = "<group>";
+		};
+		4FDE647E283BA5D000D9554E /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				4FDE647F283BA5E100D9554E /* CalculatorError.swift */,
+			);
+			path = Errors;
 			sourceTree = "<group>";
 		};
 		C713D9352570E5EB001C3AFC = {
@@ -390,6 +401,7 @@
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				4F54F1D8283636E00095171B /* Operator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				4FDE6480283BA5E100D9554E /* CalculatorError.swift in Sources */,
 				4F54F1E928367CA70095171B /* Formula.swift in Sources */,
 				4F54F1ED283692C90095171B /* ExpressionParser.swift in Sources */,
 				4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4F54F1D6283628B80095171B /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1D5283628B80095171B /* Double+Extensions.swift */; };
 		4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83D82832F7200023B8E8 /* Queue.swift */; };
 		4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */; };
 		4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */; };
@@ -30,6 +31,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4F54F1D5283628B80095171B /* Double+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extensions.swift"; sourceTree = "<group>"; };
 		4FAB83D82832F7200023B8E8 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
@@ -63,6 +65,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4F54F1D4283628740095171B /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				4F54F1D5283628B80095171B /* Double+Extensions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		4FAB83CF2832F5C70023B8E8 /* Assets */ = {
 			isa = PBXGroup;
 			children = (
@@ -181,6 +191,7 @@
 			children = (
 				4FAB83D02832F5DC0023B8E8 /* Application */,
 				4FAB83D62832F6310023B8E8 /* Utilities */,
+				4F54F1D4283628740095171B /* Extensions */,
 				4FAB83CF2832F5C70023B8E8 /* Assets */,
 			);
 			path = Calculator;
@@ -296,6 +307,7 @@
 			files = (
 				4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */,
 				4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */,
+				4F54F1D6283628B80095171B /* Double+Extensions.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4F54F1D8283636E00095171B /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1D7283636E00095171B /* Operator.swift */; };
 		4F54F1E0283637980095171B /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1DF283637980095171B /* OperatorTests.swift */; };
 		4F54F1E728366C800095171B /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1E628366C800095171B /* String+Extensions.swift */; };
+		4F54F1E928367CA70095171B /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1E828367CA70095171B /* Formula.swift */; };
 		4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83D82832F7200023B8E8 /* Queue.swift */; };
 		4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */; };
 		4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */; };
@@ -46,6 +47,7 @@
 		4F54F1DD283637980095171B /* OperatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F54F1DF283637980095171B /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		4F54F1E628366C800095171B /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
+		4F54F1E828367CA70095171B /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		4FAB83D82832F7200023B8E8 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 			children = (
 				4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */,
 				4F54F1D7283636E00095171B /* Operator.swift */,
+				4F54F1E828367CA70095171B /* Formula.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -384,6 +387,7 @@
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				4F54F1D8283636E00095171B /* Operator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				4F54F1E928367CA70095171B /* Formula.swift in Sources */,
 				4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4F54F1D6283628B80095171B /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1D5283628B80095171B /* Double+Extensions.swift */; };
 		4F54F1D8283636E00095171B /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1D7283636E00095171B /* Operator.swift */; };
+		4F54F1E0283637980095171B /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1DF283637980095171B /* OperatorTests.swift */; };
 		4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83D82832F7200023B8E8 /* Queue.swift */; };
 		4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */; };
 		4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */; };
@@ -22,6 +23,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4F54F1E1283637980095171B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 		4FAB83F62832FD060023B8E8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
@@ -34,6 +42,8 @@
 /* Begin PBXFileReference section */
 		4F54F1D5283628B80095171B /* Double+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extensions.swift"; sourceTree = "<group>"; };
 		4F54F1D7283636E00095171B /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		4F54F1DD283637980095171B /* OperatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4F54F1DF283637980095171B /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		4FAB83D82832F7200023B8E8 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
@@ -50,6 +60,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4F54F1DA283637980095171B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4FAB83EF2832FD060023B8E8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -73,6 +90,14 @@
 				4F54F1D5283628B80095171B /* Double+Extensions.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		4F54F1DE283637980095171B /* OperatorTests */ = {
+			isa = PBXGroup;
+			children = (
+				4F54F1DF283637980095171B /* OperatorTests.swift */,
+			);
+			path = OperatorTests;
 			sourceTree = "<group>";
 		};
 		4FAB83CF2832F5C70023B8E8 /* Assets */ = {
@@ -176,6 +201,7 @@
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				4FAB83F32832FD060023B8E8 /* CalculatorItemQueueTests */,
+				4F54F1DE283637980095171B /* OperatorTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -185,6 +211,7 @@
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				4FAB83F22832FD060023B8E8 /* CalculatorItemQueueTests.xctest */,
+				4F54F1DD283637980095171B /* OperatorTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -203,6 +230,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4F54F1DC283637980095171B /* OperatorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4F54F1E3283637980095171B /* Build configuration list for PBXNativeTarget "OperatorTests" */;
+			buildPhases = (
+				4F54F1D9283637980095171B /* Sources */,
+				4F54F1DA283637980095171B /* Frameworks */,
+				4F54F1DB283637980095171B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4F54F1E2283637980095171B /* PBXTargetDependency */,
+			);
+			name = OperatorTests;
+			productName = OperatorTests;
+			productReference = 4F54F1DD283637980095171B /* OperatorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		4FAB83F12832FD060023B8E8 /* CalculatorItemQueueTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4FAB83F82832FD060023B8E8 /* Build configuration list for PBXNativeTarget "CalculatorItemQueueTests" */;
@@ -247,6 +292,10 @@
 				LastSwiftUpdateCheck = 1330;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					4F54F1DC283637980095171B = {
+						CreatedOnToolsVersion = 13.3.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					4FAB83F12832FD060023B8E8 = {
 						CreatedOnToolsVersion = 13.3.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
@@ -271,11 +320,19 @@
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				4FAB83F12832FD060023B8E8 /* CalculatorItemQueueTests */,
+				4F54F1DC283637980095171B /* OperatorTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4F54F1DB283637980095171B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4FAB83F02832FD060023B8E8 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -296,6 +353,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4F54F1D9283637980095171B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4F54F1E0283637980095171B /* OperatorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4FAB83EE2832FD060023B8E8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -322,6 +387,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4F54F1E2283637980095171B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 4F54F1E1283637980095171B /* PBXContainerItemProxy */;
+		};
 		4FAB83F72832FD060023B8E8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
@@ -349,6 +419,45 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		4F54F1E4283637980095171B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gordonchoi.OperatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		4F54F1E5283637980095171B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gordonchoi.OperatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
 		4FAB83F92832FD060023B8E8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -550,6 +659,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4F54F1E3283637980095171B /* Build configuration list for PBXNativeTarget "OperatorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4F54F1E4283637980095171B /* Debug */,
+				4F54F1E5283637980095171B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4FAB83F82832FD060023B8E8 /* Build configuration list for PBXNativeTarget "CalculatorItemQueueTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4F54F1E0283637980095171B /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1DF283637980095171B /* OperatorTests.swift */; };
 		4F54F1E728366C800095171B /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1E628366C800095171B /* String+Extensions.swift */; };
 		4F54F1E928367CA70095171B /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1E828367CA70095171B /* Formula.swift */; };
+		4F54F1ED283692C90095171B /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54F1EC283692C90095171B /* ExpressionParser.swift */; };
 		4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83D82832F7200023B8E8 /* Queue.swift */; };
 		4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */; };
 		4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */; };
@@ -48,6 +49,7 @@
 		4F54F1DF283637980095171B /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		4F54F1E628366C800095171B /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		4F54F1E828367CA70095171B /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		4F54F1EC283692C90095171B /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		4FAB83D82832F7200023B8E8 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 				4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */,
 				4F54F1D7283636E00095171B /* Operator.swift */,
 				4F54F1E828367CA70095171B /* Formula.swift */,
+				4F54F1EC283692C90095171B /* ExpressionParser.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -388,6 +391,7 @@
 				4F54F1D8283636E00095171B /* Operator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				4F54F1E928367CA70095171B /* Formula.swift in Sources */,
+				4F54F1ED283692C90095171B /* ExpressionParser.swift in Sources */,
 				4FAB83D92832F7200023B8E8 /* Queue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4FAB83DB2832F8C90023B8E8 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83DA2832F8C90023B8E8 /* CalculateItem.swift */; };
 		4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */; };
 		4FAB83F52832FD060023B8E8 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83F42832FD060023B8E8 /* CalculatorItemQueueTests.swift */; };
+		4FCFE772283CBB5F00761085 /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCFE771283CBB5F00761085 /* ExpressionParserTests.swift */; };
 		4FDE6480283BA5E100D9554E /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDE647F283BA5E100D9554E /* CalculatorError.swift */; };
 		4FDE6488283BCAF900D9554E /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDE6487283BCAF900D9554E /* FormulaTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -36,6 +37,13 @@
 			remoteInfo = Calculator;
 		};
 		4FAB83F62832FD060023B8E8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+		4FCFE773283CBB5F00761085 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
 			proxyType = 1;
@@ -64,6 +72,8 @@
 		4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		4FAB83F22832FD060023B8E8 /* CalculatorItemQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FAB83F42832FD060023B8E8 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
+		4FCFE76F283CBB5F00761085 /* ExpressionParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4FCFE771283CBB5F00761085 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		4FDE647F283BA5E100D9554E /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
 		4FDE6485283BCAF900D9554E /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FDE6487283BCAF900D9554E /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
@@ -86,6 +96,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4FAB83EF2832FD060023B8E8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4FCFE76C283CBB5F00761085 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -225,6 +242,14 @@
 			path = CalculatorItemQueueTests;
 			sourceTree = "<group>";
 		};
+		4FCFE770283CBB5F00761085 /* ExpressionParserTests */ = {
+			isa = PBXGroup;
+			children = (
+				4FCFE771283CBB5F00761085 /* ExpressionParserTests.swift */,
+			);
+			path = ExpressionParserTests;
+			sourceTree = "<group>";
+		};
 		4FDE647E283BA5D000D9554E /* Errors */ = {
 			isa = PBXGroup;
 			children = (
@@ -248,6 +273,7 @@
 				4FAB83F32832FD060023B8E8 /* CalculatorItemQueueTests */,
 				4F54F1DE283637980095171B /* OperatorTests */,
 				4FDE6486283BCAF900D9554E /* FormulaTests */,
+				4FCFE770283CBB5F00761085 /* ExpressionParserTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -259,6 +285,7 @@
 				4FAB83F22832FD060023B8E8 /* CalculatorItemQueueTests.xctest */,
 				4F54F1DD283637980095171B /* OperatorTests.xctest */,
 				4FDE6485283BCAF900D9554E /* FormulaTests.xctest */,
+				4FCFE76F283CBB5F00761085 /* ExpressionParserTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -313,6 +340,24 @@
 			productReference = 4FAB83F22832FD060023B8E8 /* CalculatorItemQueueTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		4FCFE76E283CBB5F00761085 /* ExpressionParserTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4FCFE777283CBB5F00761085 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */;
+			buildPhases = (
+				4FCFE76B283CBB5F00761085 /* Sources */,
+				4FCFE76C283CBB5F00761085 /* Frameworks */,
+				4FCFE76D283CBB5F00761085 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4FCFE774283CBB5F00761085 /* PBXTargetDependency */,
+			);
+			name = ExpressionParserTests;
+			productName = ExpressionParserTests;
+			productReference = 4FCFE76F283CBB5F00761085 /* ExpressionParserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		4FDE6484283BCAF900D9554E /* FormulaTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4FDE648B283BCAF900D9554E /* Build configuration list for PBXNativeTarget "FormulaTests" */;
@@ -365,6 +410,10 @@
 						CreatedOnToolsVersion = 13.3.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					4FCFE76E283CBB5F00761085 = {
+						CreatedOnToolsVersion = 13.3.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					4FDE6484283BCAF900D9554E = {
 						CreatedOnToolsVersion = 13.3.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
@@ -391,6 +440,7 @@
 				4FAB83F12832FD060023B8E8 /* CalculatorItemQueueTests */,
 				4F54F1DC283637980095171B /* OperatorTests */,
 				4FDE6484283BCAF900D9554E /* FormulaTests */,
+				4FCFE76E283CBB5F00761085 /* ExpressionParserTests */,
 			);
 		};
 /* End PBXProject section */
@@ -404,6 +454,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4FAB83F02832FD060023B8E8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4FCFE76D283CBB5F00761085 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -446,6 +503,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4FCFE76B283CBB5F00761085 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4FCFE772283CBB5F00761085 /* ExpressionParserTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4FDE6481283BCAF900D9554E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -485,6 +550,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 4FAB83F62832FD060023B8E8 /* PBXContainerItemProxy */;
+		};
+		4FCFE774283CBB5F00761085 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 4FCFE773283CBB5F00761085 /* PBXContainerItemProxy */;
 		};
 		4FDE648A283BCAF900D9554E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -583,6 +653,45 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gordonchoi.CalculatorItemQueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		4FCFE775283CBB5F00761085 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gordonchoi.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		4FCFE776283CBB5F00761085 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gordonchoi.ExpressionParserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -806,6 +915,15 @@
 			buildConfigurations = (
 				4FAB83F92832FD060023B8E8 /* Debug */,
 				4FAB83FA2832FD060023B8E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4FCFE777283CBB5F00761085 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4FCFE775283CBB5F00761085 /* Debug */,
+				4FCFE776283CBB5F00761085 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		4FAB83ED2832FBB40023B8E8 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83EC2832FBB40023B8E8 /* CalculatorItemQueue.swift */; };
 		4FAB83F52832FD060023B8E8 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAB83F42832FD060023B8E8 /* CalculatorItemQueueTests.swift */; };
 		4FDE6480283BA5E100D9554E /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDE647F283BA5E100D9554E /* CalculatorError.swift */; };
+		4FDE6488283BCAF900D9554E /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDE6487283BCAF900D9554E /* FormulaTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
@@ -41,6 +42,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		4FDE6489283BCAF900D9554E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -57,6 +65,8 @@
 		4FAB83F22832FD060023B8E8 /* CalculatorItemQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FAB83F42832FD060023B8E8 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
 		4FDE647F283BA5E100D9554E /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
+		4FDE6485283BCAF900D9554E /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4FDE6487283BCAF900D9554E /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -76,6 +86,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4FAB83EF2832FD060023B8E8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4FDE6482283BCAF900D9554E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -216,12 +233,21 @@
 			path = Errors;
 			sourceTree = "<group>";
 		};
+		4FDE6486283BCAF900D9554E /* FormulaTests */ = {
+			isa = PBXGroup;
+			children = (
+				4FDE6487283BCAF900D9554E /* FormulaTests.swift */,
+			);
+			path = FormulaTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				4FAB83F32832FD060023B8E8 /* CalculatorItemQueueTests */,
 				4F54F1DE283637980095171B /* OperatorTests */,
+				4FDE6486283BCAF900D9554E /* FormulaTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -232,6 +258,7 @@
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				4FAB83F22832FD060023B8E8 /* CalculatorItemQueueTests.xctest */,
 				4F54F1DD283637980095171B /* OperatorTests.xctest */,
+				4FDE6485283BCAF900D9554E /* FormulaTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -286,6 +313,24 @@
 			productReference = 4FAB83F22832FD060023B8E8 /* CalculatorItemQueueTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		4FDE6484283BCAF900D9554E /* FormulaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4FDE648B283BCAF900D9554E /* Build configuration list for PBXNativeTarget "FormulaTests" */;
+			buildPhases = (
+				4FDE6481283BCAF900D9554E /* Sources */,
+				4FDE6482283BCAF900D9554E /* Frameworks */,
+				4FDE6483283BCAF900D9554E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4FDE648A283BCAF900D9554E /* PBXTargetDependency */,
+			);
+			name = FormulaTests;
+			productName = FormulaTests;
+			productReference = 4FDE6485283BCAF900D9554E /* FormulaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -320,6 +365,10 @@
 						CreatedOnToolsVersion = 13.3.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					4FDE6484283BCAF900D9554E = {
+						CreatedOnToolsVersion = 13.3.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -341,6 +390,7 @@
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				4FAB83F12832FD060023B8E8 /* CalculatorItemQueueTests */,
 				4F54F1DC283637980095171B /* OperatorTests */,
+				4FDE6484283BCAF900D9554E /* FormulaTests */,
 			);
 		};
 /* End PBXProject section */
@@ -354,6 +404,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4FAB83F02832FD060023B8E8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4FDE6483283BCAF900D9554E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -389,6 +446,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4FDE6481283BCAF900D9554E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4FDE6488283BCAF900D9554E /* FormulaTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -420,6 +485,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 4FAB83F62832FD060023B8E8 /* PBXContainerItemProxy */;
+		};
+		4FDE648A283BCAF900D9554E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 4FDE6489283BCAF900D9554E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -513,6 +583,45 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gordonchoi.CalculatorItemQueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		4FDE648C283BCAF900D9554E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gordonchoi.FormulaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		4FDE648D283BCAF900D9554E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gordonchoi.FormulaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -697,6 +806,15 @@
 			buildConfigurations = (
 				4FAB83F92832FD060023B8E8 /* Debug */,
 				4FAB83FA2832FD060023B8E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4FDE648B283BCAF900D9554E /* Build configuration list for PBXNativeTarget "FormulaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4FDE648C283BCAF900D9554E /* Debug */,
+				4FDE648D283BCAF900D9554E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator/Application/Domain/Errors/CalculatorError.swift
+++ b/Calculator/Calculator/Application/Domain/Errors/CalculatorError.swift
@@ -9,11 +9,14 @@ import Foundation
 
 enum CalculatorError: Error {
     case noRemainingValue
+    case dividedByZero
     
     var errorDescription: String {
         switch self {
         case .noRemainingValue:
             return "더 이상 계산할 값이 없습니다."
+        case .dividedByZero:
+            return "0으로 나눌 수 없습니다."
         }
     }
 }

--- a/Calculator/Calculator/Application/Domain/Errors/CalculatorError.swift
+++ b/Calculator/Calculator/Application/Domain/Errors/CalculatorError.swift
@@ -1,0 +1,19 @@
+//
+//  CalculatorError.swift
+//  Calculator
+//
+//  Created by Gordon Choi on 2022/05/23.
+//
+
+import Foundation
+
+enum CalculatorError: Error {
+    case noRemainingValue
+    
+    var errorDescription: String {
+        switch self {
+        case .noRemainingValue:
+            return "더 이상 계산할 값이 없습니다."
+        }
+    }
+}

--- a/Calculator/Calculator/Application/Domain/Models/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Application/Domain/Models/CalculatorItemQueue.swift
@@ -16,7 +16,7 @@ struct CalculatorItemQueue<T>: Queue where T: CalculateItem {
         return array.isEmpty
     }
     
-    var peek: Element? {
+    var peek: T? {
         return array.first
     }
     

--- a/Calculator/Calculator/Application/Domain/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Application/Domain/Models/ExpressionParser.swift
@@ -1,0 +1,21 @@
+//
+//  ExpressionParser.swift
+//  Calculator
+//
+//  Created by Gordon Choi on 2022/05/19.
+//
+
+enum ExpressionParser {
+    func parse(from input: String) -> Formula {
+        var formula = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
+        let inputData = componentsByOperators(from: input)
+        // TODO: 오퍼레이터와 숫자가 분리된 배열이 넘어오면 알맞은 큐에 넣어주는 작업을 수행한다
+        
+        return formula
+    }
+    
+    private func componentsByOperators(from input: String) -> [String] {
+        // TODO: 오퍼레이터와 숫자를 분리해준다
+        return []
+    }
+}

--- a/Calculator/Calculator/Application/Domain/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Application/Domain/Models/ExpressionParser.swift
@@ -6,16 +6,27 @@
 //
 
 enum ExpressionParser {
-    func parse(from input: String) -> Formula {
+    static func parse(from input: String) -> Formula {
         var formula = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
-        let inputData = componentsByOperators(from: input)
-        // TODO: 오퍼레이터와 숫자가 분리된 배열이 넘어오면 알맞은 큐에 넣어주는 작업을 수행한다
+        let operators = componentsByOperators(from: input)
+        let operands = input.split { operators.contains(String($0)) }.map { String($0) }
+        
+        operators.forEach {
+            if let `operator` = Operator(rawValue: Character($0)) {
+                formula.operators.enqueue(`operator`)
+            }
+        }
+        operands.forEach {
+            if let operand = Double($0) {
+                formula.operands.enqueue(operand)
+            }
+        }
         
         return formula
     }
     
-    private func componentsByOperators(from input: String) -> [String] {
-        // TODO: 오퍼레이터와 숫자를 분리해준다
-        return []
+    private static func componentsByOperators(from input: String) -> [String] {
+        let operators = input.filter { !$0.isNumber }.map { String($0) }
+        return operators
     }
 }

--- a/Calculator/Calculator/Application/Domain/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Application/Domain/Models/ExpressionParser.swift
@@ -7,26 +7,39 @@
 
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        var formula = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
-        let operators = componentsByOperators(from: input)
-        let operands = input.split { operators.contains(String($0)) }.map { String($0) }
+        let data = componentsByOperators(from: input)
+        var operatorsQueue = CalculatorItemQueue<Operator>()
+        var operandsQueue = CalculatorItemQueue<Double>()
         
-        operators.forEach {
-            if let `operator` = Operator(rawValue: Character($0)) {
-                formula.operators.enqueue(`operator`)
+        data.forEach {
+            if let value = Double($0) {
+                operandsQueue.enqueue(value)
+            } else {
+                let value = Character($0)
+                if let `operator` = Operator(rawValue: value) {
+                    operatorsQueue.enqueue(`operator`)
+                }
             }
         }
-        operands.forEach {
-            if let operand = Double($0) {
-                formula.operands.enqueue(operand)
-            }
-        }
+        
+        let formula = Formula(operands: operandsQueue, operators: operatorsQueue)
         
         return formula
     }
     
     private static func componentsByOperators(from input: String) -> [String] {
-        let operators = input.filter { !$0.isNumber }.map { String($0) }
-        return operators
+        var result = [input]
+        
+        Operator.allCases.forEach { `operator` in
+            var newResult = [String]()
+            result.forEach {
+                let snippet = $0.split(with: `operator`.rawValue)
+                newResult.append(contentsOf: snippet)
+            }
+            
+            result = newResult
+        }
+        
+        return result
     }
 }

--- a/Calculator/Calculator/Application/Domain/Models/Formula.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Formula.swift
@@ -16,11 +16,10 @@ struct Formula {
         
         while let nextOperator = operators.dequeue(),
               let nextOperand = operands.dequeue() {
-            let newValue = nextOperator.calculate(lhs: result, rhs: nextOperand)
-            switch newValue {
-            case .success(let value):
-                result = value
-            case .failure(let error):
+            do {
+                let newValue = try nextOperator.calculate(lhs: result, rhs: nextOperand)
+                result = newValue
+            } catch {
                 throw error
             }
         }

--- a/Calculator/Calculator/Application/Domain/Models/Formula.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Formula.swift
@@ -11,9 +11,7 @@ struct Formula {
     
     mutating func result() -> Double {
         guard var result = operands.dequeue() else {
-            // TODO: 값이 없을 때 적절한 에러 핸들링
-            print("주어진 값이 없습니다.")
-            return 0
+            return Double.nan
         }
         
         while !operators.isEmpty && !operands.isEmpty {

--- a/Calculator/Calculator/Application/Domain/Models/Formula.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Formula.swift
@@ -9,15 +9,20 @@ struct Formula {
     var operands: CalculatorItemQueue<Double>
     var operators: CalculatorItemQueue<Operator>
     
-    mutating func result() -> Double {
+    mutating func result() throws -> Double {
         guard var result = operands.dequeue() else {
-            return Double.nan
+            throw CalculatorError.noRemainingValue
         }
         
-        while !operators.isEmpty && !operands.isEmpty {
-            let nextOperator = operators.dequeue()
-            let nextOperand = operands.dequeue()
-            result = nextOperator?.calculate(lhs: result, rhs: nextOperand ?? 0) ?? result
+        while let nextOperator = operators.dequeue(),
+              let nextOperand = operands.dequeue() {
+            let newValue = nextOperator.calculate(lhs: result, rhs: nextOperand)
+            switch newValue {
+            case .success(let value):
+                result = value
+            case .failure(let error):
+                throw error
+            }
         }
         
         return result

--- a/Calculator/Calculator/Application/Domain/Models/Formula.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Formula.swift
@@ -10,13 +10,18 @@ struct Formula {
     var operators: CalculatorItemQueue<Operator>
     
     mutating func result() -> Double {
-        guard let lhs = operands.dequeue(),
-              let rhs = operands.dequeue(),
-              let operation = operators.dequeue() else {
-            // TODO: 적절한 에러 핸들링
+        guard var result = operands.dequeue() else {
+            // TODO: 값이 없을 때 적절한 에러 핸들링
+            print("주어진 값이 없습니다.")
             return 0
         }
         
-        return operation.calculate(lhs: lhs, rhs: rhs)
+        while !operators.isEmpty && !operands.isEmpty {
+            let nextOperator = operators.dequeue()
+            let nextOperand = operands.dequeue()
+            result = nextOperator?.calculate(lhs: result, rhs: nextOperand ?? 0) ?? result
+        }
+        
+        return result
     }
 }

--- a/Calculator/Calculator/Application/Domain/Models/Formula.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Formula.swift
@@ -1,0 +1,22 @@
+//
+//  Formula.swift
+//  Calculator
+//
+//  Created by Gordon Choi on 2022/05/19.
+//
+
+struct Formula {
+    var operands: CalculatorItemQueue<Double>
+    var operators: CalculatorItemQueue<Operator>
+    
+    mutating func result() -> Double {
+        guard let lhs = operands.dequeue(),
+              let rhs = operands.dequeue(),
+              let operation = operators.dequeue() else {
+            // TODO: 적절한 에러 핸들링
+            return 0
+        }
+        
+        return operation.calculate(lhs: lhs, rhs: rhs)
+    }
+}

--- a/Calculator/Calculator/Application/Domain/Models/Formula.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Formula.swift
@@ -6,10 +6,13 @@
 //
 
 struct Formula {
-    var operands: CalculatorItemQueue<Double>
-    var operators: CalculatorItemQueue<Operator>
+    let operands: CalculatorItemQueue<Double>
+    let operators: CalculatorItemQueue<Operator>
     
     mutating func result() throws -> Double {
+        var operands = self.operands
+        var operators = self.operators
+        
         guard var result = operands.dequeue() else {
             throw CalculatorError.noRemainingValue
         }
@@ -19,8 +22,8 @@ struct Formula {
             do {
                 let newValue = try nextOperator.calculate(lhs: result, rhs: nextOperand)
                 result = newValue
-            } catch {
-                throw error
+            } catch CalculatorError.dividedByZero {
+                throw CalculatorError.dividedByZero
             }
         }
         

--- a/Calculator/Calculator/Application/Domain/Models/Formula.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Formula.swift
@@ -9,7 +9,7 @@ struct Formula {
     let operands: CalculatorItemQueue<Double>
     let operators: CalculatorItemQueue<Operator>
     
-    mutating func result() throws -> Double {
+    func result() throws -> Double {
         var operands = self.operands
         var operators = self.operators
         

--- a/Calculator/Calculator/Application/Domain/Models/Operator.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Operator.swift
@@ -8,6 +8,19 @@
 enum Operator: Character, CalculateItem, CaseIterable {
     case add = "+"
     case subtract = "-"
-    case multiply = "*"
     case divide = "/"
+    case multiply = "*"
+    
+    func calculate(lhs: Double, rhs: Double) -> Double {
+        switch self {
+        case .add:
+            return add(lhs: lhs, rhs: rhs)
+        default:
+            return 0
+        }
+    }
+    
+    private func add(lhs: Double, rhs: Double) -> Double {
+        return lhs + rhs
+    }
 }

--- a/Calculator/Calculator/Application/Domain/Models/Operator.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Operator.swift
@@ -1,0 +1,13 @@
+//
+//  Operator.swift
+//  Calculator
+//
+//  Created by Gordon Choi on 2022/05/19.
+//
+
+enum Operator: Character, CalculateItem, CaseIterable {
+    case add = "+"
+    case subtract = "-"
+    case multiply = "*"
+    case divide = "/"
+}

--- a/Calculator/Calculator/Application/Domain/Models/Operator.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Operator.swift
@@ -17,8 +17,10 @@ enum Operator: Character, CalculateItem, CaseIterable {
             return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
-        default:
-            return 0
+        case .divide:
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
         }
     }
     
@@ -28,5 +30,13 @@ enum Operator: Character, CalculateItem, CaseIterable {
     
     private func subtract(lhs: Double, rhs: Double) -> Double {
         return lhs - rhs
+    }
+    
+    private func divide(lhs: Double, rhs: Double) -> Double {
+        return lhs / rhs
+    }
+    
+    private func multiply(lhs: Double, rhs: Double) -> Double {
+        return lhs * rhs
     }
 }

--- a/Calculator/Calculator/Application/Domain/Models/Operator.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Operator.swift
@@ -33,6 +33,11 @@ enum Operator: Character, CalculateItem, CaseIterable {
     }
     
     private func divide(lhs: Double, rhs: Double) -> Double {
+        guard rhs != 0 else {
+            // TODO: 구체적인 작동방식이 정해진 이후 적절한 에러 핸들링
+            print("0으로 나눌 수 없습니다.")
+            return lhs
+        }
         return lhs / rhs
     }
     

--- a/Calculator/Calculator/Application/Domain/Models/Operator.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Operator.swift
@@ -11,16 +11,24 @@ enum Operator: Character, CalculateItem, CaseIterable {
     case divide = "/"
     case multiply = "*"
     
-    func calculate(lhs: Double, rhs: Double) -> Double {
+    func calculate(lhs: Double, rhs: Double) -> Result<Double, CalculatorError> {
         switch self {
         case .add:
-            return add(lhs: lhs, rhs: rhs)
+            let value = add(lhs: lhs, rhs: rhs)
+            return .success(value)
         case .subtract:
-            return subtract(lhs: lhs, rhs: rhs)
+            let value = subtract(lhs: lhs, rhs: rhs)
+            return .success(value)
         case .divide:
-            return divide(lhs: lhs, rhs: rhs)
+            do {
+                let value = try divide(lhs: lhs, rhs: rhs)
+                return .success(value)
+            } catch {
+                return .failure(.dividedByZero)
+            }
         case .multiply:
-            return multiply(lhs: lhs, rhs: rhs)
+            let value = multiply(lhs: lhs, rhs: rhs)
+            return .success(value)
         }
     }
     
@@ -32,11 +40,9 @@ enum Operator: Character, CalculateItem, CaseIterable {
         return lhs - rhs
     }
     
-    private func divide(lhs: Double, rhs: Double) -> Double {
+    private func divide(lhs: Double, rhs: Double) throws -> Double {
         guard rhs != 0 else {
-            // TODO: 구체적인 작동방식이 정해진 이후 적절한 에러 핸들링
-            print("0으로 나눌 수 없습니다.")
-            return lhs
+            throw CalculatorError.dividedByZero
         }
         return lhs / rhs
     }

--- a/Calculator/Calculator/Application/Domain/Models/Operator.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Operator.swift
@@ -11,24 +11,24 @@ enum Operator: Character, CalculateItem, CaseIterable {
     case divide = "/"
     case multiply = "*"
     
-    func calculate(lhs: Double, rhs: Double) -> Result<Double, CalculatorError> {
+    func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {
         case .add:
             let value = add(lhs: lhs, rhs: rhs)
-            return .success(value)
+            return value
         case .subtract:
             let value = subtract(lhs: lhs, rhs: rhs)
-            return .success(value)
+            return value
         case .divide:
             do {
                 let value = try divide(lhs: lhs, rhs: rhs)
-                return .success(value)
+                return value
             } catch {
-                return .failure(.dividedByZero)
+                throw error
             }
         case .multiply:
             let value = multiply(lhs: lhs, rhs: rhs)
-            return .success(value)
+            return value
         }
     }
     

--- a/Calculator/Calculator/Application/Domain/Models/Operator.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Operator.swift
@@ -15,6 +15,8 @@ enum Operator: Character, CalculateItem, CaseIterable {
         switch self {
         case .add:
             return add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            return subtract(lhs: lhs, rhs: rhs)
         default:
             return 0
         }
@@ -22,5 +24,9 @@ enum Operator: Character, CalculateItem, CaseIterable {
     
     private func add(lhs: Double, rhs: Double) -> Double {
         return lhs + rhs
+    }
+    
+    private func subtract(lhs: Double, rhs: Double) -> Double {
+        return lhs - rhs
     }
 }

--- a/Calculator/Calculator/Application/Domain/Models/Operator.swift
+++ b/Calculator/Calculator/Application/Domain/Models/Operator.swift
@@ -23,8 +23,8 @@ enum Operator: Character, CalculateItem, CaseIterable {
             do {
                 let value = try divide(lhs: lhs, rhs: rhs)
                 return value
-            } catch {
-                throw error
+            } catch CalculatorError.dividedByZero {
+                throw CalculatorError.dividedByZero
             }
         case .multiply:
             let value = multiply(lhs: lhs, rhs: rhs)

--- a/Calculator/Calculator/Extensions/Double+Extensions.swift
+++ b/Calculator/Calculator/Extensions/Double+Extensions.swift
@@ -1,0 +1,10 @@
+//
+//  Double+Extensions.swift
+//  Calculator
+//
+//  Created by Gordon Choi on 2022/05/19.
+//
+
+extension Double: CalculateItem {
+    
+}

--- a/Calculator/Calculator/Extensions/String+Extensions.swift
+++ b/Calculator/Calculator/Extensions/String+Extensions.swift
@@ -7,18 +7,21 @@
 
 extension String {
     func split(with target: Character) -> [String] {
-        let data = self.map { String($0) }
-        let target = String(target)
+        let data = self.map { $0 }
         var result = [String]()
         var storage = ""
         
         data.forEach {
             if $0 == target {
                 result.append(storage)
-                result.append(String($0))
+                
+                let operatorValue = String($0)
+                result.append(operatorValue)
+                
                 storage = ""
             } else {
-                storage += $0
+                let letter = String($0)
+                storage += letter
             }
         }
         

--- a/Calculator/Calculator/Extensions/String+Extensions.swift
+++ b/Calculator/Calculator/Extensions/String+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  String+Extensions.swift
+//  Calculator
+//
+//  Created by Gordon Choi on 2022/05/19.
+//
+
+extension String {
+    func split(with target: Character) -> [String] {
+        return self.split(separator: target).map { String($0) }
+    }
+}

--- a/Calculator/Calculator/Extensions/String+Extensions.swift
+++ b/Calculator/Calculator/Extensions/String+Extensions.swift
@@ -7,6 +7,29 @@
 
 extension String {
     func split(with target: Character) -> [String] {
-        return self.split(separator: target).map { String($0) }
+        let data = self.map { String($0) }
+        let target = String(target)
+        var result = [String]()
+        var storage = ""
+        
+        data.forEach {
+            if $0 == target {
+                result.append(storage)
+                result.append(String($0))
+                storage = ""
+            } else {
+                storage += $0
+            }
+        }
+        
+        if storage.isNotEmpty {
+            result.append(storage)
+        }
+        
+        return result
+    }
+    
+    var isNotEmpty: Bool {
+        return !self.isEmpty
     }
 }

--- a/Calculator/CalculatorItemQueueTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorItemQueueTests/CalculatorItemQueueTests.swift
@@ -28,8 +28,6 @@ class CalculatorItemQueueTests: XCTestCase {
     }
     
     func test_큐에_원소가있을때_isEmpty가_false를_반환() {
-        // given
-        
         // when
         let result = sut.isEmpty
         
@@ -38,8 +36,6 @@ class CalculatorItemQueueTests: XCTestCase {
     }
     
     func test_peek은_첫번째원소인_5를_보여줌() {
-        // given
-        
         // when
         let result = sut.peek?.value
         
@@ -59,8 +55,6 @@ class CalculatorItemQueueTests: XCTestCase {
     }
     
     func test_dequeue로_큐의첫번째원소인_5를_제거하고_그값을반환() {
-        // given
-        
         // when
         let result = sut.dequeue()?.value
         

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -1,0 +1,36 @@
+//
+//  ExpressionParserTests.swift
+//  ExpressionParserTests
+//
+//  Created by Gordon Choi on 2022/05/24.
+//
+
+import XCTest
+@testable import Calculator
+
+class ExpressionParserTests: XCTestCase {
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+    }
+
+    func test_parse메서드에_1더하기2빼기3을_넣었을때_알맞은Formula_반환() {
+        // given
+        let input = "1+2-3"
+        
+        // when
+        var formula = ExpressionParser.parse(from: input)
+        let formulaValue = try? formula.result()
+        
+        var expected = Formula(operands: CalculatorItemQueue(array: [1, 2, 3]),
+                               operators: CalculatorItemQueue(array: [Operator.add, Operator.subtract]))
+        let expectedValue = try? expected.result()
+        
+        // then
+        XCTAssertEqual(formulaValue, expectedValue)
+    }
+}

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -23,10 +23,10 @@ class ExpressionParserTests: XCTestCase {
         let input = "1+2-3"
         
         // when
-        var formula = ExpressionParser.parse(from: input)
+        let formula = ExpressionParser.parse(from: input)
         let formulaValue = try? formula.result()
         
-        var expected = Formula(operands: CalculatorItemQueue(array: [1, 2, 3]),
+        let expected = Formula(operands: CalculatorItemQueue(array: [1, 2, 3]),
                                operators: CalculatorItemQueue(array: [Operator.add, Operator.subtract]))
         let expectedValue = try? expected.result()
         

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -1,0 +1,98 @@
+//
+//  FormulaTests.swift
+//  FormulaTests
+//
+//  Created by Gordon Choi on 2022/05/23.
+//
+
+import XCTest
+@testable import Calculator
+
+class FormulaTests: XCTestCase {
+    var sut: Formula!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        sut = Formula(operands: CalculatorItemQueue(array: [100, 200]), operators: CalculatorItemQueue(array: [Operator.add]))
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        
+        sut = nil
+    }
+
+    func test_result메서드에서_100과200을_더하면_300을반환() {
+        // when
+        let result = try? sut.result()
+        
+        // then
+        XCTAssertEqual(result, 300)
+    }
+    
+    func test_result메서드에서_100에서200을_빼면_마이너스100을반환() {
+        // given
+        sut = Formula(operands: CalculatorItemQueue(array: [100, 200]), operators: CalculatorItemQueue(array: [Operator.subtract]))
+        
+        // when
+        let result = try? sut.result()
+        
+        // then
+        XCTAssertEqual(result, -100)
+    }
+    
+    func test_result메서드에서_100에200을_곱하면_20000반환() {
+        // given
+        sut = Formula(operands: CalculatorItemQueue(array: [100, 200]), operators: CalculatorItemQueue(array: [Operator.multiply]))
+        
+        // when
+        let result = try? sut.result()
+        
+        // then
+        XCTAssertEqual(result, 20000)
+    }
+    
+    func test_result메서드에서_100을200으로나누면_영점오반환() {
+        // given
+        sut = Formula(operands: CalculatorItemQueue(array: [100, 200]), operators: CalculatorItemQueue(array: [Operator.divide]))
+        
+        // when
+        let result = try? sut.result()
+        
+        // then
+        XCTAssertEqual(result, 0.5)
+    }
+    
+    func test_Formula가_5_더하기4_빼기3_곱하기2_나누기1을하면_12를반환() {
+        // given
+        sut = Formula(operands: CalculatorItemQueue(array: [5, 4, 3, 2, 1]),
+                      operators: CalculatorItemQueue(array: [Operator.add, Operator.subtract, Operator.multiply, Operator.divide]))
+        
+        // when
+        let result = try? sut.result()
+        
+        // then
+        XCTAssertEqual(result, 12)
+    }
+    
+    func test_result메서드가_가진값이없으면_noRemainingValue오류_반환() {
+        // given
+        sut = Formula(operands: CalculatorItemQueue(), operators: CalculatorItemQueue(array: [Operator.add]))
+        
+        // then
+        XCTAssertThrowsError(try sut.result()) { error in
+            XCTAssertEqual(error as! CalculatorError, CalculatorError.noRemainingValue)
+        }
+    }
+    
+    func test_result메서드를_실행했을때_0으로나누는_계산을했다면_dividedByZero오류반환() {
+        // given
+        sut = Formula(operands: CalculatorItemQueue(array: [100, 0]), operators: CalculatorItemQueue(array: [Operator.divide]))
+        
+        // then
+        XCTAssertThrowsError(try sut.result()) { error in
+            XCTAssertEqual(error as! CalculatorError, CalculatorError.dividedByZero)
+        }
+    }
+}

--- a/Calculator/OperatorTests/OperatorTests.swift
+++ b/Calculator/OperatorTests/OperatorTests.swift
@@ -1,0 +1,27 @@
+//
+//  OperatorTests.swift
+//  OperatorTests
+//
+//  Created by Gordon Choi on 2022/05/19.
+//
+
+import XCTest
+@testable import Calculator
+
+class OperatorTests: XCTestCase {
+    var sut: Operator!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        sut = Operator.add
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        
+        sut = nil
+    }
+    
+    
+}

--- a/Calculator/OperatorTests/OperatorTests.swift
+++ b/Calculator/OperatorTests/OperatorTests.swift
@@ -23,5 +23,11 @@ class OperatorTests: XCTestCase {
         sut = nil
     }
     
-    
+    func test_calculate에_1과2를_넣고_더해줬을때_3반환() {
+        // when
+        let result = sut.calculate(lhs: 1.0, rhs: 2.0)
+        
+        // then
+        XCTAssertEqual(result, 3.0)
+    }
 }

--- a/Calculator/OperatorTests/OperatorTests.swift
+++ b/Calculator/OperatorTests/OperatorTests.swift
@@ -41,4 +41,26 @@ class OperatorTests: XCTestCase {
         // then
         XCTAssertEqual(result, 1.0)
     }
+    
+    func test_calculate에_4와2를_넣고_나누어줬을때_2반환() {
+        // given
+        sut = .divide
+        
+        // when
+        let result = sut.calculate(lhs: 4.0, rhs: 2.0)
+        
+        // then
+        XCTAssertEqual(result, 2.0)
+    }
+    
+    func test_calculate에_4와2를_넣고_곱해줬을때_8반환() {
+        // given
+        sut = .multiply
+        
+        // when
+        let result = sut.calculate(lhs: 4.0, rhs: 2.0)
+        
+        // then
+        XCTAssertEqual(result, 8.0)
+    }
 }

--- a/Calculator/OperatorTests/OperatorTests.swift
+++ b/Calculator/OperatorTests/OperatorTests.swift
@@ -30,4 +30,15 @@ class OperatorTests: XCTestCase {
         // then
         XCTAssertEqual(result, 3.0)
     }
+    
+    func test_calculate에_2와1을_넣고_빼줬을때_1반환() {
+        // given
+        sut = .subtract
+        
+        // when
+        let result = sut.calculate(lhs: 2.0, rhs: 1.0)
+        
+        // then
+        XCTAssertEqual(result, 1.0)
+    }
 }

--- a/Calculator/OperatorTests/OperatorTests.swift
+++ b/Calculator/OperatorTests/OperatorTests.swift
@@ -25,19 +25,10 @@ class OperatorTests: XCTestCase {
     
     func test_calculate에_1과2를_넣고_더해줬을때_3반환() {
         // when
-        let result = sut.calculate(lhs: 1.0, rhs: 2.0)
-        var value = Double.nan
-        var error: CalculatorError? = nil
-        
-        switch result {
-        case .success(let newValue):
-            value = newValue
-        case .failure(let newError):
-            error = newError
-        }
+        let result = try? sut.calculate(lhs: 1.0, rhs: 2.0)
         
         // then
-        XCTAssertEqual(value, 3.0)
+        XCTAssertEqual(result, 3.0)
     }
     
     func test_calculate에_2와1을_넣고_빼줬을때_1반환() {
@@ -45,19 +36,10 @@ class OperatorTests: XCTestCase {
         sut = .subtract
         
         // when
-        let result = sut.calculate(lhs: 2.0, rhs: 1.0)
-        var value = Double.nan
-        var error: CalculatorError? = nil
-        
-        switch result {
-        case .success(let newValue):
-            value = newValue
-        case .failure(let newError):
-            error = newError
-        }
-        
+        let result = try? sut.calculate(lhs: 2.0, rhs: 1.0)
+
         // then
-        XCTAssertEqual(value, 1.0)
+        XCTAssertEqual(result, 1.0)
     }
     
     func test_calculate에_4와2를_넣고_나누어줬을때_2반환() {
@@ -65,39 +47,20 @@ class OperatorTests: XCTestCase {
         sut = .divide
         
         // when
-        let result = sut.calculate(lhs: 4.0, rhs: 2.0)
-        var value = Double.nan
-        var error: CalculatorError? = nil
-        
-        switch result {
-        case .success(let newValue):
-            value = newValue
-        case .failure(let newError):
-            error = newError
-        }
+        let result = try? sut.calculate(lhs: 4.0, rhs: 2.0)
         
         // then
-        XCTAssertEqual(value, 2.0)
+        XCTAssertEqual(result, 2.0)
     }
     
     func test_calculate에서_0으로나눌경우_dividedByZero_오류반환() {
         // given
         sut = .divide
         
-        // when
-        let result = sut.calculate(lhs: 4.0, rhs: 0.0)
-        var value = Double.nan
-        var error: CalculatorError? = nil
-        
-        switch result {
-        case .success(let newValue):
-            value = newValue
-        case .failure(let newError):
-            error = newError
-        }
-        
         // then
-        XCTAssertEqual(error, CalculatorError.dividedByZero)
+        XCTAssertThrowsError(try sut.calculate(lhs: 4.0, rhs: 0.0)) { error in
+            XCTAssertEqual(error as! CalculatorError, CalculatorError.dividedByZero)
+        }
     }
     
     func test_calculate에_4와2를_넣고_곱해줬을때_8반환() {
@@ -105,18 +68,9 @@ class OperatorTests: XCTestCase {
         sut = .multiply
         
         // when
-        let result = sut.calculate(lhs: 4.0, rhs: 2.0)
-        var value = Double.nan
-        var error: CalculatorError? = nil
-        
-        switch result {
-        case .success(let newValue):
-            value = newValue
-        case .failure(let newError):
-            error = newError
-        }
+        let result = try? sut.calculate(lhs: 4.0, rhs: 2.0)
         
         // then
-        XCTAssertEqual(value, 8.0)
+        XCTAssertEqual(result, 8.0)
     }
 }

--- a/Calculator/OperatorTests/OperatorTests.swift
+++ b/Calculator/OperatorTests/OperatorTests.swift
@@ -26,9 +26,18 @@ class OperatorTests: XCTestCase {
     func test_calculate에_1과2를_넣고_더해줬을때_3반환() {
         // when
         let result = sut.calculate(lhs: 1.0, rhs: 2.0)
+        var value = Double.nan
+        var error: CalculatorError? = nil
+        
+        switch result {
+        case .success(let newValue):
+            value = newValue
+        case .failure(let newError):
+            error = newError
+        }
         
         // then
-        XCTAssertEqual(result, 3.0)
+        XCTAssertEqual(value, 3.0)
     }
     
     func test_calculate에_2와1을_넣고_빼줬을때_1반환() {
@@ -37,9 +46,18 @@ class OperatorTests: XCTestCase {
         
         // when
         let result = sut.calculate(lhs: 2.0, rhs: 1.0)
+        var value = Double.nan
+        var error: CalculatorError? = nil
+        
+        switch result {
+        case .success(let newValue):
+            value = newValue
+        case .failure(let newError):
+            error = newError
+        }
         
         // then
-        XCTAssertEqual(result, 1.0)
+        XCTAssertEqual(value, 1.0)
     }
     
     func test_calculate에_4와2를_넣고_나누어줬을때_2반환() {
@@ -48,20 +66,38 @@ class OperatorTests: XCTestCase {
         
         // when
         let result = sut.calculate(lhs: 4.0, rhs: 2.0)
+        var value = Double.nan
+        var error: CalculatorError? = nil
+        
+        switch result {
+        case .success(let newValue):
+            value = newValue
+        case .failure(let newError):
+            error = newError
+        }
         
         // then
-        XCTAssertEqual(result, 2.0)
+        XCTAssertEqual(value, 2.0)
     }
     
-    func test_calculate에서_0으로나눌경우_오류와함께_나누기이전수를_반환() {
+    func test_calculate에서_0으로나눌경우_dividedByZero_오류반환() {
         // given
         sut = .divide
         
         // when
         let result = sut.calculate(lhs: 4.0, rhs: 0.0)
+        var value = Double.nan
+        var error: CalculatorError? = nil
+        
+        switch result {
+        case .success(let newValue):
+            value = newValue
+        case .failure(let newError):
+            error = newError
+        }
         
         // then
-        XCTAssertEqual(result, 4.0)
+        XCTAssertEqual(error, CalculatorError.dividedByZero)
     }
     
     func test_calculate에_4와2를_넣고_곱해줬을때_8반환() {
@@ -70,8 +106,17 @@ class OperatorTests: XCTestCase {
         
         // when
         let result = sut.calculate(lhs: 4.0, rhs: 2.0)
+        var value = Double.nan
+        var error: CalculatorError? = nil
+        
+        switch result {
+        case .success(let newValue):
+            value = newValue
+        case .failure(let newError):
+            error = newError
+        }
         
         // then
-        XCTAssertEqual(result, 8.0)
+        XCTAssertEqual(value, 8.0)
     }
 }

--- a/Calculator/OperatorTests/OperatorTests.swift
+++ b/Calculator/OperatorTests/OperatorTests.swift
@@ -53,6 +53,17 @@ class OperatorTests: XCTestCase {
         XCTAssertEqual(result, 2.0)
     }
     
+    func test_calculate에서_0으로나눌경우_오류와함께_나누기이전수를_반환() {
+        // given
+        sut = .divide
+        
+        // when
+        let result = sut.calculate(lhs: 4.0, rhs: 0.0)
+        
+        // then
+        XCTAssertEqual(result, 4.0)
+    }
+    
     func test_calculate에_4와2를_넣고_곱해줬을때_8반환() {
         // given
         sut = .multiply


### PR DESCRIPTION
@protocorn93 안녕하세요 콘! 두 번째 PR입니다. 이번에도 잘 부탁드립니다.

### STEP 2 작업한 내용
* 사칙연산을 나타내는 `Operator` 타입을 구현했습니다.
* 사용자가 입력한 식을 나타내는 `Formula` 타입을 구현했습니다.
* 사용자의 입력을 받아서 `Formula`로 바꿔 주는 `ExpressionParser` 네임스페이스를 구현했습니다.

---

### STEP 2 고민한 점
* 기능 요구서에 주어진 UML의 해석이 전반적으로 어려웠습니다. 아직 UML에 대한 숙련도가 떨어질 뿐더러, 제 자신이 생각하고 짠 것이 아니기 때문에 주어진 요구사항을 어떻게 구현해야 할지에 대해 많이 고민했습니다.
* `ExpressionParser` 안의 `componentsByOperators`가 무슨 뜻인지 알아듣지 못해 처음에 어려움을 겪었습니다. 일단 연산자만 반환하는 거라고 받아들여서, 연산자만 반환했습니다.
    * 원래는 result 배열을 따로 만들고 연산자의 `allCases`에 대해 `forEach` 클로저 안에서 `result` 배열 안에 들어있는 개개의 케이스마다 연산자를 기준으로 분리해주고 flatten해주는 과정을 반복해서, 숫자와 연산자가 예쁘게 떨어져 있는 배열을 반환하고자 했으나, 클로저 안에서 `compactMap`을 불러올 수가 없었어서, 현재의 방향으로 선회했습니다.
    * 또한 해당 배열을 만들 수 있다 해도, 연산자를 판별할 수 있는 `isNumber`는 `Character`를 대상으로 하는 메서드라, 두 자리 이상의 수를 반환할 수 없다는 문제도 있었습니다. 이래저래 연산자만 반환하는 것이 맞다고 받아들였지만.. 꺼림칙함을 지울 수 없었습니다.
* 0으로 나눌 때, 큐에 더 이상 아이템이 없을 때 등 에러 핸들링을 해야 할 몇 가지 상황에 todo 주석을 달아 두었는데, 이는 함부로 뭘 추가하지 말라는 기능 요구서에서의 요구사항 때문입니다. 물론 에러 케이스를 분리하는 것은 좋다고 써 있지만, 그와는 별개로 새로운 타입의 지정이기 때문에, 이 문제를 저 자신이 인지하고 있는 상태에서 리뷰어와 대화를 나눠 보고 싶었습니다. 
    * 기본값을 0으로 지정한 이유는, 계산기라는 프로그램에서 기본값은 0으로 여겨지기 때문입니다. 다만 이 경우, 의도치 않게 0으로 나누는 문제가 발생할 수도 있어, 주시하고 있습니다.
* 케이스가 하나도 없는 `enum` 안에 메서드를 써 넣는다는 것은, `enum`을 온전히 네임스페이스로 쓴다는 것임을 알았습니다. 따라서 `static`을 붙여야 불러올 수 있었습니다.
* 개인적으로 시간에 쫓길 일이 있어서, 완전히 TDD를 적용하지 못 한 것이 아쉽습니다.

---

### STEP 2 조언을 얻고 싶은 점
* 기능요구서의 UML에 작성되어 있는 `split`함수의 구현 요구사항에 대한 이유가 궁금합니다.
    * 기존 `split`은 `String`을 반환하지 않으니까, 라고 하면 이해는 가지만, 그리고 요구서에 써 있는 대로 구현했지만, 구현한 것을 당장은 사용하지 않았습니다. `ExpressionParser` 안에서 사용한 `split`은 [여기](https://developer.apple.com/documentation/swift/string/2893447-split) 나온 `split`입니다.
    * `Operator`가 `CaseIterable`인 이유, `split`을 구현하게 한 이유, `componentsByOperators`가 `[String]`을 반환하는 이유 모두 연계되어 있다고 생각해서 그쪽 방향으로 짜 보려고 했지만, 아쉽게도 세 가지 간의 얼개를 분명하게 찾을 수가 없었습니다.
* `parse` 메서드 안에서, 타입 캐스팅을 하는 과정에서는 어쩔 수 없이 옵셔널이 발생하게 됩니다. 이 경우 `if let`을 통해 옵셔널을 해제해 주었는데, 이렇게 하는 것이 이 상황에서 맞는지, nil-coalescing operator를 통해서 기본값을 주는게 더 나았을지 궁금합니다. 
    * 일단 `operators`와 `operands`는 이미 작성한 로직을 통해 내부의 값을 보장할 수 있으므로 값이 들어가지 않을 일은 없다고 생각했지만, 절대라는 건 없다고 생각하니만큼, 기본값의 제공을 통해 일단 동작하게는 했어야 했을지 궁금합니다. 
    * 다만 기본값을 제공한다면, 비슷한 오류가 발생했을 때 사용자가 의도치 않은 값을 받아들게 되고, 그것은 잘못된 동작이라는 면에서 결국 대동소이하다는 생각이 들었습니다.

---
