### PR TITLE
계산기 [STEP 3] 수꿍

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		20ABBDAE2832563F003675B9 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20ABBDAD2832563F003675B9 /* CalculateItem.swift */; };
 		20ABBDBE28325EB8003675B9 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20ABBDB528325A18003675B9 /* QueueTests.swift */; };
+		20B60AF92840787E00FA0D4F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
 		20EB974128360B2E00FD5E0D /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EB974028360B2E00FD5E0D /* Operator.swift */; };
 		20EB974328360BEF00FD5E0D /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EB974228360BEF00FD5E0D /* Double.swift */; };
 		20EB974528360C4C00FD5E0D /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EB974428360C4C00FD5E0D /* String.swift */; };
@@ -29,7 +30,6 @@
 		20F2630A2834B719009AD595 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F263082834B671009AD595 /* Queue.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
-		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
@@ -344,8 +344,8 @@
 				20EB974328360BEF00FD5E0D /* Double.swift in Sources */,
 				20EB974528360C4C00FD5E0D /* String.swift in Sources */,
 				20F263072834B63E009AD595 /* CalculatorItemQueue.swift in Sources */,
-				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				20EB974128360B2E00FD5E0D /* Operator.swift in Sources */,
+				20B60AF92840787E00FA0D4F /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				20EB974B2836526100FD5E0D /* CalculatorError.swift in Sources */,
 				20EB974728360D9300FD5E0D /* Formula.swift in Sources */,

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -16,4 +16,22 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         
     }
+    @IBAction func touchNumberButton(_ sender: UIButton) {
+    }
+    
+    @IBAction func touchOperatorButton(_ sender: UIButton) {
+    }
+    
+    @IBAction func touchResultButton(_ sender: UIButton) {
+    }
+    
+    @IBAction func touchAllClearButton(_ sender: UIButton) {
+    }
+    
+    @IBAction func touchClearEntryButton(_ sender: UIButton) {
+    }
+    
+    @IBAction func touchSignChangerButton(_ sender: UIButton) {
+    }
+    
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -132,6 +132,21 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchSignChangerButton(_ sender: UIButton) {
+        guard let convertedNumberInput = convertNumberInput() else {
+            return
+        }
+        
+        guard convertedNumberInput != 0 else {
+            return
+        }
+        
+        numberInput.text = String(-convertedNumberInput)
+        
+        guard let calculationResult = convertNumberInput() else {
+            return
+        }
+        
+        formatCalculatorItems(number: calculationResult)
     }
     
     func resetNumberInput() {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -23,6 +23,42 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchNumberButton(_ sender: UIButton) {
+        guard lastInput.arrangedSubviews.count <= 0 || operatorInput.text != "" else {
+            clearLastInput()
+            
+            numberInput.text = sender.currentTitle
+            return
+        }
+        
+        let digit = sender.currentTitle
+        
+        guard var text = numberInput.text else {
+            return
+        }
+        
+        guard digit != "." || text.filter({ $0 == "." }).count < 1 else {
+            return
+        }
+        
+        guard let unwrappedDigit: String = digit else {
+            return
+        }
+            
+        text += unwrappedDigit
+        numberInput.text = text
+
+        
+//        guard text.contains(".") == false else {
+//            return
+//        }
+        
+        let trimmedResultLabel = text.replacingOccurrences(of: ",", with: "")
+        
+        guard let trimmedResultLabelToDouble = Double(trimmedResultLabel) else {
+            return
+        }
+        
+        numberInput.text = String(trimmedResultLabelToDouble)
     }
     
     @IBAction func touchOperatorButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -76,6 +76,7 @@ class ViewController: UIViewController {
             clearLastInput()
         }
         
+        addCalculatorItems()
         operatorInput.text = sender.currentTitle
         resetNumberInput()
     }
@@ -142,5 +143,42 @@ class ViewController: UIViewController {
         }
         
         numberInput.text = formattedResult
