### PR TITLE
계산기 [STEP 2] 민쏜

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,7 +13,14 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		FD658B59284242D600C3034B /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD658B58284242D600C3034B /* Error.swift */; };
 		FD7979B128355155006E81C6 /* Double+CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7979B028355155006E81C6 /* Double+CalculateItem.swift */; };
+		FDB90F082840D89600E324ED /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB90F072840D89600E324ED /* ExpressionParser.swift */; };
+		FDB90F102840FF7400E324ED /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB90F0F2840FF7400E324ED /* ExpressionParserTests.swift */; };
+		FDCED530283FE0CD0046DB91 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCED52F283FE0CD0046DB91 /* Operator.swift */; };
+		FDCED538283FE2100046DB91 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCED537283FE2100046DB91 /* OperatorTests.swift */; };
+		FDCED53F283FEB8A0046DB91 /* Fomula.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCED53E283FEB8A0046DB91 /* Fomula.swift */; };
+		FDCED547283FEBFF0046DB91 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCED546283FEBFF0046DB91 /* FormulaTests.swift */; };
 		FDF780412834DE4100A91171 /* Queue+CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF780402834DE4000A91171 /* Queue+CalculatorItemQueue.swift */; };
 		FDF780592834EFBB00A91171 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF780582834EFBB00A91171 /* CalculatorItemQueueTests.swift */; };
 		FDFB0CEF283A4F4D0017E844 /* Node+LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFB0CEE283A4F4D0017E844 /* Node+LinkedList.swift */; };
@@ -22,6 +29,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		FDB90F112840FF7400E324ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+		FDCED539283FE2100046DB91 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+		FDCED548283FEBFF0046DB91 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 		FDF7805A2834EFBB00A91171 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
@@ -54,7 +82,17 @@
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FD658B58284242D600C3034B /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		FD7979B028355155006E81C6 /* Double+CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+CalculateItem.swift"; sourceTree = "<group>"; };
+		FDB90F072840D89600E324ED /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		FDB90F0D2840FF7400E324ED /* ExpressionParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FDB90F0F2840FF7400E324ED /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
+		FDCED52F283FE0CD0046DB91 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		FDCED535283FE2100046DB91 /* OperatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FDCED537283FE2100046DB91 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
+		FDCED53E283FEB8A0046DB91 /* Fomula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fomula.swift; sourceTree = "<group>"; };
+		FDCED544283FEBFF0046DB91 /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FDCED546283FEBFF0046DB91 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		FDF780402834DE4000A91171 /* Queue+CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Queue+CalculatorItemQueue.swift"; sourceTree = "<group>"; };
 		FDF780562834EFBB00A91171 /* CalculatorItemQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDF780582834EFBB00A91171 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -67,6 +105,27 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		C713D93B2570E5EB001C3AFC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDB90F0A2840FF7400E324ED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDCED532283FE2100046DB91 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDCED541283FEBFF0046DB91 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -104,6 +163,9 @@
 				FDF780572834EFBB00A91171 /* CalculatorItemQueueTests */,
 				FDFB0CF5283A4F5D0017E844 /* NodeTests */,
 				FDFB0D02283A5F8C0017E844 /* LinkedListTests */,
+				FDCED536283FE2100046DB91 /* OperatorTests */,
+				FDCED545283FEBFF0046DB91 /* FormulaTests */,
+				FDB90F0E2840FF7400E324ED /* ExpressionParserTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -115,6 +177,9 @@
 				FDF780562834EFBB00A91171 /* CalculatorItemQueueTests.xctest */,
 				FDFB0CF4283A4F5D0017E844 /* NodeTests.xctest */,
 				FDFB0D01283A5F8C0017E844 /* LinkedListTests.xctest */,
