### PR TITLE
계산기 [STEP 2-2] Judy

### DIFF
--- a/Calculator/Calculator/Model/CalculatorError.swift
+++ b/Calculator/Calculator/Model/CalculatorError.swift
@@ -1,4 +1,5 @@
 enum CalculatorError: Error {
     case devideByZero
     case emptyFormula
+    case wrongFormula
 }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -18,4 +18,10 @@ struct CalculatorItemQueue<Item: CalculatorItem> {
     
         return calculatorList.takeOut()
     }
+
+    init(list: [Item] = []) {
+        for item in list {
+            enqueue(item)
+        }
+    }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,29 +1,25 @@
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        var formula = Formula()
         let splitedInput = componentByOperators(from: input)
-       
-        splitedInput.compactMap { Double($0) }
-            .forEach { formula.operands.enqueue($0) }
+        let operands = splitedInput.compactMap { Double($0) }
+        let operators = splitedInput.filter { $0.count == 1 }.compactMap { Operator(rawValue: Character($0)) }
+        let operandQueue = CalculatorItemQueue<Double>.init(list: operands)
+        let operatorQueue = CalculatorItemQueue<Operator>.init(list: operators)
         
-        splitedInput.filter { $0.count == 1 }
-            .compactMap { Operator(rawValue: Character($0)) }
-            .forEach { formula.operators.enqueue($0) }
-        
-        return formula
+        return Formula(operands: operandQueue, operators: operatorQueue)
     }
     
     private static func componentByOperators(from input: String) -> [String] {
-       var doubledString: [[String]] = [[]]
+       var doubledString: [[String]] = []
        var result: [String] = [input]
         
         Operator.allCases.forEach { opr in
-            result.forEach {
-                doubledString.append($0.split(with: opr.symbol))
-            }
+           result.forEach {
+               doubledString.append($0.split(with: opr.symbol))
+           }
            result = doubledString.flatMap { $0 }
            doubledString.removeAll()
-       }
+        }
         
         return result
     }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -23,15 +23,13 @@ enum ExpressionParser {
     }
     
     private static func componentByOperators(from input: String) -> [String] {
-       var doubledString: [[String]] = []
-       var result: [String] = [input]
+        var result: [String] = [input]
         
         Operator.allCases.forEach { opr in
-           result.forEach {
-               doubledString.append($0.split(with: opr.symbol))
-           }
-           result = doubledString.flatMap { $0 }
-           doubledString.removeAll()
+            let doubledString = result.reduce(into: [] ) {
+                $0.append($1.split(with: opr.symbol))
+            }
+            result = doubledString.flatMap { $0 }
         }
         
         return result

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -4,7 +4,7 @@ enum ExpressionParser {
         let splitedInput = componentByOperators(from: input)
 
         for index in 0...splitedInput.count/2 {
-            guard Int(splitedInput[index*2]) != nil else {
+            guard Double(splitedInput[index*2]) != nil else {
                 throw CalculatorError.wrongFormula
             }
         }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,8 +1,21 @@
+import CoreGraphics
 enum ExpressionParser {
-    static func parse(from input: String) -> Formula {
+    static func parse(from input: String) throws -> Formula {
         let splitedInput = componentByOperators(from: input)
+
+        for index in 0...splitedInput.count/2 {
+            guard Int(splitedInput[index*2]) != nil else {
+                throw CalculatorError.wrongFormula
+            }
+        }
+                
         let operands = splitedInput.compactMap { Double($0) }
         let operators = splitedInput.filter { $0.count == 1 }.compactMap { Operator(rawValue: Character($0)) }
+        
+        guard operands.count * operators.count != 0 else {
+            throw CalculatorError.wrongFormula
+        }
+                
         let operandQueue = CalculatorItemQueue<Double>.init(list: operands)
         let operatorQueue = CalculatorItemQueue<Operator>.init(list: operators)
         

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,6 +1,6 @@
 struct Formula {
-    var operands = CalculatorItemQueue<Double>()
-    var operators = CalculatorItemQueue<Operator>()
+    private(set) var operands: CalculatorItemQueue<Double>
+    private(set) var operators: CalculatorItemQueue<Operator>
     
     mutating func result() throws -> Double {
         guard !operators.isEmpty || !operators.isEmpty else { throw CalculatorError.emptyFormula }
@@ -14,5 +14,10 @@ struct Formula {
         }
         
         return calculateResult
+    }
+    
+    init( operands: CalculatorItemQueue<Double>,  operators: CalculatorItemQueue<Operator>) {
+        self.operands = operands
+        self.operators = operators
     }
 }

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -8,8 +8,7 @@ class ExpressionParserTests: XCTestCase {
         let expectation: [Double] = [11, 244, 3]
         
         // when
-        let formula = ExpressionParser.parse(from: input)
-        let result = formula.operands.calculatorItems
+        let result = try? ExpressionParser.parse(from: input).operands.calculatorItems
         
         // then
         XCTAssertEqual(result, expectation)
@@ -21,59 +20,41 @@ class ExpressionParserTests: XCTestCase {
         let expectation: [Operator] = [.multiply, .divide]
         
         // when
-        let formula = ExpressionParser.parse(from: input)
-        let result = formula.operators.calculatorItems
+        let result = try? ExpressionParser.parse(from: input).operators.calculatorItems
         
         // then
         XCTAssertEqual(result, expectation)
     }
     
-    func test_parse_숫자와기호가무작위로들어왔을때_연산자를분리하는지() {
+    func test_parse_숫자와기호가무작위로들어왔을때_에러를반환하는지() {
         // givwn
         let input = "2*+2857//24-"
-        let expectation: [Operator] = [.multiply, .add, .divide, .divide, .subtract]
-        
+
         // when
-        let formula = ExpressionParser.parse(from: input)
-        let result = formula.operators.calculatorItems
+        let result = try? ExpressionParser.parse(from: input)
         
         // then
-        XCTAssertEqual(result, expectation)
+        XCTAssertNil(result)
     }
     
-    func test_parse_숫자와기호가무작위로들어왔을때_피연산자를분리하는지() {
-        // givwn
-        let input = "2*+2857//24-3"
-        let expectation: [Double] = [2, 2857, 24, 3]
-        
-        // when
-        let formula = ExpressionParser.parse(from: input)
-        let result = formula.operands.calculatorItems
-        
-        // then
-        XCTAssertEqual(result, expectation)
-    }
     
-    func test_parse_연산자만들어있을때_연산자만분리되어들어가는지() {
-        // givwn
-        let input = "*+//-"
-        let expectation: [Operator] = [.multiply, .add, .divide, .divide, .subtract]
-        
-        // when
-        let formula = ExpressionParser.parse(from: input)
-        let result = formula.operators.calculatorItems
-        
-        // then
-        XCTAssertEqual(result, expectation)
-    }
-    
-    func test_parse_연산자만들어있을때_피연산자큐는nil인지() {
+    func test_parse_연산자만들어있을때_에러를반환하는지() {
         // givwn
         let input = "*+//-"
 
         // when
-        let formula = ExpressionParser.parse(from: input)
-        let result = formula.operands.calculatorItems
+        let result = try? ExpressionParser.parse(from: input)
+        
+        // then
+        XCTAssertNil(result)
+    }
+    
+    func test_parse_피연산자만들어있을때_에러를반환하는지() {
+        // givwn
+        let input = "123456"
+
+        // when
+        let result = try? ExpressionParser.parse(from: input)
         
         // then
         XCTAssertNil(result)

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -2,15 +2,6 @@ import XCTest
 @testable import Calculator
 
 class ExpressionParserTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-    }
-
-    override func tearDownWithError() throws {
-        try super.tearDownWithError()
-    }
-    
     func test_parse_formula의operands에123만들어가는지() {
         // givwn
         let input = "11+244-3"

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -2,39 +2,26 @@ import XCTest
 @testable import Calculator
 
 class FormulaTests: XCTestCase {
-    var sut: Formula!
-    
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        sut = Formula()
-    }
-
-    override func tearDownWithError() throws {
-        try super.tearDownWithError()
-        sut = nil
-    }
-    
     func test_result_1더하기2곱하기3빼기4는5가나오는지() {
         // given
+        let operands = CalculatorItemQueue<Double>.init(list: [1, 2, 3, 4])
+        let operators = CalculatorItemQueue<Operator>.init(list: [Operator.add, Operator.multiply, Operator.subtract])
+        var formula = Formula(operands: operands, operators: operators)
         let expectation: Double = 5
         
         // when
-        sut.operands.enqueue(1)
-        sut.operators.enqueue(.add)
-        sut.operands.enqueue(2)
-        sut.operators.enqueue(.multiply)
-        sut.operands.enqueue(3)
-        sut.operators.enqueue(.subtract)
-        sut.operands.enqueue(4)
-        let result = try? sut.result()
+        let result = try? formula.result()
         
         // then
         XCTAssertEqual(result, expectation)
     }
     
     func test_result_비어있는formula면에러를보내는지() {
+        // given
+        var formula = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
+        
         // when
-        let result = try? sut.result()
+        let result = try? formula.result()
         
         // then
         XCTAssertNil(result)


### PR DESCRIPTION
안녕하세요 제이슨(@ehgud0670) 🤗
계산기 STEP 2에서 추가적으로 리팩토링한 부분만 따로 PR 보냅니다!
세세하게 신경써주셔서 감사합니다 😊 잘부탁드려요!

## <br>Formula에 init 생성
**Formula**에 `init` 생성해 연산자 큐와 피연산자 큐를 받아 초기화하도록 했습니다. 큐를 초기화해서 `init`의 파라미터로 넣어줄 수 있도록 **CalculatorItemQueue**에도 `init`을 추가했습니다.
**Formula**를 `init`으로 생성하게 되어 **ExpressionParser**의 `parse` 역시 **Formula** 인스턴스를 생성해 큐에 직접 `enqueue` 하는 방식이 아닌 큐를 만들어 초기화한 **Formula**를 반환하는 방식으로 변경했습니다.

## <br>ExpressionParser 무작위 입력값에 대한 에러
입력값으로 연산자와 피연산자 무작위로 들어왔을 때 에러를 던지도록 **CalculatorError**에 `wrongFormula` 에러를 추가했습니다. `componentByOperators`에서 분리한 input의 짝수 번째 인덱스가 Double로 형변환 가능한지 검사해서 에러를 던지도록 했습니다.
```swift
for index in 0...splitedInput.count/2 {
    guard Double(splitedInput[index*2]) != nil else {
        throw CalculatorError.wrongFormula
    }
}
```

동작은 잘하지만 `for`문 안에 `guard`가 있는게 조금 걸리긴합니다.. 괜찮을까요?

```swift
guard operands.count * operators.count != 0 else {
    throw CalculatorError.wrongFormula
}
```
그리고 위 검사로만으로는 숫자만 들어있는 입력을 잡아낼 수가 없어서 분리한 연산자와 피연산자 배열의 `count`가 0이상인지 한 번 더 검사를 진행합니다. 한 번의 검사를 통해 에러를 던질 수 있으면 좋겠는데 다른 검사 방법이 있을지, 아니면 두 번 하는 방법도 괜찮을지 궁금합니다!

## <br> componentByOperators 사이드 이펙트 제거
```swift
Operator.allCases.forEach { opr in
    let doubledString = result.reduce(into: [] ) {
        $0.append($1.split(with: opr.symbol))
    }
    result = doubledString.flatMap { $0 }
}
```
사이드 이펙트가 말씀해주신 대로 함수 밖에 있는 변수를 변화시키는 것으로 생각하여 `reduce`를 이용해 doubledString 배열도 `forEach` 내부에서 생성하고 변경하도록 했습니다. 제이슨은 `reduce`를 두 번 사용하셨다고 했는데 제가 다른 방식으로 생각한걸까요? 🤔 