+    }
+    
+    func addCalculatorItems() {
+        guard let result = convertNumberInput() else {
+            return
+        }
+        formatCalculatorItems(number: result)
+        
+        let label = UILabel()
+        label.text = numberInput.text
+        label.numberOfLines = 0
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.adjustsFontForContentSizeCategory = true
+        
+        guard let `operator` = operatorInput.text else {
+            return
+        }
+        
+        guard let number = numberInput.text else {
+            return
+        }
+        
+        label.text = `operator` + " " + number
+        
+        let newInput = UIStackView(arrangedSubviews: [label])
+        
+        lastInput.addArrangedSubview(newInput)
+        
+        guard let labelText = label.text else {
+            return
+        }
+        
+        let whitespacesRemovedInput = labelText.replacingOccurrences(of: " ", with: "")
+        let commaRemovedInput = whitespacesRemovedInput.replacingOccurrences(of: ",", with: "")
+        
+        totalInput += commaRemovedInput
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -170,10 +170,12 @@ class ViewController: UIViewController {
     }
     
     private func convertNumberInput() -> Double? {
-        guard let onceTrimmmedInput = removeComma() else {
+        guard let text = numberInput.text else {
             return nil
         }
         
+        let onceTrimmmedInput = removeComma(text)
+
         guard let twiceTrimmedInput = convertStringToDouble(onceTrimmmedInput) else {
             return nil
         }
@@ -181,12 +183,12 @@ class ViewController: UIViewController {
         return twiceTrimmedInput
     }
     
-    private func removeComma() -> String? {
-        guard let text = numberInput.text else {
-            return nil
-        }
-        
-        let trimmedInput = text.replacingOccurrences(of: ",", with: "")
+    private func removeComma(_ input: String) -> String {
+//        guard let text = numberInput.text else {
+//            return nil
+//        }
+//
+        let trimmedInput = input.replacingOccurrences(of: ",", with: "")
         
         return trimmedInput
     }
@@ -247,9 +249,20 @@ class ViewController: UIViewController {
             return
         }
         
-        let firstTrimmedInput = labelText.replacingOccurrences(of: " ", with: "")
-        let secondTrimmedInput = firstTrimmedInput.replacingOccurrences(of: ",", with: "")
+        addTrimmedInputToTotalInput(labelText)
+    }
+    
+    private func addTrimmedInputToTotalInput(_ input: String) {
+        let firstTrimmedInput = removeWhitespaces(input)
+        let secondTrimmedInput = removeComma(firstTrimmedInput)
+        
         totalInput += secondTrimmedInput
+    }
+    
+    private func removeWhitespaces(_ input: String) -> String {
+        let trimmedInput = input.replacingOccurrences(of: " ", with: "")
+        
+        return trimmedInput
     }
     
     private func goToBottomOfScrollView() {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -95,26 +95,30 @@ class ViewController: UIViewController {
         do {
             let calculationResult = try formula.result()
             applyNumberFormatter(calculationResult)
-        } catch (let error) {
-            switch error {
-            case CalculatorError.dividedByZero:
-                numberInput.text = CalculatorError.dividedByZero.localizedDescription
-            case CalculatorError.notEnoughOperands:
-                numberInput.text = CalculatorError.notEnoughOperands.localizedDescription
-            case CalculatorError.notEnoughOperators:
-                numberInput.text = CalculatorError.notEnoughOperators.localizedDescription
-            case CalculatorError.emptyQueues:
-                numberInput.text = CalculatorError.emptyQueues.localizedDescription
-            case CalculatorError.invalidOperator:
-                numberInput.text = CalculatorError.invalidOperator.localizedDescription
-            default:
-                numberInput.text = "unknown error"
-            }
+        } catch (let calculationError) {
+            handleError(calculationError)
         }
         
         resetOperatorInput()
         resetTotalInput()
         goToBottomOfScrollView()
+    }
+    
+    func handleError(_ error: Error) {
+        switch error {
+        case CalculatorError.dividedByZero:
+            numberInput.text = CalculatorError.dividedByZero.localizedDescription
+        case CalculatorError.notEnoughOperands:
+            numberInput.text = CalculatorError.notEnoughOperands.localizedDescription
+        case CalculatorError.notEnoughOperators:
+            numberInput.text = CalculatorError.notEnoughOperators.localizedDescription
+        case CalculatorError.emptyQueues:
+            numberInput.text = CalculatorError.emptyQueues.localizedDescription
+        case CalculatorError.invalidOperator:
+            numberInput.text = CalculatorError.invalidOperator.localizedDescription
+        default:
+            numberInput.text = "unknown error"
+        }
     }
     
     @IBAction private func allClearButtonDidTapped(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -12,6 +12,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var lastInput: UIStackView!
     
+    private var totalInput: String = ""
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -48,17 +48,15 @@ class ViewController: UIViewController {
         numberInput.text = text
 
         
-//        guard text.contains(".") == false else {
-//            return
-//        }
-        
-        let trimmedResultLabel = text.replacingOccurrences(of: ",", with: "")
-        
-        guard let trimmedResultLabelToDouble = Double(trimmedResultLabel) else {
+        guard text.contains(".") == false else {
             return
         }
         
-        numberInput.text = String(trimmedResultLabelToDouble)
+        guard let convertedNumberInput = convertNumberInput() else {
+            return
+        }
+        
+        formatCalculatorItems(number: convertedNumberInput)
     }
     
     @IBAction func touchOperatorButton(_ sender: UIButton) {
@@ -97,5 +95,34 @@ class ViewController: UIViewController {
             lastInput.removeArrangedSubview(lastView)
             lastView.removeFromSuperview()
         }
+    }
+    
+    func convertNumberInput() -> Double? {
+        guard let text = numberInput.text else {
+            return nil
+        }
+        
+        let trimmedNumberInput = text.replacingOccurrences(of: ",", with: "")
+        
+        guard let trimmedNumberInputToDouble = Double(trimmedNumberInput) else {
+            return nil
+        }
+        
+        return trimmedNumberInputToDouble
+    }
+    
+    func formatCalculatorItems(number: Double) {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.minimumIntegerDigits = 1
+        numberFormatter.minimumFractionDigits = 0
+        numberFormatter.maximumFractionDigits = 20
+        numberFormatter.maximumIntegerDigits = 20
+        
+        guard let formattedResult = numberFormatter.string(from: number as NSNumber) else {
+            return
+        }
+        
+        numberInput.text = formattedResult
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -17,6 +17,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         resetNumberInput()
+        resetOperatorInput()
         
     }
     @IBAction func touchNumberButton(_ sender: UIButton) {
@@ -39,5 +40,9 @@ class ViewController: UIViewController {
     
     func resetNumberInput() {
         numberInput.text = "0"
+    }
+    
+    func resetOperatorInput() {
+        operatorInput.text = ""
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -162,14 +162,7 @@ class ViewController: UIViewController {
     }
     
     func clearLastInput() {
-        while lastInput.arrangedSubviews.count > 0 {
-            guard let lastView = lastInput.arrangedSubviews.last else {
-                return
-            }
-
-            lastInput.removeArrangedSubview(lastView)
-            lastView.removeFromSuperview()
-        }
+        lastInput.subviews.forEach { $0.removeFromSuperview() }
     }
     
     func convertNumberInput() -> Double? {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -79,6 +79,7 @@ class ViewController: UIViewController {
         addCalculatorItems()
         operatorInput.text = sender.currentTitle
         resetNumberInput()
+        goToBottomOfScrollView()
     }
     
     @IBAction func touchResultButton(_ sender: UIButton) {
@@ -111,6 +112,7 @@ class ViewController: UIViewController {
         }
         
         resetOperatorInput()
+        goToBottomOfScrollView()
         resetNumberInput()
     }
     
@@ -210,5 +212,11 @@ class ViewController: UIViewController {
         let commaRemovedInput = whitespacesRemovedInput.replacingOccurrences(of: ",", with: "")
         
         totalInput += commaRemovedInput
+    }
+    
+    func goToBottomOfScrollView() {
+        scrollView.setContentOffset(CGPoint(x: 0,
+                                            y: scrollView.contentSize.height - scrollView.bounds.height),
+                                    animated: true)
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -18,8 +18,9 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         resetNumberInput()
         resetOperatorInput()
-        
+        resetTotalInput()
     }
+    
     @IBAction func touchNumberButton(_ sender: UIButton) {
     }
     
@@ -44,5 +45,9 @@ class ViewController: UIViewController {
     
     func resetOperatorInput() {
         operatorInput.text = ""
+    }
+    
+    func resetTotalInput() {
+        totalInput = ""
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -16,10 +16,10 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        clearLastInput()
         resetNumberInput()
         resetOperatorInput()
         resetTotalInput()
-        clearLastInput()
     }
     
     @IBAction func touchNumberButton(_ sender: UIButton) {
@@ -56,7 +56,7 @@ class ViewController: UIViewController {
             return
         }
         
-        applyNumberFormatter(number: convertedNumberInput)
+        applyNumberFormatter(convertedNumberInput)
     }
     
     @IBAction func touchOperatorButton(_ sender: UIButton) {
@@ -69,6 +69,7 @@ class ViewController: UIViewController {
         }
         
         guard Double(text) != 0.0 else {
+            operatorInput.text = sender.currentTitle
             return
         }
         
@@ -93,7 +94,7 @@ class ViewController: UIViewController {
         
         do {
             let calculationResult = try formula.result()
-            applyNumberFormatter(number: calculationResult)
+            applyNumberFormatter(calculationResult)
         } catch (let error) {
             switch error {
             case CalculatorError.dividedByZero:
@@ -112,8 +113,8 @@ class ViewController: UIViewController {
         }
         
         resetOperatorInput()
-        goToBottomOfScrollView()
         resetTotalInput()
+        goToBottomOfScrollView()
     }
     
     @IBAction func touchAllClearButton(_ sender: UIButton) {
@@ -136,19 +137,17 @@ class ViewController: UIViewController {
             return
         }
         
-        applyNumberFormatter(number: convertedNumberInput)
-        
         guard convertedNumberInput != 0 else {
             return
         }
         
         numberInput.text = String(-convertedNumberInput)
         
-        guard let calculationResult = convertNumberInput() else {
+        guard let newConvertedNumberInput = convertNumberInput() else {
             return
         }
         
-        applyNumberFormatter(number: calculationResult)
+        applyNumberFormatter(newConvertedNumberInput)
     }
     
     func resetNumberInput() {
@@ -197,7 +196,7 @@ class ViewController: UIViewController {
         return trimmedInput
     }
     
-    func applyNumberFormatter(number: Double) {
+    func applyNumberFormatter(_ number : Double) {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumIntegerDigits = 1
@@ -213,18 +212,11 @@ class ViewController: UIViewController {
     }
     
     func addCalculatorItems() {
-        guard let result = convertNumberInput() else {
+        guard let convertedNumberInput = convertNumberInput() else {
             return
         }
-        applyNumberFormatter(number: result)
         
-        let label = UILabel()
-        label.isHidden = true
-        label.text = numberInput.text
-        label.numberOfLines = 0
-        label.textColor = .white
-        label.font = UIFont.preferredFont(forTextStyle: .title3)
-        label.adjustsFontForContentSizeCategory = true
+        applyNumberFormatter(convertedNumberInput)
         
         guard let `operator` = operatorInput.text else {
             return
@@ -234,12 +226,16 @@ class ViewController: UIViewController {
             return
         }
         
+        let label = UILabel()
+        label.isHidden = true
         label.text = `operator` + " " + number
-        
+        label.numberOfLines = 0
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.adjustsFontForContentSizeCategory = true
         let newInput = UIStackView(arrangedSubviews: [label])
         
         lastInput.addArrangedSubview(newInput)
-        
         UIView.animate(withDuration: 0.0000001) {
             label.isHidden = false
         }
@@ -248,10 +244,9 @@ class ViewController: UIViewController {
             return
         }
         
-        let whitespacesRemovedInput = labelText.replacingOccurrences(of: " ", with: "")
-        let commaRemovedInput = whitespacesRemovedInput.replacingOccurrences(of: ",", with: "")
-        
-        totalInput += commaRemovedInput
+        let firstTrimmedInput = labelText.replacingOccurrences(of: " ", with: "")
+        let secondTrimmedInput = firstTrimmedInput.replacingOccurrences(of: ",", with: "")
+        totalInput += secondTrimmedInput
     }
     
     func goToBottomOfScrollView() {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -113,7 +113,7 @@ class ViewController: UIViewController {
         
         resetOperatorInput()
         goToBottomOfScrollView()
-        resetNumberInput()
+        resetTotalInput()
     }
     
     @IBAction func touchAllClearButton(_ sender: UIButton) {
@@ -188,6 +188,7 @@ class ViewController: UIViewController {
         formatCalculatorItems(number: result)
         
         let label = UILabel()
+        label.isHidden = true
         label.text = numberInput.text
         label.numberOfLines = 0
         label.textColor = .white
@@ -207,6 +208,10 @@ class ViewController: UIViewController {
         let newInput = UIStackView(arrangedSubviews: [label])
         
         lastInput.addArrangedSubview(newInput)
+        
+        UIView.animate(withDuration: 0.0000001) {
+            label.isHidden = false
+        }
         
         guard let labelText = label.text else {
             return

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -82,6 +82,36 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchResultButton(_ sender: UIButton) {
+        guard operatorInput.text != "" else {
+            return
+        }
+        
+        addCalculatorItems()
+        
+        var formula = ExpressionParser.parse(from: totalInput)
+        
+        do {
+            let calculationResult = try formula.result()
+            formatCalculatorItems(number: calculationResult)
+        } catch (let error) {
+            switch error {
+            case CalculatorError.dividedByZero:
+                numberInput.text = CalculatorError.dividedByZero.localizedDescription
+            case CalculatorError.notEnoughOperands:
+                numberInput.text = CalculatorError.notEnoughOperands.localizedDescription
+            case CalculatorError.notEnoughOperators:
+                numberInput.text = CalculatorError.notEnoughOperators.localizedDescription
+            case CalculatorError.emptyQueues:
+                numberInput.text = CalculatorError.emptyQueues.localizedDescription
+            case CalculatorError.invalidOperator:
+                numberInput.text = CalculatorError.invalidOperator.localizedDescription
+            default:
+                numberInput.text = "unknown error"
+            }
+        }
+        
+        resetOperatorInput()
+        resetNumberInput()
     }
     
     @IBAction func touchAllClearButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -19,6 +19,7 @@ class ViewController: UIViewController {
         resetNumberInput()
         resetOperatorInput()
         resetTotalInput()
+        clearLastInput()
     }
     
     @IBAction func touchNumberButton(_ sender: UIButton) {
@@ -49,5 +50,16 @@ class ViewController: UIViewController {
     
     func resetTotalInput() {
         totalInput = ""
+    }
+    
+    func clearLastInput() {
+        while lastInput.arrangedSubviews.count > 0 {
+            guard let lastView = lastInput.arrangedSubviews.last else {
+                return
+            }
+
+            lastInput.removeArrangedSubview(lastView)
+            lastView.removeFromSuperview()
+        }
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        resetnumberInput()
+        resetNumberInput()
         
     }
     @IBAction func touchNumberButton(_ sender: UIButton) {
@@ -37,7 +37,7 @@ class ViewController: UIViewController {
     @IBAction func touchSignChangerButton(_ sender: UIButton) {
     }
     
-    func resetnumberInput() {
+    func resetNumberInput() {
         numberInput.text = "0"
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -241,9 +241,6 @@ class ViewController: UIViewController {
         let newInput = UIStackView(arrangedSubviews: [label])
         
         lastInput.addArrangedSubview(newInput)
-        UIView.animate(withDuration: 0.0000001) {
-            label.isHidden = false
-        }
         
         guard let labelText = label.text else {
             return

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -16,6 +16,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        resetnumberInput()
         
     }
     @IBAction func touchNumberButton(_ sender: UIButton) {
@@ -36,4 +37,7 @@ class ViewController: UIViewController {
     @IBAction func touchSignChangerButton(_ sender: UIButton) {
     }
     
+    func resetnumberInput() {
+        numberInput.text = "0"
+    }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -56,7 +56,7 @@ class ViewController: UIViewController {
             return
         }
         
-        formatCalculatorItems(number: convertedNumberInput)
+        applyNumberFormatter(number: convertedNumberInput)
     }
     
     @IBAction func touchOperatorButton(_ sender: UIButton) {
@@ -93,7 +93,7 @@ class ViewController: UIViewController {
         
         do {
             let calculationResult = try formula.result()
-            formatCalculatorItems(number: calculationResult)
+            applyNumberFormatter(number: calculationResult)
         } catch (let error) {
             switch error {
             case CalculatorError.dividedByZero:
@@ -136,6 +136,8 @@ class ViewController: UIViewController {
             return
         }
         
+        applyNumberFormatter(number: convertedNumberInput)
+        
         guard convertedNumberInput != 0 else {
             return
         }
@@ -146,7 +148,7 @@ class ViewController: UIViewController {
             return
         }
         
-        formatCalculatorItems(number: calculationResult)
+        applyNumberFormatter(number: calculationResult)
     }
     
     func resetNumberInput() {
@@ -166,20 +168,36 @@ class ViewController: UIViewController {
     }
     
     func convertNumberInput() -> Double? {
+        guard let onceTrimmmedInput = removeComma() else {
+            return nil
+        }
+        
+        guard let twiceTrimmedInput = convertStringToDouble(onceTrimmmedInput) else {
+            return nil
+        }
+        
+        return twiceTrimmedInput
+    }
+    
+    func removeComma() -> String? {
         guard let text = numberInput.text else {
             return nil
         }
         
-        let trimmedNumberInput = text.replacingOccurrences(of: ",", with: "")
+        let trimmedInput = text.replacingOccurrences(of: ",", with: "")
         
-        guard let trimmedNumberInputToDouble = Double(trimmedNumberInput) else {
+        return trimmedInput
+    }
+    
+    func convertStringToDouble(_ input: String) -> Double? {
+        guard let trimmedInput = Double(input) else {
             return nil
         }
         
-        return trimmedNumberInputToDouble
+        return trimmedInput
     }
     
-    func formatCalculatorItems(number: Double) {
+    func applyNumberFormatter(number: Double) {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumIntegerDigits = 1
@@ -198,7 +216,7 @@ class ViewController: UIViewController {
         guard let result = convertNumberInput() else {
             return
         }
-        formatCalculatorItems(number: result)
+        applyNumberFormatter(number: result)
         
         let label = UILabel()
         label.isHidden = true

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -7,6 +7,10 @@
 import UIKit
 
 class ViewController: UIViewController {
+    @IBOutlet weak var numberInput: UILabel!
+    @IBOutlet weak var operatorInput: UILabel!
+    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet weak var lastInput: UIStackView!
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -184,10 +184,6 @@ class ViewController: UIViewController {
     }
     
     private func removeComma(_ input: String) -> String {
-//        guard let text = numberInput.text else {
-//            return nil
-//        }
-//
         let trimmedInput = input.replacingOccurrences(of: ",", with: "")
         
         return trimmedInput
@@ -223,38 +219,62 @@ class ViewController: UIViewController {
         
         applyNumberFormatter(convertedNumberInput)
         
+        let label = makeUILabel()
+        let newInput = UIStackView(arrangedSubviews: [label])
+
+        lastInput.addArrangedSubview(newInput)
+        
+        let labelText = unwrapLabelText(label)
+        let firstTrimmedInput = removeWhitespaces(labelText)
+        let secondTrimmedInput = removeComma(firstTrimmedInput)
+        totalInput += secondTrimmedInput
+    }
+    
+    private func unwrapLabelText(_ label: UILabel) -> String {
+        guard let labelText = label.text else {
+            return "비어있음"
+        }
+        
+        return labelText
+    }
+    
+    private func unwrapOperatorInput() -> String {
         guard let `operator` = operatorInput.text else {
-            return
+            return "비어있음"
         }
         
+        return `operator`
+    }
+    
+    private func unwrapNumberInput() -> String {
         guard let number = numberInput.text else {
-            return
+            return "비어있음"
         }
         
+        return number
+    }
+    
+    private func makeUILabel() -> UILabel {
+        let `operator` = unwrapOperatorInput()
+        let number = unwrapNumberInput()
         let label = UILabel()
-        label.isHidden = true
+        
+        label.isHidden = false
         label.text = `operator` + " " + number
         label.numberOfLines = 0
         label.textColor = .white
         label.font = UIFont.preferredFont(forTextStyle: .title3)
         label.adjustsFontForContentSizeCategory = true
-        let newInput = UIStackView(arrangedSubviews: [label])
         
-        lastInput.addArrangedSubview(newInput)
-        
-        guard let labelText = label.text else {
-            return
-        }
-        
-        addTrimmedInputToTotalInput(labelText)
+        return label
     }
     
-    private func addTrimmedInputToTotalInput(_ input: String) {
-        let firstTrimmedInput = removeWhitespaces(input)
-        let secondTrimmedInput = removeComma(firstTrimmedInput)
-        
-        totalInput += secondTrimmedInput
-    }
+//    private func addTrimmedInputToTotalInput(_ input: String) {
+//        let firstTrimmedInput = removeWhitespaces(input)
+//        let secondTrimmedInput = removeComma(firstTrimmedInput)
+//
+//        totalInput += secondTrimmedInput
+//    }
     
     private func removeWhitespaces(_ input: String) -> String {
         let trimmedInput = input.replacingOccurrences(of: " ", with: "")

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -127,9 +127,8 @@ class ViewController: UIViewController {
     @IBAction private func touchClearEntryButton(_ sender: UIButton) {
         resetNumberInput()
         
-        if totalInput == "" {
-            clearLastInput()
-        }
+        totalInput == "" ? clearLastInput() : ()
+        
     }
     
     @IBAction private func touchSignChangerButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -117,6 +117,10 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchAllClearButton(_ sender: UIButton) {
+        clearLastInput()
+        resetNumberInput()
+        resetOperatorInput()
+        resetTotalInput()
     }
     
     @IBAction func touchClearEntryButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -60,6 +60,24 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchOperatorButton(_ sender: UIButton) {
+        guard numberInput.text != "0" || lastInput.arrangedSubviews.count > 0 else {
+            return
+        }
+        
+        guard let text = numberInput.text else {
+            return
+        }
+        
+        guard Double(text) != 0.0 else {
+            return
+        }
+        
+        if operatorInput.text == "" && lastInput.arrangedSubviews.count > 0 {
+            clearLastInput()
+        }
+        
+        operatorInput.text = sender.currentTitle
+        resetNumberInput()
     }
     
     @IBAction func touchResultButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -124,6 +124,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchClearEntryButton(_ sender: UIButton) {
+        resetNumberInput()
+        
+        if totalInput == "" {
+            clearLastInput()
+        }
     }
     
     @IBAction func touchSignChangerButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -22,7 +22,7 @@ class ViewController: UIViewController {
         resetTotalInput()
     }
     
-    @IBAction private func touchNumberButton(_ sender: UIButton) {
+    @IBAction private func numberButtonDidTapped(_ sender: UIButton) {
         guard lastInput.arrangedSubviews.count <= 0 || operatorInput.text != "" else {
             clearLastInput()
             
@@ -59,7 +59,7 @@ class ViewController: UIViewController {
         applyNumberFormatter(convertedNumberInput)
     }
     
-    @IBAction private func touchOperatorButton(_ sender: UIButton) {
+    @IBAction private func operatorButtonDidTapped(_ sender: UIButton) {
         guard numberInput.text != "0" || lastInput.arrangedSubviews.count > 0 else {
             return
         }
@@ -83,7 +83,7 @@ class ViewController: UIViewController {
         goToBottomOfScrollView()
     }
     
-    @IBAction private func touchResultButton(_ sender: UIButton) {
+    @IBAction private func resultButtonDidTapped(_ sender: UIButton) {
         guard operatorInput.text != "" else {
             return
         }
@@ -117,21 +117,21 @@ class ViewController: UIViewController {
         goToBottomOfScrollView()
     }
     
-    @IBAction private func touchAllClearButton(_ sender: UIButton) {
+    @IBAction private func allClearButtonDidTapped(_ sender: UIButton) {
         clearLastInput()
         resetNumberInput()
         resetOperatorInput()
         resetTotalInput()
     }
     
-    @IBAction private func touchClearEntryButton(_ sender: UIButton) {
+    @IBAction private func clearEntryButtonDidTapped(_ sender: UIButton) {
         resetNumberInput()
         
         totalInput == "" ? clearLastInput() : ()
         
     }
     
-    @IBAction private func touchSignChangerButton(_ sender: UIButton) {
+    @IBAction private func signChangerButtonDidTapped(_ sender: UIButton) {
         guard let convertedNumberInput = convertNumberInput() else {
             return
         }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -238,7 +238,7 @@ class ViewController: UIViewController {
         guard let newCalculationItemsInput = makeUIStackView() else {
             return
         }
-
+        
         addStackView(newCalculationItemsInput)
     }
     
@@ -359,7 +359,7 @@ class ViewController: UIViewController {
         guard let formattedNumber = formatNumber(signChangedNumber) else {
             return
         }
-
+        
         setNumber(formattedNumber)
     }
     
@@ -371,11 +371,11 @@ class ViewController: UIViewController {
         guard let formattedNumber = formatNumberForBeingRecognizedAsNumber(number) else {
             return nil
         }
-
+        
         guard formattedNumber != 0 else {
             return nil
         }
-
+        
         let singChangedNumber = String(-formattedNumber)
         
         return singChangedNumber
@@ -397,7 +397,6 @@ class ViewController: UIViewController {
         lastInput.subviews.forEach { $0.removeFromSuperview() }
     }
     
-    
     private func removeWhitespaces(_ input: String) -> String {
         let trimmedInput = input.replacingOccurrences(of: " ", with: "")
         
@@ -405,6 +404,7 @@ class ViewController: UIViewController {
     }
     
     private func goToBottomOfScrollView() {
+        scrollView.layoutIfNeeded()
         scrollView.setContentOffset(CGPoint(x: 0,
                                             y: scrollView.contentSize.height - scrollView.bounds.height),
                                     animated: true)

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -31,7 +31,7 @@ class ViewController: UIViewController {
             return
         }
         
-        guard let formattedNumber = formatNumberForBeingRecognizedAsNumber(number) else {
+        guard let formattedNumber = formatNumber(number) else {
             return
         }
         
@@ -107,6 +107,18 @@ class ViewController: UIViewController {
         return numberInput.text
     }
     
+    private func formatNumber(_ number: String) -> String? {
+        guard let formattedNumber = formatNumberForBeingRecognizedAsNumber(number) else {
+            return nil
+        }
+        
+        guard let reFormattedNumber = formatNumberForExposure(formattedNumber) else {
+            return nil
+        }
+        
+        return reFormattedNumber
+    }
+    
     private func formatNumberForBeingRecognizedAsNumber(_ number: String) -> Double? {
         let onceTrimmmedInput = removeComma(number)
         
@@ -131,12 +143,8 @@ class ViewController: UIViewController {
         return trimmedInput
     }
     
-    private func setNumber(_ number : Double) {
-        guard let formattedNumber = formatNumberForExposure(number) else {
-            return
-        }
-        
-        numberInput.text = formattedNumber
+    private func setNumber(_ number : String) {
+        numberInput.text = number
     }
     
     private func formatNumberForExposure(_ number: Double) -> String? {
@@ -196,7 +204,11 @@ class ViewController: UIViewController {
         
         do {
             let calculationResult = try formula.result()
-            setNumber(calculationResult)
+            guard let result = formatNumberForExposure(calculationResult) else {
+                return
+            }
+            
+            setNumber(result)
         } catch (let calculationError) {
             handleError(calculationError)
         }
@@ -253,15 +265,15 @@ class ViewController: UIViewController {
         }
         
         // 부호 바꾸기
-        let text = String(-formattedNumber)
+        let singChangedNumber = String(-formattedNumber)
         
         // 변환 과정
-        guard let formattedText = formatNumberForBeingRecognizedAsNumber(text) else {
+        
+        guard let reformattedNumber = formatNumber(singChangedNumber) else {
             return
         }
-        
         // update
-        setNumber(formattedText)
+        setNumber(reformattedNumber)
     }
     
     private func resetNumberInput() {
@@ -287,7 +299,7 @@ class ViewController: UIViewController {
             return
         }
         
-        guard let formattedNumber = formatNumberForBeingRecognizedAsNumber(number) else {
+        guard let formattedNumber = formatNumber(number) else {
             return
         }
         

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -7,10 +7,10 @@
 import UIKit
 
 class ViewController: UIViewController {
-    @IBOutlet weak var numberInput: UILabel!
-    @IBOutlet weak var operatorInput: UILabel!
-    @IBOutlet weak var scrollView: UIScrollView!
-    @IBOutlet weak var lastInput: UIStackView!
+    @IBOutlet private weak var numberInput: UILabel!
+    @IBOutlet private weak var operatorInput: UILabel!
+    @IBOutlet private weak var scrollView: UIScrollView!
+    @IBOutlet private weak var lastInput: UIStackView!
     
     private var totalInput: String = ""
     
@@ -22,7 +22,7 @@ class ViewController: UIViewController {
         resetTotalInput()
     }
     
-    @IBAction func touchNumberButton(_ sender: UIButton) {
+    @IBAction private func touchNumberButton(_ sender: UIButton) {
         guard lastInput.arrangedSubviews.count <= 0 || operatorInput.text != "" else {
             clearLastInput()
             
@@ -59,7 +59,7 @@ class ViewController: UIViewController {
         applyNumberFormatter(convertedNumberInput)
     }
     
-    @IBAction func touchOperatorButton(_ sender: UIButton) {
+    @IBAction private func touchOperatorButton(_ sender: UIButton) {
         guard numberInput.text != "0" || lastInput.arrangedSubviews.count > 0 else {
             return
         }
@@ -83,7 +83,7 @@ class ViewController: UIViewController {
         goToBottomOfScrollView()
     }
     
-    @IBAction func touchResultButton(_ sender: UIButton) {
+    @IBAction private func touchResultButton(_ sender: UIButton) {
         guard operatorInput.text != "" else {
             return
         }
@@ -117,14 +117,14 @@ class ViewController: UIViewController {
         goToBottomOfScrollView()
     }
     
-    @IBAction func touchAllClearButton(_ sender: UIButton) {
+    @IBAction private func touchAllClearButton(_ sender: UIButton) {
         clearLastInput()
         resetNumberInput()
         resetOperatorInput()
         resetTotalInput()
     }
     
-    @IBAction func touchClearEntryButton(_ sender: UIButton) {
+    @IBAction private func touchClearEntryButton(_ sender: UIButton) {
         resetNumberInput()
         
         if totalInput == "" {
@@ -132,7 +132,7 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func touchSignChangerButton(_ sender: UIButton) {
+    @IBAction private func touchSignChangerButton(_ sender: UIButton) {
         guard let convertedNumberInput = convertNumberInput() else {
             return
         }
@@ -150,23 +150,23 @@ class ViewController: UIViewController {
         applyNumberFormatter(newConvertedNumberInput)
     }
     
-    func resetNumberInput() {
+    private func resetNumberInput() {
         numberInput.text = "0"
     }
     
-    func resetOperatorInput() {
+    private func resetOperatorInput() {
         operatorInput.text = ""
     }
     
-    func resetTotalInput() {
+    private func resetTotalInput() {
         totalInput = ""
     }
     
-    func clearLastInput() {
+    private func clearLastInput() {
         lastInput.subviews.forEach { $0.removeFromSuperview() }
     }
     
-    func convertNumberInput() -> Double? {
+    private func convertNumberInput() -> Double? {
         guard let onceTrimmmedInput = removeComma() else {
             return nil
         }
@@ -178,7 +178,7 @@ class ViewController: UIViewController {
         return twiceTrimmedInput
     }
     
-    func removeComma() -> String? {
+    private func removeComma() -> String? {
         guard let text = numberInput.text else {
             return nil
         }
@@ -188,7 +188,7 @@ class ViewController: UIViewController {
         return trimmedInput
     }
     
-    func convertStringToDouble(_ input: String) -> Double? {
+    private func convertStringToDouble(_ input: String) -> Double? {
         guard let trimmedInput = Double(input) else {
             return nil
         }
@@ -196,7 +196,7 @@ class ViewController: UIViewController {
         return trimmedInput
     }
     
-    func applyNumberFormatter(_ number : Double) {
+    private func applyNumberFormatter(_ number : Double) {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumIntegerDigits = 1
@@ -211,7 +211,7 @@ class ViewController: UIViewController {
         numberInput.text = formattedResult
     }
     
-    func addCalculatorItems() {
+    private func addCalculatorItems() {
         guard let convertedNumberInput = convertNumberInput() else {
             return
         }
@@ -249,7 +249,7 @@ class ViewController: UIViewController {
         totalInput += secondTrimmedInput
     }
     
-    func goToBottomOfScrollView() {
+    private func goToBottomOfScrollView() {
         scrollView.setContentOffset(CGPoint(x: 0,
                                             y: scrollView.contentSize.height - scrollView.bounds.height),
                                     animated: true)

--- a/Calculator/Calculator/Model/CalculatorError.swift
+++ b/Calculator/Calculator/Model/CalculatorError.swift
@@ -4,10 +4,29 @@
 //
 //  Created by 전민수 on 2022/05/19.
 //
+import Foundation
+
 enum CalculatorError: Error {
     case dividedByZero
     case emptyQueues
     case notEnoughOperators
     case notEnoughOperands
     case invalidOperator
+}
+
+extension CalculatorError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .dividedByZero:
+            return NSLocalizedString("NaN", comment: "Error: Divided By Zero")
+        case .emptyQueues:
+            return NSLocalizedString("empty queues", comment: "Error: Empty Queues")
+        case .notEnoughOperators:
+            return NSLocalizedString("not enough operators", comment: "Error: Not Enough Operators")
+        case .notEnoughOperands:
+            return NSLocalizedString("not enough operands", comment: "Error: Not Enough Operands")
+        case .invalidOperator:
+            return NSLocalizedString("invalid operator", comment: "Error: Invalid Operator")
+        }
+    }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -18,8 +18,28 @@ enum ExpressionParser {
     }
     
     private static func componentsByOperators(from input: String) -> [String] {
-        let operators = input.filter { $0.isNumber == false && $0 != "." && $0 != "-" }.map { String($0) }
+        let operators = input.filter { self.isOperator($0) }.map { String($0) }
         
         return operators
     }
+    
+    private static func isOperator(_ input: Character) -> Bool {
+        guard !self.isNumber(input) && !self.isNumberSymbol(input) else {
+            return false
+        }
+        
+        return true
+    }
+    
+    private static func isNumber(_ input: Character) -> Bool {
+        return input.isNumber
+    }
+    
+    private static func isNumberSymbol(_ input: Character) -> Bool {
+        let numberSymbolArray: [Character] = [".", "-"]
+        
+        return numberSymbolArray.contains(input)
+    }
+    
+    
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -6,25 +6,19 @@
 //
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        var operators = componentsByOperators(from: input)
-        var operands = input.split { operators.contains(String($0)) }.map { Double($0) ?? 0.0 }
+        let operators = componentsByOperators(from: input)
+        let operands = input.split { operators.contains(String($0)) }.map { Double($0) ?? 0.0 }
         var operatorsQueue = CalculatorItemQueue<String>()
         var operandsQueue = CalculatorItemQueue<Double>()
-        
-        if input.first == "-" {
-            operators.removeFirst()
-            operands[0] = -(operands[0])
-        }
 
         operators.forEach { operatorsQueue.queue.enqueue(element: $0) }
         operands.forEach { operandsQueue.queue.enqueue(element: $0) }
-        
         
         return Formula(operands: operandsQueue, operators: operatorsQueue)
     }
     
     private static func componentsByOperators(from input: String) -> [String] {
-        let operators = input.filter { $0.isNumber == false && $0 != "." }.map { String($0) }
+        let operators = input.filter { $0.isNumber == false && $0 != "." && $0 != "-" }.map { String($0) }
         
         return operators
     }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -6,9 +6,9 @@
 //
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
-    case subtract = "-"
-    case divide = "/"
-    case multiply = "*"
+    case subtract = "−"
+    case divide = "÷"
+    case multiply = "×"
     
     func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchAllClearButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6rd-lJ-9Nu"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -93,6 +96,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchClearEntryButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZNM-CS-Ylb"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -101,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchSignChangerButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4Rf-50-03j"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -109,6 +118,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="oZ8-kW-OKY"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -122,6 +134,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="80L-ee-fcV"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -130,6 +145,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="idJ-h3-ezk"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -138,6 +156,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Uup-yA-cSe"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -146,6 +167,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WTu-la-kQf"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -159,6 +183,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0Dx-sh-O6d"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -167,6 +194,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="J5s-Z6-poo"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -175,6 +205,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aNC-q6-mYr"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -183,6 +216,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9Qo-xp-n48"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -196,6 +232,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="g75-Ps-jSV"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -204,6 +243,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JEK-un-bPM"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -212,6 +254,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="j0f-yT-mEa"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -220,6 +265,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fPf-k6-fCF"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -233,6 +281,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6qo-EI-cFZ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -241,6 +292,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ANr-AU-7Gg"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -249,6 +303,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cZh-F9-OJj"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -260,6 +317,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchResultButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BSe-Ua-emX"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -86,7 +86,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchAllClearButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6rd-lJ-9Nu"/>
+                                                    <action selector="allClearButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Dp1-GL-6rw"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
@@ -97,7 +97,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchClearEntryButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZNM-CS-Ylb"/>
+                                                    <action selector="clearEntryButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bCE-sv-wvg"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
@@ -108,7 +108,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchSignChangerButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4Rf-50-03j"/>
+                                                    <action selector="signChangerButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="49J-8v-uga"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
@@ -119,7 +119,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="oZ8-kW-OKY"/>
+                                                    <action selector="operatorButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fpH-fX-blZ"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -135,7 +135,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="80L-ee-fcV"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="83v-7M-fY3"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
@@ -146,7 +146,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="idJ-h3-ezk"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1Az-aK-Hpc"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
@@ -157,7 +157,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Uup-yA-cSe"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="jmb-2s-TMH"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
@@ -168,7 +168,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WTu-la-kQf"/>
+                                                    <action selector="operatorButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CaE-3O-1hP"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -184,7 +184,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0Dx-sh-O6d"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LV1-aJ-31Y"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
@@ -195,7 +195,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="J5s-Z6-poo"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tkx-h9-uAH"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
@@ -206,7 +206,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aNC-q6-mYr"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hOJ-95-y4N"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
@@ -217,7 +217,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9Qo-xp-n48"/>
+                                                    <action selector="operatorButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9lz-Nc-g5V"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -233,7 +233,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="g75-Ps-jSV"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iHO-vS-5IK"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
@@ -244,7 +244,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JEK-un-bPM"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="X2x-Qe-n0l"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
@@ -255,7 +255,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="j0f-yT-mEa"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="w2Q-D1-1ZB"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
@@ -266,7 +266,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fPf-k6-fCF"/>
+                                                    <action selector="operatorButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="G5L-ft-PQW"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -282,7 +282,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6qo-EI-cFZ"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MJK-Lk-3CM"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
@@ -293,7 +293,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ANr-AU-7Gg"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ae3-2G-JUC"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
@@ -304,7 +304,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cZh-F9-OJj"/>
+                                                    <action selector="numberButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="if8-7H-Ina"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
@@ -318,7 +318,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchResultButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BSe-Ua-emX"/>
+                                                    <action selector="resultButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wlp-fS-txy"/>
                                                 </connections>
                                             </button>
                                         </subviews>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,22 +18,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -40,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -265,19 +266,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -302,6 +303,12 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="lastInput" destination="XRe-QE-UJf" id="bsG-na-Th7"/>
+                        <outlet property="numberInput" destination="Lwz-OF-XHD" id="g0d-M7-IxA"/>
+                        <outlet property="operatorInput" destination="HPC-iy-qdm" id="7px-cE-aYx"/>
+                        <outlet property="scrollView" destination="BOT-7g-vxv" id="3Ta-jm-bvX"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -33,7 +33,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_피연산수가_뺄셈을_정상적으로_계산하는지_테스트() throws {
         // given
-        let input = "1-2-3"
+        let input = "1−2−3"
         let expectation: Double = -4
         
         // when
@@ -46,7 +46,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_피연산수가_곱셈을_정상적으로_계산하는지_테스트() throws {
         // given
-        let input = "1*2*3"
+        let input = "1×2×3"
         let expectation: Double = 6
         
         // when
@@ -59,7 +59,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_피연산수가_나눗셈을_정상적으로_계산하는지_테스트() throws {
         // given
-        let input = "10/2/5"
+        let input = "10÷2÷5"
         let expectation: Double = 1
 
         // when
@@ -72,7 +72,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_복수의_연산자와_피연산수가_혼합되어_있는_문자열값을_정상적으로_계산하는지_테스트() throws {
         // given
-        let input = "10+2-3*4/6"
+        let input = "10+2−3×4÷6"
         let expectation: Double = 6
         
         // when
@@ -85,7 +85,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_0으로_나눌때_오류처리가_정상적으로_이루어져_NaN의_값을_반환하는지_테스트() throws {
         // given
-        let input = "100/0"
+        let input = "100÷0"
         
         // when
         var parser = ExpressionParser.parse(from: input)
@@ -125,7 +125,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_사칙연산자만으로_구성된_문자열이_입력될때_오류처리가_정상적으로_이루어지는지_테스트() throws {
         // given
-        let input = "+-*/"
+        let input = "+−×÷"
         
         // when
         var parser = ExpressionParser.parse(from: input)
@@ -151,7 +151,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_연산자와_피연산수가_올바른_순서를_따르지_않을때_오류처리가_정상적으로_이루어지는지_테스트() throws {
         // given
-        let input = "+-*1/123"
+        let input = "+−×1÷123"
         
         // when
         var parser = ExpressionParser.parse(from: input)
@@ -177,7 +177,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_소수점_아래_자리수가_큰_피연산수를_입력받았을때_정상적으로_값이_출력되는지_테스트() throws {
         // given
-        let input = "0.000001*0.000002"
+        let input = "0.000001×0.000002"
         let expectation = 0.000001 * 0.000002
        
         // when
@@ -190,7 +190,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_실수인_수가_있는_피연산수를_입력받았을때_정상적으로_값이_출력되는지_테스트() throws {
         // given
-        let input = "4.3+1/5*10.2"
+        let input = "4.3+1÷5×10.2"
         let expectation = ((4.3 + 1) / 5) * 10.2
        
         // when
@@ -203,7 +203,7 @@ class FormulaTests: XCTestCase {
     
     func test_result_음수로_시작하는_피연산수를_입력받았을때_정상적으로_값이_출력되는지_테스트() throws {
         // given
-        let input = "-4.3+1/5*10.2"
+        let input = "-4.3+1÷5×10.2"
         let expectation = ((-4.3 + 1) / 5) * 10.2
        
         // when


### PR DESCRIPTION
안녕하세요, 찰리!! @kcharliek 
미리 말씀드렸던 기한보다, 그리고 이렇게 늦은 시간에 계산기 프로젝트 STEP 3 PR을 드려 사과의 말씀을 전합니다.
STEP3의 기능들은 새로운 함수들보다는 실제 계산기는 어떻게 구현되어 있는지 자꾸 고민해보고,
고민한 기능들을 추가하는 데 있어 시행착오 과정이 생각보다 많은 시간을 잡아먹어 지연 제출하게 되었습니다.
현재 혼자 완성할 수 있는 범위 내에서는 최대한 노력해보았고, 이에 추가적으로 혼자 끙끙 앓기보다는
찰리와 함께 의견을 나누고 싶어 부족한 면이 많지만 PR 드립니다.
마지막 스텝도 잘 부탁드립니다!! 🙇‍♂️🙇

# [STEP 3]

## 고민한점 
### 1. 음수 계산

- 일반적인 계산기는 음수의 값이 입력받았을 때도, 이를 음수로 인식하여 문제없이 계산을 해나갑니다. 하지만, 계산기 프로젝트에서의 계산은 `Operator`열거형 구조의 `calculate` 메서드를 통해 진행됩니다. 여기서 `subtract` 케이스의 `rawValue`를 키보드에 있는 `-`로 입력하면, "1-(-1)"이라는 `input`에 대하여 `subtract` 케이스가 두 번 언급한 것으로 받아들여, 계산을 두 번 실행하고자 하고, 이는 곧 피연산수 부족으로 인하여 오류를 발생시킵니다.
- 이를 해결하기 위하여 처음에는 음수로 입력된 값이면, 일반적인 경우 피연산수의 개수보다 연산자의 개수가 크거나 같을 것이므로, 피연산수의 수가 연산자의 수보다 1개 더 많아질 때까지, 반복문을 실행시켜, 각각의 "+-", "/-", "*-", "--"의 경우에 맞는 동작을 구현해야할까 고민하였습니다.
- 하지만, 더욱 근본적인 측면에 집중한 결과, 빼기의 "-"와, 음수를 의미하는 "-"부호에 대하여 일반적으로는 같다고 생각하나, 컴퓨터에서는 이를 서로 다른 것으로 인식하게 한다면 위의 문제를 해결할 수 있었습니다. 스토리보드에 접근하여 마이너스 연산 버튼의 `currentTitle`을 확인한 결과, 키보드에 있는 "-" 부호와 서로 다르다는 것을 발견하였습니다. 이에 `Operator`열거형 구조의 `subtract` 케이스의 `rawValue`를 `currentTitle`과 같은 부호로 설정하고, 부호전환에 관하여서는 키보드에 있는 "-" 부호를 이용한 결과, 빼기와 음수를 컴퓨터에서 구분하여 인식이 가능해져 음수 연산이 정상적으로 작동하였습니다.

<br>

### 2. stackView 내 subview 삭제

- 메인 스토리 보드에 구현되어 있는 `stackView` 내 두 개의 `subView`를 코드를 통해 제거하고자 하였습니다. 이에 `removeArrangedSubview` 메서드를 통해 해당 뷰들을 제거하였습니다. 최초하면에는 이 서브뷰들이 보이지 않아 제거된 줄 알았으나, 사용자 입력값을 뷰에 올리게 될 때, 계산기 화면의 구석에서 다시 등장하는 것을 확인할 수 있었습니다. 이를 통해 해당 메서드로는 없어진 것처럼 보이나 사실은 없어진게 아닐까 의심을 하게 되었습니다. 이를 바탕으로 뷰 계층구조와 자료들을 검색해본 결과, `removeArrangedSubview` 메서드를 통해서는 배열에서 해당 뷰를 제거할 수는 있지만, 여전히 뷰의 `hierarchy`에는 남아있고, 심지어는 제거된 뷰들의 위치와 크기가 더 이상 스택 뷰에서 관리되지 않는다는 사실을 알 수 있었습니다.
- 그래서 해당 뷰들을 뷰의 `hierarchy`에도 남지 못하도록, 확실하게 제거하고자 `removeFromSuperview` 메서드를 실행하였고, 이를 해결할 수 있었습니다. 추가로, 애플 개발자 문서를 찾아보니 `removeFromSuperview` 메서드 이외에도 뷰의 `isHidden`속성을 `true`로 설정하면 같은 결과를 도출할 수 있음을 알게 되었습니다.
<br>

## 의문점

### 1. 함수 내 guard 문을 별도의 함수로 기능 분리

- `touchNumberButton` 메서드만 살펴보아도 `guard`문이 6개나 쓰였습니다. 물론 옵셔널 바인딩을 위하여 사용한 경우도 있지만, 조건을 설정해주기 위하여 guard문을 사용한 경우도 적지 않았습니다. 이에, 함수의 기능 분리를 위하여, 각각의 guard문을 `touchNumberButton` 내에서 분리하여 별도의 함수 내에 구현하고, 이를 호출만 하는 방식으로 `touchNumberButton` 메서드를 수정해보았습니다. 하지만, 이는 정상적으로 작동하지 않았습니다. 
- 이러한 실패 결과가 나타난 이유를 예를 들어 설명드리자면, 3개의 조건을 만족하였을 때 프로퍼티를 변경하는 `method`라는 함수를 구현해보았습니다. 아래와 같이 하나의 함수 내 3개의 guard문이 있고 값을 변경하는 코드가 존재할 때는 `condition1`을 충족한 이후, 이를 충족하는 상태에서 `condition2`에 접근하고, 또 이를 충족하면 `condition3`에 접근하여, 모두 충족할 시, 값을 변경하는 코드에 접근할 수 있게 됩니다.

```swift
func method() {
    guard condition1 else { return }
    guard condition2 else { return }
    guard condition3 else { return }
    
    someProperty = changedProperty
}
```
<br>

- 하지만 아래와 같이 각각의 `guard`문을 함수로 빼내어 이를 호출하는 방식으로 진행할 시, `firstGuard`문의 조건을 충족한다면, 첫번쨔 조건을 충족했다는 상태에서 `secondGuard()` 함수에 접근하는 것이 아니라, 조건을 충족한 상태가 만료된 채 두번째 `guard`문 함수에 접근하는 것으로 인식하였습니다. 즉, 3가지 조건을 충족한다 하여도, 값을 변경하는 코드에 접근하였을 때의 상태는 그 3가지 조건을 동시에 만족한 상태가 아닌 것입니다. 
```swift
func method() {
    firstGuard()
    secondGuard()
    thirdGuard()
    someProperty = changedProperty
}

func firstGuard() {
    guard condition1 else { return }
}

func secondGuard() {
    guard condition2 else { return }
}

func thirdGuard() {
    guard condition3 else { return }
}

```
<br>

- 이를 바탕으로, 저는 `guard`문을 함수 외부로 빼내기에는 어렵다고 판단이 되는데, 제가 이해한 작동 방식이 옳은 것인지, 그리고 이를 해결할 수 있는 방법이 무엇이 있을지 여쭈어보고 싶습니다.



<br>

### 2. stackView 내 subview로 Label 추가 시 애니메이션

![May-26-2022 20-51-04](https://user-images.githubusercontent.com/99063327/170482942-b1586a97-f5fb-4675-9003-28df8e00cbe7.gif)

- 계산기에서 입력한 지난 연산자와 피연산수는 입력 이후, 스크롤뷰 내 스택뷰에 쌓이는 방식으로 진행하고자 하였습니다. 이에 `Label`의 속성을 생략하면 다음과 같은 코드를 작성할 수 있었습니다.

```swift
private func clearLastInput() {
    lastInput.subviews.forEach { $0.removeFromSuperview() }
}

private func addCalculatorItems() {
	...
    let label = UILabel()
    label.isHidden = true
    lastInput.addArrangedSubview(label)
    UIView.animate(withDuration: 1) {
        label.isHidden = false
	}
	...
}
```
<br>

- 먼저, 스토리보드에서 확인할 수 있는 초기에 설정된 스택뷰를 `clearLastInput` 함수를 통하여 제거하고, 연산자 버튼이 터치될 때마다, 이전까지 입력된 피연산수와 연산자를 스택뷰에 추가하기 위하여, `addCalculatorItems` 함수 내 `addArrangedSubview` 함수를 사용하였습니다. 하지만 이를 작동한 결과는 위의 동적 이미지에서 확인하실 수 있듯이, 처음의 입력값은 왼쪽에서 오른쪽으로 이동하는 것에 비해, 나머지 입력값은 아래에서 위로 이동함을 알 수 있었습니다.
- 지금까지 고민해본 결과, `clearLastInput` 함수로 인하여 스택뷰가 아무것도 없을 때는 왼쪽에서 오른쪽으로 이동하지만, 스택뷰가 하나라도 존재한다면 아래에서 위로 애니메이션이 작동하는 것 같습니다. 현재는 `Label`을 스택뷰 안에 넣어 뷰를 추가하는 방식으로 진행하였는데, 이렇게 진행할 시에는 모든 입력값들이 왼쪽에서 오른쪽으로 이동함을 발견할 수 있었습니다.
- 왜 이러한 문제가 일어나는지 오랜 시간 고민해봐도 마땅한 근거를 발견하지는 못했습니다. 이에 찰리는 위의 문제가 어떤 이유로 일어나는지 알고 계신지 질문드리고 싶습니다.

<br>

### 3. UILabel.text 옵셔널 처리

- Step2의 피드백을 통하여 ??의 사용을 지양하고, 옵셔널 바인딩 방법을 사용해야 함을 배울 수 있었습니다. 이를 바탕으로 Step3를 진행해보았는데, `touchNumberButton` 메서드와 관련하여 `guard` 구문을 통하여 "text = numberInput.text"으로 옵셔널 바인딩을 하여, 여러 조건을 충족하는지 `text`를 통해 확인해보고, 최종적으로 `numberInput.text`의 값을 최신화해주기 위해선 "numberInput.text = text"와 같이 `text`를 다시 넣어주어야 했습니다.
- 이에, 옵셔널 바인딩을 다음의 방법으로 진행하는 것이 옳은지 확신이 들지 않고, 해당 프로퍼티를 계속 이용하고자 하는데, 그 프로퍼티 자체의 네이밍을 사용하면서 옵셔널 추출을 하는 또다른 방식이 있을지 궁금합니다.
<br>

### 4. stackView 화면 하단 자동 이동

```swift
private func goToBottomOfScrollView() {
    scrollView.setContentOffset(CGPoint(x: 0,
                                        y: scrollView.contentSize.height - scrollView.bounds.height),
                                animated: true)
}
```
<br>

- 저는 위의 코드를 `touchOperatorButton` 함수 내에 구현하여 연산자 버튼이 클릭되어, 입력값들이 스택뷰에 올라간 이후, `goToBottomOfScrollView` 함수를 통하여 화면이 아래로 스크롤 되도록 구현해보았습니다. 그러던 중, 문제점을 발견하였는데, `addCalculatorItems` 함수 내에서 "UIView.animate(withDuration: 1) { label.isHidden = false }" 코드가 없으면, 새로운 입력값이 스택뷰에 오를때마다 실시간으로 화면이 아래로 스크롤 되는 것이 아닌, 한박자 늦게 이동되고 있음을 발견하였습니다. 
- `animation`의 유무가 화면 자동 이동에 영향을 미친 것인지, 혹은 화면 자동 이동 코드는 모두 한박자 늦게 이동되고 있었는데, `animation`을 통해 화면이 자동적으로 이동된 것인지 혼란스러워 질문드리고자 합니다.

<animation 적용시>

![May-26-2022 21-25-41](https://user-images.githubusercontent.com/99063327/170487742-ba7a66f9-402e-4a2f-81b8-fed06ec1948d.gif)


<animation 미적용시>

![May-26-2022 21-27-13](https://user-images.githubusercontent.com/99063327/170487905-10dc6b9e-29e4-4303-a19c-86adac5e5d9c.gif)