+				FDCED535283FE2100046DB91 /* OperatorTests.xctest */,
+				FDCED544283FEBFF0046DB91 /* FormulaTests.xctest */,
+				FDB90F0D2840FF7400E324ED /* ExpressionParserTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -134,12 +199,40 @@
 			path = Calculator;
 			sourceTree = "<group>";
 		};
+		FDB90F0E2840FF7400E324ED /* ExpressionParserTests */ = {
+			isa = PBXGroup;
+			children = (
+				FDB90F0F2840FF7400E324ED /* ExpressionParserTests.swift */,
+			);
+			path = ExpressionParserTests;
+			sourceTree = "<group>";
+		};
+		FDCED536283FE2100046DB91 /* OperatorTests */ = {
+			isa = PBXGroup;
+			children = (
+				FDCED537283FE2100046DB91 /* OperatorTests.swift */,
+			);
+			path = OperatorTests;
+			sourceTree = "<group>";
+		};
+		FDCED545283FEBFF0046DB91 /* FormulaTests */ = {
+			isa = PBXGroup;
+			children = (
+				FDCED546283FEBFF0046DB91 /* FormulaTests.swift */,
+			);
+			path = FormulaTests;
+			sourceTree = "<group>";
+		};
 		FDF780422834DEE400A91171 /* Model */ = {
 			isa = PBXGroup;
 			children = (
 				FDF780402834DE4000A91171 /* Queue+CalculatorItemQueue.swift */,
 				FD7979B028355155006E81C6 /* Double+CalculateItem.swift */,
 				FDFB0CEE283A4F4D0017E844 /* Node+LinkedList.swift */,
+				FDCED52F283FE0CD0046DB91 /* Operator.swift */,
+				FDCED53E283FEB8A0046DB91 /* Fomula.swift */,
+				FDB90F072840D89600E324ED /* ExpressionParser.swift */,
+				FD658B58284242D600C3034B /* Error.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -203,6 +296,60 @@
 			productName = Calculator;
 			productReference = C713D93E2570E5EB001C3AFC /* Calculator.app */;
 			productType = "com.apple.product-type.application";
+		};
+		FDB90F0C2840FF7400E324ED /* ExpressionParserTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FDB90F132840FF7400E324ED /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */;
+			buildPhases = (
+				FDB90F092840FF7400E324ED /* Sources */,
+				FDB90F0A2840FF7400E324ED /* Frameworks */,
+				FDB90F0B2840FF7400E324ED /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FDB90F122840FF7400E324ED /* PBXTargetDependency */,
+			);
+			name = ExpressionParserTests;
+			productName = ExpressionParserTests;
+			productReference = FDB90F0D2840FF7400E324ED /* ExpressionParserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		FDCED534283FE2100046DB91 /* OperatorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FDCED53B283FE2100046DB91 /* Build configuration list for PBXNativeTarget "OperatorTests" */;
+			buildPhases = (
+				FDCED531283FE2100046DB91 /* Sources */,
+				FDCED532283FE2100046DB91 /* Frameworks */,
+				FDCED533283FE2100046DB91 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FDCED53A283FE2100046DB91 /* PBXTargetDependency */,
+			);
+			name = OperatorTests;
+			productName = OperatorTests;
+			productReference = FDCED535283FE2100046DB91 /* OperatorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		FDCED543283FEBFF0046DB91 /* FormulaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FDCED54A283FEBFF0046DB91 /* Build configuration list for PBXNativeTarget "FormulaTests" */;
+			buildPhases = (
+				FDCED540283FEBFF0046DB91 /* Sources */,
+				FDCED541283FEBFF0046DB91 /* Frameworks */,
+				FDCED542283FEBFF0046DB91 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FDCED549283FEBFF0046DB91 /* PBXTargetDependency */,
+			);
+			name = FormulaTests;
+			productName = FormulaTests;
+			productReference = FDCED544283FEBFF0046DB91 /* FormulaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		FDF780552834EFBB00A91171 /* CalculatorItemQueueTests */ = {
 			isa = PBXNativeTarget;
@@ -270,6 +417,18 @@
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
+					FDB90F0C2840FF7400E324ED = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
+					FDCED534283FE2100046DB91 = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
+					FDCED543283FEBFF0046DB91 = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					FDF780552834EFBB00A91171 = {
 						CreatedOnToolsVersion = 13.3;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
@@ -301,6 +460,9 @@
 				FDF780552834EFBB00A91171 /* CalculatorItemQueueTests */,
 				FDFB0CF3283A4F5D0017E844 /* NodeTests */,
 				FDFB0D00283A5F8C0017E844 /* LinkedListTests */,
+				FDCED534283FE2100046DB91 /* OperatorTests */,
+				FDCED543283FEBFF0046DB91 /* FormulaTests */,
+				FDB90F0C2840FF7400E324ED /* ExpressionParserTests */,
 			);
 		};
 /* End PBXProject section */
@@ -313,6 +475,27 @@
 				C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */,
 				C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */,
 				C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDB90F0B2840FF7400E324ED /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDCED533283FE2100046DB91 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDCED542283FEBFF0046DB91 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -345,11 +528,39 @@
 			buildActionMask = 2147483647;
 			files = (
 				FDFB0CEF283A4F4D0017E844 /* Node+LinkedList.swift in Sources */,
+				FDB90F082840D89600E324ED /* ExpressionParser.swift in Sources */,
 				FD7979B128355155006E81C6 /* Double+CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				FDCED53F283FEB8A0046DB91 /* Fomula.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				FDCED530283FE0CD0046DB91 /* Operator.swift in Sources */,
 				FDF780412834DE4100A91171 /* Queue+CalculatorItemQueue.swift in Sources */,
+				FD658B59284242D600C3034B /* Error.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDB90F092840FF7400E324ED /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FDB90F102840FF7400E324ED /* ExpressionParserTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDCED531283FE2100046DB91 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FDCED538283FE2100046DB91 /* OperatorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FDCED540283FEBFF0046DB91 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FDCED547283FEBFF0046DB91 /* FormulaTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -380,6 +591,21 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		FDB90F122840FF7400E324ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = FDB90F112840FF7400E324ED /* PBXContainerItemProxy */;
+		};
+		FDCED53A283FE2100046DB91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = FDCED539283FE2100046DB91 /* PBXContainerItemProxy */;
+		};
+		FDCED549283FEBFF0046DB91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = FDCED548283FEBFF0046DB91 /* PBXContainerItemProxy */;
+		};
 		FDF7805B2834EFBB00A91171 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
@@ -576,6 +802,123 @@
 			};
 			name = Release;
 		};
+		FDB90F142840FF7400E324ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = io.minsson.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		FDB90F152840FF7400E324ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.minsson.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		FDCED53C283FE2100046DB91 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = io.minsson.OperatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		FDCED53D283FE2100046DB91 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.minsson.OperatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		FDCED54B283FEBFF0046DB91 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = io.minsson.FormulaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		FDCED54C283FEBFF0046DB91 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.minsson.FormulaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
 		FDF7805C2834EFBB00A91171 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -710,6 +1053,33 @@
 			buildConfigurations = (
 				C713D9532570E5ED001C3AFC /* Debug */,
 				C713D9542570E5ED001C3AFC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FDB90F132840FF7400E324ED /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FDB90F142840FF7400E324ED /* Debug */,
+				FDB90F152840FF7400E324ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FDCED53B283FE2100046DB91 /* Build configuration list for PBXNativeTarget "OperatorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FDCED53C283FE2100046DB91 /* Debug */,
+				FDCED53D283FE2100046DB91 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FDCED54A283FEBFF0046DB91 /* Build configuration list for PBXNativeTarget "FormulaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FDCED54B283FEBFF0046DB91 /* Debug */,
+				FDCED54C283FEBFF0046DB91 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator/Model/Error.swift
+++ b/Calculator/Calculator/Model/Error.swift
@@ -1,0 +1,17 @@
+//
+//  Error.swift
+//  Calculator
+//
+//  Created by Minseong Kang on 2022/05/28.
+//
+
+enum CalculatorError: Error {
+    case divisionByZero
+    
+    var description: String {
+        switch self {
+        case .divisionByZero:
+            return "NaN"
+        }
+    }
+}

--- a/Calculator/Calculator/Model/Error.swift
+++ b/Calculator/Calculator/Model/Error.swift
@@ -6,11 +6,11 @@
 //
 
 enum CalculatorError: Error {
-    case divisionByZero
+    case dividedByZero
     
     var description: String {
         switch self {
-        case .divisionByZero:
+        case .dividedByZero:
             return "NaN"
         }
     }

--- a/Calculator/Calculator/Model/Error.swift
+++ b/Calculator/Calculator/Model/Error.swift
@@ -7,11 +7,15 @@
 
 enum CalculatorError: Error {
     case dividedByZero
+    case emptyCalculatorItemQueue
     
     var description: String {
         switch self {
         case .dividedByZero:
             return "NaN"
+        case .emptyCalculatorItemQueue:
+            return "CalculatorItemQueue is empty"
         }
+        
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -19,12 +19,9 @@ enum ExpressionParser {
         let numbersToEnqueue: [Double] = numbersParsedFromInput.compactMap( { Double($0) } )
         numbersToEnqueue.forEach( { resultOperands.enqueue($0) } )
         
-        for character in input {
-            if let eachOperator = Operator(rawValue: character) {
-                resultOperators.enqueue(eachOperator)
-            }
-        }
- 
+        let operatorsFromInput: [Operator] = input.compactMap( { Operator(rawValue: $0) } )
+        operatorsFromInput.forEach( { resultOperators.enqueue($0) } )
+
         return Formula(operands: resultOperands, operators: resultOperators)
     }
     

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,0 +1,38 @@
+//
+//  ExpressionParser.swift
+//  Calculator
+//
+//  Created by Minseong Kang on 2022/05/27.
+//
+
+import Foundation
+
+enum ExpressionParser {
+    
+    // MARK: - Action
+    
+    static func parse(from input: String) -> Formula {
+        var resultOperands = CalculatorItemQueue<Double>()
+        var resultOperators = CalculatorItemQueue<Operator>()
+
+        let numbersParsedFromInput: [String] = componentsByOperators(from: input)
+        let numbersToEnqueue: [Double] = numbersParsedFromInput.compactMap( { Double($0) } )
+        numbersToEnqueue.forEach( { resultOperands.enqueue($0) } )
+        
+        for character in input {
+            if let eachOperator = Operator(rawValue: character) {
+                resultOperators.enqueue(eachOperator)
+            }
+        }
+ 
+        return Formula(operands: resultOperands, operators: resultOperators)
+    }
+    
+    static private func componentsByOperators(from input: String) -> [String] {
+        var operators: CharacterSet = []
+        Operator.allCases.forEach( { operators.insert(charactersIn: String($0.rawValue)) } )
+        
+        let numbersOnly: [String] = input.components(separatedBy: operators)
+        return numbersOnly
+    }
+}

--- a/Calculator/Calculator/Model/Fomula.swift
+++ b/Calculator/Calculator/Model/Fomula.swift
@@ -15,7 +15,7 @@ struct Formula {
     // MARK: - Action
     
     func result() throws -> Double {
-        guard var result = operands.dequeue()?.data else { return 0.000000000999 }
+        guard var result = operands.dequeue()?.data else { throw CalculatorError.emptyCalculatorItemQueue }
         
         while let mathOperator = operators.dequeue()?.data,
               let currentNumber = operands.dequeue()?.data {

--- a/Calculator/Calculator/Model/Fomula.swift
+++ b/Calculator/Calculator/Model/Fomula.swift
@@ -1,0 +1,28 @@
+//
+//  Fomula.swift
+//  Calculator
+//
+//  Created by Minseong Kang on 2022/05/27.
+//
+
+struct Formula {
+    
+    // MARK: - Properties
+    
+    var operands = CalculatorItemQueue<Double>()
+    var operators = CalculatorItemQueue<Operator>()
+    
+    // MARK: - Action
+    
+    func result() throws -> Double {
+        guard var lhs = operands.dequeue()?.data else { return 0.000000000999 }
+        
+        while let mathOperator = operators.dequeue()?.data,
+              let rhs = operands.dequeue()?.data {
+            lhs = try mathOperator.calculate(lhs: lhs, rhs: rhs)
+        }
+        
+        let result = lhs
+        return result
+    }
+}

--- a/Calculator/Calculator/Model/Fomula.swift
+++ b/Calculator/Calculator/Model/Fomula.swift
@@ -15,14 +15,13 @@ struct Formula {
     // MARK: - Action
     
     func result() throws -> Double {
-        guard var lhs = operands.dequeue()?.data else { return 0.000000000999 }
+        guard var result = operands.dequeue()?.data else { return 0.000000000999 }
         
         while let mathOperator = operators.dequeue()?.data,
-              let rhs = operands.dequeue()?.data {
-            lhs = try mathOperator.calculate(lhs: lhs, rhs: rhs)
+              let currentNumber = operands.dequeue()?.data {
+            result = try mathOperator.calculate(lhs: result, rhs: currentNumber)
         }
-        
-        let result = lhs
+
         return result
     }
 }

--- a/Calculator/Calculator/Model/Fomula.swift
+++ b/Calculator/Calculator/Model/Fomula.swift
@@ -9,8 +9,14 @@ struct Formula {
     
     // MARK: - Properties
     
-    var operands = CalculatorItemQueue<Double>()
-    var operators = CalculatorItemQueue<Operator>()
+    private var operands: CalculatorItemQueue<Double>
+    private var operators: CalculatorItemQueue<Operator>
+    
+    // MARK: - Initializer
+    init(operands: CalculatorItemQueue<Double>, operators: CalculatorItemQueue<Operator>) {
+        self.operands = operands
+        self.operators = operators
+    }
     
     // MARK: - Action
     

--- a/Calculator/Calculator/Model/Node+LinkedList.swift
+++ b/Calculator/Calculator/Model/Node+LinkedList.swift
@@ -24,6 +24,7 @@ final class LinkedList<Element> {
     // MARK: - Properties
     
     private(set) var head: Node<Element>?
+    private var tail: Node<Element>?
     
     var length: Int {
         var currentNode = head
@@ -42,16 +43,12 @@ final class LinkedList<Element> {
     func append(_ newNode: Node<Element>) {
         if head == nil {
             head = newNode
+            tail = head
             return
         }
         
-        var currentNode = head
-        
-        while currentNode?.nextNode != nil {
-            currentNode = currentNode?.nextNode
-        }
-        
-        currentNode?.nextNode = newNode
+        tail?.nextNode = newNode
+        tail = newNode
     }
     
     func isEmpty() -> Bool {

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -1,0 +1,48 @@
+//
+//  Operator.swift
+//  Calculator
+//
+//  Created by Minseong Kang on 2022/05/27.
+//
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+"
+    case subtract = "-"
+    case divide = "/"
+    case multiply = "*"
+    
+    // MARK: - Action
+    
+    func calculate(lhs: Double, rhs: Double) throws -> Double {
+        switch self {
+        case .add:
+            return add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            return subtract(lhs: lhs, rhs: rhs)
+        case .divide:
+            return try divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
+        }
+    }
+    
+    private func add(lhs: Double, rhs: Double) -> Double {
+        return lhs + rhs
+    }
+    
+    private func subtract(lhs: Double, rhs: Double) -> Double {
+        return lhs - rhs
+    }
+    
+    private func divide(lhs: Double, rhs: Double) throws -> Double {
+        if rhs == 0.0 {
+            throw CalculatorError.divisionByZero
+        } else {
+            return lhs / rhs
+        }
+    }
+    
+    private func multiply(lhs: Double, rhs: Double) -> Double {
+        return lhs * rhs
+    }
+}

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -36,7 +36,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
     
     private func divide(lhs: Double, rhs: Double) throws -> Double {
         if rhs == 0.0 {
-            throw CalculatorError.divisionByZero
+            throw CalculatorError.dividedByZero
         } else {
             return lhs / rhs
         }

--- a/Calculator/Calculator/Model/Queue+CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/Queue+CalculatorItemQueue.swift
@@ -23,7 +23,7 @@ struct CalculatorItemQueue<Element: CalculateItem>: Queue {
     
     // MARK: - Properties
     
-    private var queue = LinkedList<Element>()
+    private let queue = LinkedList<Element>()
     
     var peek: Element? {
         return queue.head?.data ?? nil
@@ -35,7 +35,7 @@ struct CalculatorItemQueue<Element: CalculateItem>: Queue {
         queue.append(Node(data))
     }
     
-    mutating func dequeue() -> Node<Element>? {
+    func dequeue() -> Node<Element>? {
         return queue.isEmpty() == true ? nil : queue.removeFirstNode()
     }
     

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -1,0 +1,37 @@
+//
+//  ExpressionParserTests.swift
+//  ExpressionParserTests
+//
+//  Created by Minseong Kang on 2022/05/27.
+//
+
+import XCTest
+@testable import Calculator
+
+class ExpressionParserTests: XCTestCase {
+
+    // MARK: - Properties
+
+    var sut: ExpressionParser!
+    
+    // MARK: - Actions
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    // MARK: - parse(from:)
+    
+    func test_parse메서드_input계산식을_계산한_결과가_정확하다() throws {
+        // given
+        let input = "100+200-150*3/2"
+        
+        // when
+        let parsedFormula = ExpressionParser.parse(from: input)
+        
+        // then
+        XCTAssertEqual(try parsedFormula.result(), Double(225.0))
+    }
+}

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -53,8 +53,8 @@ class FormulaTests: XCTestCase {
             XCTAssertThrowsError(result)
             XCTAssertEqual(String(result), "NaN")
             return String(result)
-        } catch CalculatorError.divisionByZero {
-            return CalculatorError.divisionByZero.description
+        } catch CalculatorError.dividedByZero {
+            return CalculatorError.dividedByZero.description
         }
     }
 }

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -17,7 +17,15 @@ class FormulaTests: XCTestCase {
     // MARK: - Actions
     
     override func setUpWithError() throws {
-        sut = Formula()
+        var operandsQueue = CalculatorItemQueue<Double>()
+        let operands: [Double] = [2.0, 3.0, 1.0, 4.0, 4.0]
+        operands.forEach( { operandsQueue.enqueue($0) } )
+        
+        var operatorsQueue = CalculatorItemQueue<Operator>()
+        let operators: [Operator] = [.add, .subtract, .multiply, .divide]
+        operators.forEach( { operatorsQueue.enqueue($0) } )
+        
+        sut = Formula(operands: operandsQueue, operators: operatorsQueue)
     }
 
     override func tearDownWithError() throws {
@@ -28,10 +36,15 @@ class FormulaTests: XCTestCase {
 
     func test_result메서드_2더하기3빼기1곱하기4나누기4는_4가나온다() throws {
         // given
-        let numbersArray = [2.0, 3.0, 1.0, 4.0, 4.0]
-        let operatorsArray: [Operator] = [.add, .subtract, .multiply, .divide]
-        numbersArray.forEach { sut.operands.enqueue($0) }
-        operatorsArray.forEach { sut.operators.enqueue($0) }
+        var operandsQueue = CalculatorItemQueue<Double>()
+        let operands: [Double] = [2.0, 3.0, 1.0, 4.0, 4.0]
+        operands.forEach( { operandsQueue.enqueue($0) } )
+        
+        var operatorsQueue = CalculatorItemQueue<Operator>()
+        let operators: [Operator] = [.add, .subtract, .multiply, .divide]
+        operators.forEach( { operatorsQueue.enqueue($0) } )
+        
+        sut = Formula(operands: operandsQueue, operators: operatorsQueue)
         
         // when
         let result = try sut.result()
@@ -42,11 +55,16 @@ class FormulaTests: XCTestCase {
     
     func test_result메서드_0으로_나누면_에러처리하고_NaN을_리턴한다() throws -> String {
         // given
-        let numbersArray = [1.0, 2.0, 3.0, 4.0, 0.0]
-        let operatorsArray: [Operator] = [.add, .subtract, .add, .divide]
-        numbersArray.forEach { sut.operands.enqueue($0) }
-        operatorsArray.forEach { sut.operators.enqueue($0) }
+        var operandsQueue = CalculatorItemQueue<Double>()
+        let operands: [Double] = [1.0, 2.0, 3.0, 4.0, 0.0]
+        operands.forEach( { operandsQueue.enqueue($0) } )
         
+        var operatorsQueue = CalculatorItemQueue<Operator>()
+        let operators: [Operator] = [.add, .subtract, .multiply, .divide]
+        operators.forEach( { operatorsQueue.enqueue($0) } )
+        
+        sut = Formula(operands: operandsQueue, operators: operatorsQueue)
+
         // then
         do {
             let result = try sut.result()

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -1,0 +1,60 @@
+//
+//  FormulaTests.swift
+//  FormulaTests
+//
+//  Created by Minseong Kang on 2022/05/27.
+//
+
+import XCTest
+@testable import Calculator
+
+class FormulaTests: XCTestCase {
+    
+    // MARK: - Properties
+    
+    var sut: Formula!
+    
+    // MARK: - Actions
+    
+    override func setUpWithError() throws {
+        sut = Formula()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+
+    // MARK: - result()
+
+    func test_result메서드_2더하기3빼기1곱하기4나누기4는_4가나온다() throws {
+        // given
+        let numbersArray = [2.0, 3.0, 1.0, 4.0, 4.0]
+        let operatorsArray: [Operator] = [.add, .subtract, .multiply, .divide]
+        numbersArray.forEach { sut.operands.enqueue($0) }
+        operatorsArray.forEach { sut.operators.enqueue($0) }
+        
+        // when
+        let result = try sut.result()
+        
+        // then
+        XCTAssertEqual(result, 2+3-1*4/4)
+    }
+    
+    func test_result메서드_0으로_나누면_에러처리하고_NaN을_리턴한다() throws -> String {
+        // given
+        let numbersArray = [1.0, 2.0, 3.0, 4.0, 0.0]
+        let operatorsArray: [Operator] = [.add, .subtract, .add, .divide]
+        numbersArray.forEach { sut.operands.enqueue($0) }
+        operatorsArray.forEach { sut.operators.enqueue($0) }
+        
+        // then
+        do {
+            let result = try sut.result()
+            XCTAssertThrowsError(result)
+            XCTAssertEqual(String(result), "NaN")
+            return String(result)
+        } catch CalculatorError.divisionByZero {
+            return CalculatorError.divisionByZero.description
+        }
+    }
+}

--- a/Calculator/OperatorTests/OperatorTests.swift
+++ b/Calculator/OperatorTests/OperatorTests.swift
@@ -1,0 +1,53 @@
+//
+//  OperatorTests.swift
+//  OperatorTests
+//
+//  Created by Minseong Kang on 2022/05/27.
+//
+
+import XCTest
+@testable import Calculator
+
+class OperatorTests: XCTestCase {
+    
+    // MARK: - Properties
+    
+    let num1 = 2.0
+    let num2 = 5.0
+    
+
+    // MARK: - calculate(lhs:rhs:)를 통한 사칙연산 메서드의 테스트
+    
+    func test_calulate메서드를_통한_add메서드_두_파라미터의_합을_리턴() throws {
+        // when
+        let result = try Operator.add.calculate(lhs: num1, rhs: num2)
+        
+        // then
+        XCTAssertEqual(result, num1 + num2)
+    }
+    
+    func test_calulate메서드를_통한_subtract메서드_두_파라미터의_차를_리턴() throws {
+        // when
+        let result = try Operator.subtract.calculate(lhs: num1, rhs: num2)
+        
+        // then
+        XCTAssertEqual(result, num1 - num2)
+    }
+    
+    func test_calulate메서드를_통한_divide메서드_좌항을_우항으로_나눈_값을_리턴() throws {
+        // when
+        let result = try Operator.divide.calculate(lhs: num1, rhs: num2)
+        
+        // then
+        XCTAssertEqual(result, num1 / num2)
+    }
+    
+    func test_calulate메서드를_통한_multiply메서드_두_파라미터의_곱을_리턴() throws {
+        // when
+        let result = try Operator.multiply.calculate(lhs: num1, rhs: num2)
+        
+        // then
+        XCTAssertEqual(result, num1 * num2)
+    }
+
+}


### PR DESCRIPTION
@protocorn93 

안녕하세요, 콘!
Step 2 PR 제출합니다. 검토 부탁드립니다! ☺️

Step 2는 정말.. 정말 쉽지 않았어요...

그 이유를 생각해보자면,
1) UML을 통해 각 객체간 관계를 파악하는 것
2) 메서드와 변수명을 통해 각 객체의 역할을 추론하는 것
이 두 작업이 무척 낯설었기 때문이었던 것 같아요.

아래는 제가 콘에게 드리고 싶었던 질문들이에요.
이것들 외에도 제가 인지하지 못하고 넘어간, 개선하면 좋을만한 사항들이 많을 거라고 생각해요.
아직 제가 이해하고 적용하기에 어려울만한 내용이라도 피드백 해주시면 나중에 발전해나가면서 다시 돌아보고, 성장할 수 있는 계기가 될 것 같아요..!

제게는 콘의 피드백이 너무 귀중한만큼 가감없는 피드백 부탁 드립니다..!!
감사합니다!!

# 프로젝트를 수행하면서 궁금했던 것들

## 1. extension Double
UML과 달리, 저는 `split(with:)` 메서드를 별도로 구현하지 않았어요. 현재 제가 작성한 구조상으로는 `componentsByOperators(from input:)` 메서드와 역할이 겹쳐, `split(with:)`을 쓰게 되면 오히려 불필요한 코드가 된다고 생각했기 때문이에요. 

제가 UML을 이해한 바로는, `componentsByOperators(from input:)` 안에서 `split(with:)`을 쓰는 구조 같아요. 제가 이해한 바가 맞다면, UML이 이렇게 작성된 데에는 아마 어떤 합리적인 이유가 있을텐데, 저로서는 아직 잘 이해가 되지 않아요.

만약 이게 실제로 회사나 다른 프로젝트에서 UML을 그린 동료 혹은 상사와 협업하는 상황이었다면, 아마 업무를 수행하기 전에 이 부분에 대해 미리 질문했을 것 같아요.

개인 프로젝트다보니 혼자서는 답을 잘 찾지 못했어요. 콘은 어떻게 생각하시나요?

## 2. ExpressionParser 열거형
만약 제가 직접 구현했다면, 저는 열거형 대신에 구조체를 사용했을 것 같아요. 열거형은 case를 이용해 선택의 경우의 수를 지정하기 위해 사용한다고 알고 있었는데, case가 없는 열거형은 낯설었어요. 

이런 case가 없는 열거형을 구조체와 비교한다면 어떤 장단점이 있는지 궁금해요.

## 3. parse(from:) 메서드의 Test
parse(from:) 메서드의 목적은 아규먼트로 받은 계산식을 연산자 Queue와 피연산자 Queue로 분류해, Formula 인스턴스를 리턴하는 거라고 생각했어요.

이를 테스트하기 위해 아래와 같은 코드를 작성했었는데, `Global function 'XCTAssertEqual(_:_:_:file:line:)' requires that 'Formula' conform to 'Equatable'` 라는 에러가 발생했어요.

생각해보니 Node()와 Node()를 비교하는 거니 당연히 그렇겠다는 생각이 들었어요. 그래서 PR로 제출한 코드와 같이 `result()` 메서드를 사용해 간접적으로 `parse(from:)` 메서드의 작동을 테스트해봤어요.

이런 경우에 콘이라면 어떻게 진행했을까요?

```swift
    func test_parse메서드_input계산식을_연산자Queue와_피연산자Queue로_나누어_Formula타입으로_반환한다() {
        // given
        let input = "100+200-150*3/2"
        
        // when
        var operandsExpected = CalculatorItemQueue<Double>()
        var operatorsExpected = CalculatorItemQueue<Operator>()
        
        [100.0, 200.0, 150.0, 3.0, 2.0].forEach( { operandsExpected.enqueue($0) } )
        [Operator.add, Operator.subtract, Operator.multiply, Operator.divide].forEach( { operatorsExpected.enqueue($0) } )
        
        let result = ExpressionParser.parse(from: input)
        
        // then
        XCTAssertEqual(result, Formula(operands: operandsExpected, operators: operatorsExpected))
    }
}
```


## 4. parse(from input:)의 축약
`parse(from:)`의 정의부를 보면 아래와 같은 코드가 포함되어 있어요. `parse(from:)` 메서드에서 아규먼트로 전달 받은 `input`에서 함수의 최종 리턴에 포함시킬 `피연산자 Queue`인 `resultOperands`를 추출하기 위한 코드예요.

아래 코드와 같이 그 과정의 한 단계마다 변수 네이밍을 신경써서 가독성을 높이고자 해봤어요.
그런데 결과물을 보니, 이 과정은 말그대로 데이터를 추출하기 위해 잠깐 거쳐가는 과정일 뿐인데, 이렇게 변수명을 자세하게 적는 게 유의미한 걸까? 라는 의문이 들었어요.

오히려 너무 자세히 적다 보니 가독성이 안 좋아진 것 같기도 하다는 생각이 들었어요.
```swift
let numbersParsedFromInput: [String] = componentsByOperators(from: input)
let numbersToEnqueue: [Double] = numbersParsedFromInput.compactMap( { Double($0) } )
numbersToEnqueue.forEach( { resultOperands.enqueue($0) } )
```

그래서 최대한 축약하면 어떤 모습일지 궁금해서 아래처럼 축약해봤어요. 

```swift
componentsByOperators(from: input)
    .compactMap( { Double($0) } )
    .forEach( { resultOperands.enqueue($0) } )
```

두번째 코드는 너무 극단적인 축약이라고 생각하지만, 첫번째의 코드는 또 너무 자세한 것 같아요. 
콘은 어떻게 생각하시나요?




## 5. componentsByOperators(from:) 메서드의 구조

### 1) 최초 작성본
```swift
static private func componentsByOperators(from input: String) -> [String] {
    let numbers: [String] = input.components(separatedBy: ["+", "-", "*", "/"])
        return numbers
}
```

처음에 작성한 코드에서는 `["+", "-", "*", "/"]`과 같이 매직 리터럴이 사용되고 있어요. 이를 개선해보고자 아래와 같이 작성해봤어요.

### 2) 제출 코드
```swift
static private func componentsByOperators(from input: String) -> [String] {
    var operators: CharacterSet = []
    Operator.allCases.forEach( { operators.insert(charactersIn: String($0.rawValue)) } )
    
    let numbersOnly: [String] = input.components(separatedBy: operators)
    return numbersOnly
}
```

위에서 components(separatedBy:)에 ["+", "-", "*", "/"]을 아규먼트로 넣었던 바, 당연히 allCases로 받은 값도 그대로 넣을 수 있다고 생각했었는데, 예상치 못한 문제가 있었어요. 

아규먼트 타입이 CharacterSet이어야 한다는 거였어요. 이에 따라 해결법을 찾아 제출 코드를 작성했어요.

이렇게 작성함으로써 매직 리터럴을 제거할 수 있었고, 앞으로 어떤 연산자가 새로 생기든 대응할 수 있다는 점에서 확장성이 좋아졌다는 생각이 들어요. 

하지만 과연 이것이 읽기 좋은 코드인가에 대한 의문이 들어요. 이 코드를 처음 보는 동료가 원활하게 읽을 수 있을까요? 좀 더 풀어서 쓰는 게 좋을까요? 아니면 제 레벨에서는 난해해 보이지만, 현업 수준에서는 아무 문제 없이 읽히는 코드인가요? 콘은 어떻게 생각하시나요?


## 6. result() 메서드의 변수명과 옵셔널 바인딩의 리턴값
```swift
func result() throws -> Double {
    guard var lhs = operands.dequeue()?.data else { return 0.000000000999 }
    
    while let mathOperator = operators.dequeue()?.data,
          let rhs = operands.dequeue()?.data {
        lhs = try mathOperator.calculate(lhs: lhs, rhs: rhs)
    }
    
    let result = lhs
    return result
}
```

### 1) 변수명
위 메서드에서 `lhs`라는 변수명이 적절하지 않다고 생각하는데, 더 나은 대안이 떠오르지 않아요. 처음에는 `temp`라고 썼는데 더 좋지 않은 변수명이라고 생각해서 일단은 `lhs`라고 해놓은 상태였어요.

`lhs`: `Operator` 열거형에 포함된 `calculate(lhs:rhs:)`메서드에 사용할 변수예요. 우선 숫자 Queue의 첫번째 숫자를 넣게 되어 있어요.

그 후 반복문에서  `calculater(lhs:rhs:)`를 호출할 때 `lhs`의 아규먼트로 넣어요. `rhs` 자리에는 숫자 Queue에서 `Dequeue()`되는 값이 들어와요.

그리고 반복문을 통해 연산을 진행하며 연산 결과를 `lhs` 변수에 계속 쌓아나가는 방식이에요. 보통 이런 역할을 하는 변수명에는 `total`이나 `result` 같은 네이밍을 사용했는데, 맨 처음 숫자 Queue에서 첫번째 값이 들어가는 코드가 있어 그렇게 네이밍을 하는 것도 어색하다는 생각이 들어요.

콘은 어떻게 생각하시나요?

### 2) 옵셔널 바인딩의 리턴값

옵셔널 바인딩에서 값이 없을 경우에 대해 `return 0.000000000999`라고 써놨어요. `result()`의 리턴형이 `Double`이라 어떤 값을 리턴해야할지 고민하다가 만약 계산기에서 마주하게 되면 보통 이상하게 생각할 수 있는 숫자를 넣어봤어요. 아니면, 차라리 에러를 리턴하는 게 더 나을지도 모른다는 생각이 들기도 해요. 콘은 어떻게 생각하시나요?
