### PR TITLE
계산기 II [STEP1] borysarang, yeton

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		4520B2132836959000652886 /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4520B2112836959000652886 /* ExpressionParserTests.swift */; };
 		4520B2162836C50E00652886 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4520B2152836C50E00652886 /* CalculatorError.swift */; };
 		4520B2172836C50E00652886 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4520B2152836C50E00652886 /* CalculatorError.swift */; };
+		457F071E2844CA8500C9B27B /* NameSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457F071D2844CA8500C9B27B /* NameSpace.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -67,6 +68,7 @@
 		4520B20E2836943800652886 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		4520B2112836959000652886 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		4520B2152836C50E00652886 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
+		457F071D2844CA8500C9B27B /* NameSpace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameSpace.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				C713D94A2570E5ED001C3AFC /* Assets.xcassets */,
 				C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */,
 				C713D94F2570E5ED001C3AFC /* Info.plist */,
+				457F071D2844CA8500C9B27B /* NameSpace.swift */,
 			);
 			path = Calculator;
 			sourceTree = "<group>";
@@ -306,6 +309,7 @@
 				4520B1F82834125E00652886 /* CalculatorList.swift in Sources */,
 				4520B1F62834121900652886 /* Node.swift in Sources */,
 				4520B209283651DB00652886 /* Double.swift in Sources */,
+				457F071E2844CA8500C9B27B /* NameSpace.swift in Sources */,
 				4520B20F2836943800652886 /* ExpressionParser.swift in Sources */,
 				4520B20228362F6800652886 /* Formula.swift in Sources */,
 			);

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressAllClearButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ahd-Ii-8t6"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -93,6 +96,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressClearEntryButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aPD-vm-K6y"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -351,6 +357,11 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="currendOperand" destination="Lwz-OF-XHD" id="G0k-3f-FuZ"/>
+                        <outlet property="currentOperator" destination="HPC-iy-qdm" id="CMv-ea-iWO"/>
+                        <outlet property="scrollViewContents" destination="XRe-QE-UJf" id="NJI-Ha-PCe"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -311,9 +311,6 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
-                                                <connections>
-                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vrg-iB-xj7"/>
-                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -107,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressReverseSignButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5cs-dP-PcG"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -12,17 +14,17 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="181" width="568" height="45"/>
+                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="568" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="453" y="0.0" width="115" height="20.5"/>
+                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
                                                         <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
@@ -39,7 +41,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="453" y="24.5" width="115" height="20.5"/>
+                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
                                                         <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
@@ -71,13 +73,13 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="gA2-7M-FxF"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YKH-82-hZC">
-                                <rect key="frame" x="16" y="303" width="568" height="277"/>
+                                <rect key="frame" x="16" y="362.5" width="382" height="479.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="AP2-25-h5E">
-                                        <rect key="frame" x="0.0" y="0.0" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="89.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ped-N8-JbY">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="AC">
@@ -88,7 +90,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="CE">
@@ -99,7 +101,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="⁺⁄₋">
@@ -110,7 +112,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="÷">
@@ -123,10 +125,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="35B-Om-mGh">
-                                        <rect key="frame" x="0.0" y="57" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="97.5" width="382" height="89.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L6z-2G-Gar">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="7">
@@ -137,7 +139,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="8">
@@ -148,7 +150,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="9">
@@ -159,7 +161,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="×">
@@ -172,10 +174,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="e7N-N0-vb2">
-                                        <rect key="frame" x="0.0" y="114" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="195" width="382" height="89.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-yz-XvG">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="4">
@@ -186,7 +188,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="5">
@@ -197,7 +199,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="6">
@@ -208,7 +210,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="−">
@@ -221,10 +223,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="NpY-aR-Nd4">
-                                        <rect key="frame" x="0.0" y="171" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="292.5" width="382" height="89.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nCE-qB-NiN">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="1">
@@ -235,7 +237,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="2">
@@ -246,7 +248,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="3">
@@ -257,7 +259,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="+">
@@ -270,10 +272,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="R7j-41-DOy">
-                                        <rect key="frame" x="0.0" y="228" width="568" height="49"/>
+                                        <rect key="frame" x="0.0" y="390" width="382" height="89.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mSz-Y3-r5Z">
-                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="0">
@@ -284,7 +286,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
-                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="00">
@@ -295,7 +297,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
-                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title=".">
@@ -306,7 +308,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
-                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
+                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Daw-iX-Owl" secondAttribute="height" multiplier="1:1" id="t9i-OQ-WFF"/>
@@ -324,10 +326,10 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="246" width="568" height="37"/>
+                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="568" height="37"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
                                                 <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
@@ -336,7 +338,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="27.5" y="0.0" width="540.5" height="37"/>
+                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -364,7 +364,7 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="currendOperand" destination="Lwz-OF-XHD" id="G0k-3f-FuZ"/>
+                        <outlet property="currentOperand" destination="Lwz-OF-XHD" id="Coc-4P-04U"/>
                         <outlet property="currentOperator" destination="HPC-iy-qdm" id="CMv-ea-iWO"/>
                         <outlet property="scrollViewContents" destination="XRe-QE-UJf" id="NJI-Ha-PCe"/>
                     </connections>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,17 +12,17 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
+                                <rect key="frame" x="16" y="181" width="568" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="568" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
+                                                <rect key="frame" x="453" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
                                                         <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
@@ -41,7 +39,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
+                                                <rect key="frame" x="453" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
                                                         <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
@@ -73,13 +71,13 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="gA2-7M-FxF"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YKH-82-hZC">
-                                <rect key="frame" x="16" y="362.5" width="382" height="479.5"/>
+                                <rect key="frame" x="16" y="303" width="568" height="277"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="AP2-25-h5E">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ped-N8-JbY">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="AC">
@@ -90,7 +88,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="CE">
@@ -101,7 +99,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="⁺⁄₋">
@@ -112,7 +110,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="÷">
@@ -125,10 +123,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="35B-Om-mGh">
-                                        <rect key="frame" x="0.0" y="97.5" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="57" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L6z-2G-Gar">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="7">
@@ -139,7 +137,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="8">
@@ -150,7 +148,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="9">
@@ -161,7 +159,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="×">
@@ -174,10 +172,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="e7N-N0-vb2">
-                                        <rect key="frame" x="0.0" y="195" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="114" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-yz-XvG">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="4">
@@ -188,7 +186,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="5">
@@ -199,7 +197,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="6">
@@ -210,7 +208,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="−">
@@ -223,10 +221,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="NpY-aR-Nd4">
-                                        <rect key="frame" x="0.0" y="292.5" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="171" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nCE-qB-NiN">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="1">
@@ -237,7 +235,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="2">
@@ -248,7 +246,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="3">
@@ -259,7 +257,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="+">
@@ -272,10 +270,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="R7j-41-DOy">
-                                        <rect key="frame" x="0.0" y="390" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="228" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mSz-Y3-r5Z">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="0">
@@ -286,7 +284,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="00">
@@ -297,7 +295,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title=".">
@@ -308,7 +306,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Daw-iX-Owl" secondAttribute="height" multiplier="1:1" id="t9i-OQ-WFF"/>
@@ -326,10 +324,10 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
+                                <rect key="frame" x="16" y="246" width="568" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="568" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
                                                 <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
@@ -338,7 +336,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
+                                                <rect key="frame" x="27.5" y="0.0" width="540.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -364,8 +362,8 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="currentOperand" destination="Lwz-OF-XHD" id="Coc-4P-04U"/>
-                        <outlet property="currentOperator" destination="HPC-iy-qdm" id="CMv-ea-iWO"/>
+                        <outlet property="currentOperandLabel" destination="Lwz-OF-XHD" id="Coc-4P-04U"/>
+                        <outlet property="currentOperatorLabel" destination="HPC-iy-qdm" id="CMv-ea-iWO"/>
                         <outlet property="operationScrollView" destination="BOT-7g-vxv" id="I4F-WI-IPQ"/>
                         <outlet property="operationStackView" destination="XRe-QE-UJf" id="NJI-Ha-PCe"/>
                     </connections>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -366,6 +366,7 @@
                     <connections>
                         <outlet property="currentOperand" destination="Lwz-OF-XHD" id="Coc-4P-04U"/>
                         <outlet property="currentOperator" destination="HPC-iy-qdm" id="CMv-ea-iWO"/>
+                        <outlet property="scrollView" destination="BOT-7g-vxv" id="I4F-WI-IPQ"/>
                         <outlet property="scrollViewContents" destination="XRe-QE-UJf" id="NJI-Ha-PCe"/>
                     </connections>
                 </viewController>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -317,6 +317,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressEqualButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bXQ-Nk-z1a"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -364,8 +364,8 @@
                     <connections>
                         <outlet property="currentOperand" destination="Lwz-OF-XHD" id="Coc-4P-04U"/>
                         <outlet property="currentOperator" destination="HPC-iy-qdm" id="CMv-ea-iWO"/>
+                        <outlet property="operationScrollView" destination="BOT-7g-vxv" id="I4F-WI-IPQ"/>
                         <outlet property="operationStackView" destination="XRe-QE-UJf" id="NJI-Ha-PCe"/>
-                        <outlet property="scrollView" destination="BOT-7g-vxv" id="I4F-WI-IPQ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,22 +18,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -40,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -108,6 +109,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="k8z-Us-GUg"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -121,6 +125,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iyp-lN-9KS"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -129,6 +136,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qC0-2U-S8G"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -137,6 +147,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CM6-JA-s7s"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -145,6 +158,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="r2e-IF-2sv"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -158,6 +174,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="v3Y-5K-vyv"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -166,6 +185,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="guM-6j-WOx"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -174,6 +196,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QlI-fT-nvY"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -182,6 +207,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="j0W-C7-MBJ"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -195,6 +223,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BSQ-6t-oer"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -203,6 +234,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WZN-Dj-b2e"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -211,6 +245,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Uxx-H2-RDd"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -219,6 +256,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="FCe-3U-qdd"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -232,6 +272,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8hN-7V-EC0"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -240,6 +283,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UJl-kE-AF6"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -259,25 +305,28 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vrg-iB-xj7"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -86,7 +86,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressAllClearButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ahd-Ii-8t6"/>
+                                                    <action selector="allClearButtonDidTap:" destination="BYZ-38-t0r" eventType="touchUpInside" id="i4t-hm-FF5"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
@@ -97,7 +97,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressClearEntryButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aPD-vm-K6y"/>
+                                                    <action selector="clearEntryButtonDidTap:" destination="BYZ-38-t0r" eventType="touchUpInside" id="yQN-z1-Y84"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
@@ -108,7 +108,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressReverseSignButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5cs-dP-PcG"/>
+                                                    <action selector="reverseSignButtonDidTap:" destination="BYZ-38-t0r" eventType="touchUpInside" id="NrQ-R7-liH"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
@@ -119,7 +119,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="k8z-Us-GUg"/>
+                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="brb-47-Jrs"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -135,7 +135,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iyp-lN-9KS"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="E5s-iq-fax"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
@@ -146,7 +146,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qC0-2U-S8G"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sxu-rh-ix3"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
@@ -157,7 +157,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CM6-JA-s7s"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8jh-9O-t7l"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
@@ -168,7 +168,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="r2e-IF-2sv"/>
+                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Rax-sH-KUj"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -184,7 +184,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="v3Y-5K-vyv"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qXU-3o-2Fc"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
@@ -195,7 +195,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="guM-6j-WOx"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UTq-Gn-u35"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
@@ -206,7 +206,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QlI-fT-nvY"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WoW-es-2h3"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
@@ -217,7 +217,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="j0W-C7-MBJ"/>
+                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="x3U-RP-HYZ"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -233,7 +233,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BSQ-6t-oer"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dxM-PM-pPI"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
@@ -244,7 +244,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WZN-Dj-b2e"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="NnN-IF-099"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
@@ -255,7 +255,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Uxx-H2-RDd"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rdI-W9-8NM"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
@@ -266,7 +266,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="FCe-3U-qdd"/>
+                                                    <action selector="pressOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aXU-jT-KuX"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -282,7 +282,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8hN-7V-EC0"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7Fs-O2-Wuq"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
@@ -293,7 +293,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UJl-kE-AF6"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tfA-ql-fud"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
@@ -304,7 +304,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="82j-v2-4wQ"/>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="874-cq-FdD"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
@@ -318,7 +318,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="pressEqualButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bXQ-Nk-z1a"/>
+                                                    <action selector="equalButtonDidTap:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CKn-fr-46V"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -372,7 +372,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="140.57971014492756" y="138.61607142857142"/>
+            <point key="canvasLocation" x="-97" y="137"/>
         </scene>
     </scenes>
     <resources>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -14,17 +12,17 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="240.5" width="382" height="45"/>
+                                <rect key="frame" x="16" y="181" width="568" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="568" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
+                                                <rect key="frame" x="453" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
                                                         <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
@@ -41,7 +39,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
+                                                <rect key="frame" x="453" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
                                                         <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
@@ -73,13 +71,13 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="gA2-7M-FxF"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YKH-82-hZC">
-                                <rect key="frame" x="16" y="362.5" width="382" height="479.5"/>
+                                <rect key="frame" x="16" y="303" width="568" height="277"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="AP2-25-h5E">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ped-N8-JbY">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="AC">
@@ -90,7 +88,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="CE">
@@ -101,7 +99,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="⁺⁄₋">
@@ -112,7 +110,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="÷">
@@ -125,10 +123,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="35B-Om-mGh">
-                                        <rect key="frame" x="0.0" y="97.5" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="57" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L6z-2G-Gar">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="7">
@@ -139,7 +137,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="8">
@@ -150,7 +148,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="9">
@@ -161,7 +159,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="×">
@@ -174,10 +172,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="e7N-N0-vb2">
-                                        <rect key="frame" x="0.0" y="195" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="114" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-yz-XvG">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="4">
@@ -188,7 +186,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="5">
@@ -199,7 +197,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="6">
@@ -210,7 +208,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="−">
@@ -223,10 +221,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="NpY-aR-Nd4">
-                                        <rect key="frame" x="0.0" y="292.5" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="171" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nCE-qB-NiN">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="1">
@@ -237,7 +235,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="2">
@@ -248,7 +246,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="3">
@@ -259,7 +257,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="+">
@@ -272,10 +270,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="R7j-41-DOy">
-                                        <rect key="frame" x="0.0" y="390" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="228" width="568" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mSz-Y3-r5Z">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="0">
@@ -286,7 +284,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="144" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="00">
@@ -297,7 +295,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="288" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title=".">
@@ -308,7 +306,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="432" y="0.0" width="136" height="49"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Daw-iX-Owl" secondAttribute="height" multiplier="1:1" id="t9i-OQ-WFF"/>
@@ -326,10 +324,10 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
+                                <rect key="frame" x="16" y="246" width="568" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="568" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
                                                 <rect key="frame" x="0.0" y="0.0" width="19.5" height="37"/>
@@ -338,7 +336,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="27.5" y="0.0" width="354.5" height="37"/>
+                                                <rect key="frame" x="27.5" y="0.0" width="540.5" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -366,8 +364,8 @@
                     <connections>
                         <outlet property="currentOperand" destination="Lwz-OF-XHD" id="Coc-4P-04U"/>
                         <outlet property="currentOperator" destination="HPC-iy-qdm" id="CMv-ea-iWO"/>
+                        <outlet property="operationStackView" destination="XRe-QE-UJf" id="NJI-Ha-PCe"/>
                         <outlet property="scrollView" destination="BOT-7g-vxv" id="I4F-WI-IPQ"/>
-                        <outlet property="scrollViewContents" destination="XRe-QE-UJf" id="NJI-Ha-PCe"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -300,6 +300,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="pressOperandButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="82j-v2-4wQ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/CalculatorQueue/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/CalculatorQueue/CalculatorItemQueue.swift
@@ -4,23 +4,22 @@
 //
 //  Created by 유한석 on 2022/05/16.
 //
-class CalculatorItemQueue {
-    private var queue: CalculatorList<CalculatorItem> = CalculatorList()
+struct CalculatorItemQueue<T: CalculatorItem> {
+    private var queue = CalculatorList<T>()
     var count: Int {
         return queue.size()
     }
-    
-    func enQueue(_ input: CalculatorItem) {
+
+    mutating func enqueue(_ input: T) {
         let newNode = Node(value: input)
         self.queue.append(newNode)
     }
-    func deQueue() -> Node<CalculatorItem>? {
+
+    mutating func dequeue() -> Node<T>? {
         if queue.isEmpty() {
             return nil
         }
+
         return queue.pop()
-    }
-    func removeAll() {
-        queue.removeAll()
     }
 }

--- a/Calculator/Calculator/CalculatorQueue/CalculatorList.swift
+++ b/Calculator/Calculator/CalculatorQueue/CalculatorList.swift
@@ -4,35 +4,40 @@
 //
 //  Created by 유한석 on 2022/05/17.
 //
-class CalculatorList<T> {
+class CalculatorList<T: CalculatorItem> {
     private var head: Node<T>?
-    private var tail: Node<T>?
     
     init(head: Node<T>? = nil) {
         self.head = head
-        self.tail = head
     }
     
     func size() -> Int {
         guard var counterNode = head else {
             return 0
         }
+        
         var count: Int = 1
         while counterNode.next != nil {
             count += 1
             counterNode = counterNode.next!
         }
+        
         return count
     }
+    
     func append(_ newNode: Node<T>) {
-        guard tail != nil else {
-            tail = newNode
+        guard head != nil else {
             head = newNode
             return
         }
-        tail?.next = newNode
-        tail = tail?.next
+        
+        var node = head
+        while node?.next != nil {
+            node = node?.next
+        }
+        node?.next = newNode
     }
+    
     func isEmpty() -> Bool {
         if head == nil {
             return true
@@ -40,18 +45,14 @@ class CalculatorList<T> {
             return false
         }
     }
-    func removeAll() {
-        tail = nil
-        head = nil
-    }
+    
     func pop() -> Node<T>? {
         guard let firstNode = head else {
             return nil
         }
+        
         head = head?.next
-        if size() == 0 {
-            tail = nil
-        }
+        
         return firstNode
     }
 }

--- a/Calculator/Calculator/CalculatorQueue/ExpressionParser.swift
+++ b/Calculator/Calculator/CalculatorQueue/ExpressionParser.swift
@@ -9,16 +9,17 @@ enum ExpressionParser {
         let operandsQueue = CalculatorItemQueue()
         let operatorQueue = CalculatorItemQueue()
         let formula = Formula(operands: operandsQueue, operators: operatorQueue)
-        let operators: [Character] = componentsByOperators(from: input).map { op in
-            Character(op)
-        }
-        let operands: [Double] = input.split {
-            operators.contains($0)
+        let operators: [String] = componentsByOperators(from: input)
+        let operands: [Double] = input.split(with: " ").filter {
+            !operators.contains($0)
         }.map {
-            Double($0) ?? 0.0
+            Double($0) ?? 0
         }
-        operators.forEach {
-            guard let calcOperator = Operator.init(rawValue: $0) else {
+        
+        operators.map{
+            Character($0)
+        }.forEach {
+            guard let calcOperator = Operator(rawValue: $0) else {
                 return
             }
             formula.operators.enQueue(calcOperator)
@@ -26,14 +27,16 @@ enum ExpressionParser {
         operands.forEach {
             formula.operands.enQueue($0)
         }
+        
         return formula
     }
     static private func componentsByOperators(from input: String) -> [String] {
         let operatorList = Operator.allCases.map {
-            "\(String($0.rawValue))"
+            String($0.rawValue)
         }
-        return input.filter {
-            operatorList.contains(String($0)) == true
+        let components = input.components(separatedBy: " ")
+        return components.filter {
+            operatorList.contains(String($0))
         }.map {
             String($0)
         }

--- a/Calculator/Calculator/CalculatorQueue/ExpressionParser.swift
+++ b/Calculator/Calculator/CalculatorQueue/ExpressionParser.swift
@@ -6,39 +6,32 @@
 //
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        let operandsQueue = CalculatorItemQueue()
-        let operatorQueue = CalculatorItemQueue()
-        let formula = Formula(operands: operandsQueue, operators: operatorQueue)
-        let operators: [String] = componentsByOperators(from: input)
-        let operands: [Double] = input.split(with: " ").filter {
-            !operators.contains($0)
-        }.map {
-            Double($0) ?? 0
+        let operandsQueue = CalculatorItemQueue<Double>()
+        let operatorQueue = CalculatorItemQueue<Operator>()
+        var formula = Formula(operands: operandsQueue, operators: operatorQueue)
+        let operands: [String] = componentsByOperators(from: input)
+        let inputSpacesRemoved = input.split(with: Character(" ")).joined()
+        let operators = inputSpacesRemoved.filter { !$0.isNumber }.map { String($0) }
+    
+        operators.forEach {
+            if let `operator` = Operator(rawValue: Character($0)) {
+                formula.operators.enqueue(`operator`)
+            }
         }
         
-        operators.map{
-            Character($0)
-        }.forEach {
-            guard let calcOperator = Operator(rawValue: $0) else {
-                return
-            }
-            formula.operators.enQueue(calcOperator)
-        }
         operands.forEach {
-            formula.operands.enQueue($0)
+            if let operand = Double($0) {
+                formula.operands.enqueue(operand)
+            }
         }
         
         return formula
     }
+    
     static private func componentsByOperators(from input: String) -> [String] {
-        let operatorList = Operator.allCases.map {
-            String($0.rawValue)
-        }
-        let components = input.components(separatedBy: " ")
-        return components.filter {
-            operatorList.contains(String($0))
-        }.map {
-            String($0)
-        }
+        let inputSpacesRemoved = input.split(with: Character(" ")).joined()
+        let operands = inputSpacesRemoved.components(separatedBy:["+","−","÷","×"])
+        
+        return operands
     }
 }

--- a/Calculator/Calculator/CalculatorQueue/Formula.swift
+++ b/Calculator/Calculator/CalculatorQueue/Formula.swift
@@ -8,7 +8,7 @@ struct Formula {
     var operands: CalculatorItemQueue
     var operators: CalculatorItemQueue
     
-    mutating func result() -> Double {
+    mutating func result() throws -> Double {
         guard var lhs = operands.deQueue()?.value as? Double else {
             return 0.0
         }
@@ -19,13 +19,7 @@ struct Formula {
             guard let rhs = operands.deQueue()?.value as? Double else {
                 return lhs
             }
-            do {
-                try lhs = calcOperator.calculate(lhs: lhs, rhs: rhs)
-            } catch CalculatorError.divideByZero {
-                debugPrint("CalculatorError.divideByZero")
-            } catch {
-                debugPrint("Unknown Error")
-            }
+            try lhs = calcOperator.calculate(lhs: lhs, rhs: rhs)            
         }
         return lhs
     }

--- a/Calculator/Calculator/CalculatorQueue/Formula.swift
+++ b/Calculator/Calculator/CalculatorQueue/Formula.swift
@@ -5,22 +5,26 @@
 //  Created by 유한석 on 2022/05/19.
 //
 struct Formula {
-    var operands: CalculatorItemQueue
-    var operators: CalculatorItemQueue
+    var operands: CalculatorItemQueue<Double>
+    var operators: CalculatorItemQueue<Operator>
     
     mutating func result() throws -> Double {
-        guard var lhs = operands.deQueue()?.value as? Double else {
+        guard var formulaResult = operands.dequeue()?.value else {
             return 0.0
         }
+        
         while operators.count > 0, operands.count > 0 {
-            guard let calcOperator = operators.deQueue()?.value as? Operator else {
-                return lhs
+            guard let `operator` = operators.dequeue()?.value else {
+                return formulaResult
             }
-            guard let rhs = operands.deQueue()?.value as? Double else {
-                return lhs
+            
+            guard let operand = operands.dequeue()?.value else {
+                return formulaResult
             }
-            try lhs = calcOperator.calculate(lhs: lhs, rhs: rhs)            
+            
+            try formulaResult = `operator`.calculate(lhs: formulaResult, rhs: operand)            
         }
-        return lhs
+        
+        return formulaResult
     }
 }

--- a/Calculator/Calculator/CalculatorQueue/Node.swift
+++ b/Calculator/Calculator/CalculatorQueue/Node.swift
@@ -4,9 +4,9 @@
 //
 //  Created by 유한석 on 2022/05/18.
 //
-class Node<T> {
+class Node<T: CalculatorItem> {
     var value: T
-    var next: Node?
+    var next: Node<T>?
     
     init(value: T) {
         self.value = value

--- a/Calculator/Calculator/NameSpace.swift
+++ b/Calculator/Calculator/NameSpace.swift
@@ -5,9 +5,11 @@
 //  Created by 유한석 on 2022/05/30.
 //
 enum CalcAccessory {
-    static let Zero: String = "0"
-    static let DoubleZero: String = "00"
-    static let Empty: String = ""
-    static let Dot: String = "."
-    static let Spacing: String = " "
+    static let zero: String = "0"
+    static let doubleZero: String = "00"
+    static let empty: String = ""
+    static let dot: String = "."
+    static let spacing: String = " "
+    static let nan: String = "NaN"
+    static let comma: String = ","
 }

--- a/Calculator/Calculator/NameSpace.swift
+++ b/Calculator/Calculator/NameSpace.swift
@@ -1,0 +1,13 @@
+//
+//  NameSpace.swift
+//  Calculator
+//
+//  Created by 유한석 on 2022/05/30.
+//
+enum CalcAccessory {
+    static let Zero: String = "0"
+    static let DoubleZero: String = "00"
+    static let Empty: String = ""
+    static let Dot: String = "."
+    static let Spacing: String = " "
+}

--- a/Calculator/Calculator/Operator/Operator.swift
+++ b/Calculator/Calculator/Operator/Operator.swift
@@ -29,7 +29,7 @@ enum Operator: Character, CaseIterable, CalculatorItem {
         return lhs - rhs
     }
     private func divide(lhs: Double, rhs: Double) throws -> Double {
-        if rhs == 0 {
+        if rhs == 0.0 {
             throw CalculatorError.divideByZero
         } else {
             return lhs / rhs

--- a/Calculator/Calculator/Operator/Operator.swift
+++ b/Calculator/Calculator/Operator/Operator.swift
@@ -6,9 +6,9 @@
 //
 enum Operator: Character, CaseIterable, CalculatorItem {
     case add = "+"
-    case substract = "-"
-    case divide = "/"
-    case multiply = "*"
+    case substract = "−"
+    case divide = "÷"
+    case multiply = "×"
     
     func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -8,6 +8,9 @@ import UIKit
 
 class ViewController: UIViewController {
     
+    @IBOutlet weak var scrollViewContents: UIStackView!
+    @IBOutlet weak var currendOperand: UILabel!
+    @IBOutlet weak var currentOperator: UILabel!
     
     
     override func viewDidLoad() {

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -25,6 +25,9 @@ class ViewController: UIViewController {
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
         isEndOperation = false
+        guard currentOperand.text?.count ?? 0 < 20 else {
+            return
+        }
         if currentOperand.text?.first == "0" || currentOperand.text == "NaN"{
             currentOperand.text = ""
         }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 class ViewController: UIViewController {
     
     @IBOutlet weak var scrollViewContents: UIStackView!
-    @IBOutlet weak var currendOperand: UILabel!
+    @IBOutlet weak var currentOperand: UILabel!
     @IBOutlet weak var currentOperator: UILabel!
     private var operationQueue: String = ""
     private let ZERO = "0"
@@ -22,25 +22,25 @@ class ViewController: UIViewController {
     }
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
-        if currendOperand.text == "0" || currendOperand.text == "NaN" {
-            currendOperand.text = ""
+        if currentOperand.text?.first == "0" || currentOperand.text == "NaN" {
+            currentOperand.text = ""
         }
-        if currendOperand.text?.contains(".") == true,
+        if currentOperand.text?.contains(".") == true,
            sender.currentTitle == "." {
             return
         }
-        currendOperand?.text = (currendOperand?.text ?? "") + (sender.currentTitle ?? "")
+        currentOperand?.text = (currentOperand?.text ?? "") + (sender.currentTitle ?? "")
     }
     
     @IBAction func pressOperatorButton(_ sender: UIButton) {
-        guard currendOperand.text != ZERO else {
+        guard currentOperand.text != ZERO else {
             currentOperator.text = (sender.currentTitle ?? "")
             return
         }
+        addScrollViewContent()
         currentOperator.text = sender.currentTitle
-        operationQueue += "\(currendOperand?.text ?? ZERO) \(sender.currentTitle ?? "") "
+        operationQueue += "\(currentOperand?.text ?? ZERO) \(sender.currentTitle ?? "") "
         //create Scrollview Content
-        print(operationQueue)
         clearCurrentOperand()
     }
     
@@ -54,25 +54,26 @@ class ViewController: UIViewController {
         clearCurrentOperand()
     }
     @IBAction func pressReverseSignButton(_ sender: UIButton) {
-        guard currendOperand.text != ZERO else {
+        guard currentOperand.text != ZERO else {
             return
         }
-        if currendOperand.text?.first == "-" {
-            currendOperand.text?.removeFirst()
+        if currentOperand.text?.first == "-" {
+            currentOperand.text?.removeFirst()
         } else {
-            currendOperand.text = "-" + (currendOperand.text ?? "")
+            currentOperand.text = "-" + (currentOperand.text ?? "")
         }
     }
     @IBAction func pressEqualButton(_ sender: UIButton) {
-        operationQueue += currendOperand.text ?? "0"
+        addScrollViewContent()
+        operationQueue += currentOperand.text ?? "0"
         print("EQUAL BUTTON, CURRENT OPERATIONQUEUE : \(operationQueue)")
         var formula = ExpressionParser.parse(from: operationQueue)
         do {
             let operationResult = try formula.result()
             print("OperationResult : \(operationResult)")
-            currendOperand.text = String(operationResult)
+            currentOperand.text = String(operationResult)
         } catch CalculatorError.divideByZero {
-            currendOperand.text = "NaN"
+            currentOperand.text = "NaN"
         } catch {
             debugPrint("UNKNOWN ERROR")
         }
@@ -82,7 +83,7 @@ class ViewController: UIViewController {
     
     //MARK: - ViewController Method
     private func clearCurrentOperand() {
-        currendOperand.text = ZERO
+        currentOperand.text = ZERO
     }
     private func clearCurrentOperator() {
         currentOperator.text = ""
@@ -93,4 +94,24 @@ class ViewController: UIViewController {
         }
     }
 }
-
+//MARK: - UI Components
+extension ViewController {
+    private func createScrollViewContent(_ inputOperator: String, _ inputOperand: String) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.addArrangedSubview(createUILabel(inputOperator))
+        stackView.addArrangedSubview(createUILabel(inputOperand))
+        return stackView
+    }
+    private func createUILabel(_ text: String) -> UILabel {
+        let uiLabel = UILabel()
+        uiLabel.textColor = .white
+        uiLabel.font = .preferredFont(forTextStyle: .title3, compatibleWith: nil)
+        uiLabel.text = text
+        return uiLabel
+    }
+    private func addScrollViewContent() {
+        let currentContent = createScrollViewContent(currentOperator.text ?? "", currentOperand.text ?? "")
+        scrollViewContents.addArrangedSubview(currentContent)
+    }
+}

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -85,7 +85,7 @@ class ViewController: UIViewController {
         var formula = ExpressionParser.parse(from: operationStack)
         do {
             let operationResult = try formula.result()
-            currentOperand.text = stringToDecimal(String(operationResult))
+            currentOperand.text = changeDecimalStyle(String(operationResult))
         } catch CalculatorError.divideByZero {
             currentOperand.text = "NaN"
         } catch {
@@ -131,7 +131,7 @@ extension ViewController {
         operationScrollView.setContentOffset(CGPoint(x: 0,
                                             y: operationScrollView.contentSize.height - operationScrollView.bounds.height), animated: true)
     }
-    private func stringToDecimal(_ input: String?) -> String {
+    private func changeDecimalStyle(_ input: String?) -> String {
         let filteredInput = input?.filter {
             $0 != ","
         }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -74,7 +74,7 @@ class ViewController: UIViewController {
         }
     }
     @IBAction func pressEqualButton(_ sender: UIButton) {
-        if isEndOperation {
+        guard !isEndOperation else {
             return
         }
         addScrollViewContent()

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -37,7 +37,7 @@ class ViewController: UIViewController {
             return
         }
         currentOperator.text = sender.currentTitle
-        operationQueue += "\(currendOperand?.text) \(sender.currentTitle) "
+        operationQueue += "\(currendOperand?.text ?? ZERO) \(sender.currentTitle) "
         //create Scrollview Content
         print(operationQueue)
         clearCurrentOperand()
@@ -51,7 +51,13 @@ class ViewController: UIViewController {
     @IBAction func pressClearEntryButton(_ sender: UIButton) {
         clearCurrentOperand()
     }
-    
+    @IBAction func pressReverseSignButton(_ sender: UIButton) {
+        if currendOperand.text?.first == "-" {
+            currendOperand.text?.removeFirst()
+        } else {
+            currendOperand.text = "-" + (currendOperand.text ?? "")
+        }
+    }
     //MARK: - ViewController Method
     private func clearCurrentOperand() {
         currendOperand.text = ZERO

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 class ViewController: UIViewController {
-    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet weak var operationScrollView: UIScrollView!
     @IBOutlet weak var operationStackView: UIStackView!
     @IBOutlet weak var currentOperand: UILabel!
     @IBOutlet weak var currentOperator: UILabel!
@@ -130,8 +130,8 @@ extension ViewController {
         operationStackView.addArrangedSubview(currentContent)
     }
     private func scrolling() {
-        scrollView.setContentOffset(CGPoint(x: 0,
-                                            y: scrollView.contentSize.height - scrollView.bounds.height), animated: true)
+        operationScrollView.setContentOffset(CGPoint(x: 0,
+                                            y: operationScrollView.contentSize.height - operationScrollView.bounds.height), animated: true)
     }
     private func stringToDecimal(_ input: String?) -> String {
         let filteredInput = input?.filter {

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -34,10 +34,11 @@ class ViewController: UIViewController {
     
     @IBAction func pressOperatorButton(_ sender: UIButton) {
         guard currendOperand.text != ZERO else {
+            currentOperator.text = (sender.currentTitle ?? "")
             return
         }
         currentOperator.text = sender.currentTitle
-        operationQueue += "\(currendOperand?.text ?? ZERO) \(sender.currentTitle) "
+        operationQueue += "\(currendOperand?.text ?? ZERO) \(sender.currentTitle ?? "") "
         //create Scrollview Content
         print(operationQueue)
         clearCurrentOperand()
@@ -52,6 +53,9 @@ class ViewController: UIViewController {
         clearCurrentOperand()
     }
     @IBAction func pressReverseSignButton(_ sender: UIButton) {
+        guard currendOperand.text != ZERO else {
+            return
+        }
         if currendOperand.text?.first == "-" {
             currendOperand.text?.removeFirst()
         } else {

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -124,10 +124,8 @@ class ViewController: UIViewController {
         
         addCurrentOperationToScrollViewContent()
         operationStack += currentOperand.text ?? CalcAccessory.Zero
-        operationStack = operationStack.filter {
-            $0 != ","
-        }
         var formula = ExpressionParser.parse(from: operationStack)
+        
         do {
             let operationResult = try formula.result()
             currentOperand.text = changeDecimalStyle(String(operationResult))

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -8,6 +8,7 @@ import UIKit
 
 class ViewController: UIViewController {
     
+    @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var scrollViewContents: UIStackView!
     @IBOutlet weak var currentOperand: UILabel!
     @IBOutlet weak var currentOperator: UILabel!
@@ -42,6 +43,7 @@ class ViewController: UIViewController {
         operationQueue += "\(currentOperand?.text ?? ZERO) \(sender.currentTitle ?? "") "
         //create Scrollview Content
         clearCurrentOperand()
+        scrolling()
     }
     
     @IBAction func pressAllClearButton(_ sender: UIButton) {
@@ -79,6 +81,7 @@ class ViewController: UIViewController {
         }
         clearCurrentOperator()
         operationQueue = ""
+        scrolling()
     }
     
     //MARK: - ViewController Method
@@ -113,5 +116,9 @@ extension ViewController {
     private func addScrollViewContent() {
         let currentContent = createScrollViewContent(currentOperator.text ?? "", currentOperand.text ?? "")
         scrollViewContents.addArrangedSubview(currentContent)
+    }
+    private func scrolling() {
+        scrollView.setContentOffset(CGPoint(x: 0,
+                                            y: scrollView.contentSize.height - scrollView.bounds.height), animated: true)
     }
 }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -13,6 +13,9 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
-
+    @IBAction func pressOperandButton(_ sender: UIButton) {
+        
+    }
+    
 }
 

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -9,83 +9,78 @@ import UIKit
 class ViewController: UIViewController {
     @IBOutlet weak var operationScrollView: UIScrollView!
     @IBOutlet weak var operationStackView: UIStackView!
-    @IBOutlet weak var currentOperand: UILabel!
-    @IBOutlet weak var currentOperator: UILabel!
+    @IBOutlet weak var currentOperandLabel: UILabel!
+    @IBOutlet weak var currentOperatorLabel: UILabel!
     private var operationStack: String = ""
     
     override func viewDidLoad() {
         super.viewDidLoad()
         clearOperationScrollviewContent()
-        clearCurrentOperandUILabel()
-        clearCurrentOperatorUILabel()
-        // Do any additional setup after loading the view.
+        clearCurrentOperandLabel()
+        clearCurrentOperatorLabel()
     }
     
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
-        let operandLabel = currentOperand.text ?? CalcAccessory.Empty
+        let operandLabel = currentOperandLabel.text ?? CalcAccessory.empty
         
-        guard sender.currentTitle != CalcAccessory.Dot || currentOperand.text?.contains(CalcAccessory.Dot) == false
-        else {
+        if sender.currentTitle == CalcAccessory.dot, currentOperandLabel.text?.contains(CalcAccessory.dot) == true {
             return
         }
         
-        if operandLabel == CalcAccessory.Zero,
-            (sender.currentTitle == CalcAccessory.Zero || sender.currentTitle == CalcAccessory.DoubleZero) {
+        if operandLabel == CalcAccessory.zero,
+            (sender.currentTitle == CalcAccessory.zero || sender.currentTitle == CalcAccessory.doubleZero) {
             return
-        } else if operandLabel == CalcAccessory.Zero, sender.currentTitle != CalcAccessory.Dot {
-            currentOperand.text = CalcAccessory.Empty
+        } else if operandLabel == CalcAccessory.zero, sender.currentTitle != CalcAccessory.dot {
+            currentOperandLabel.text = CalcAccessory.empty
         }
         
-        if operandLabel == "NaN" {
+        if operandLabel == CalcAccessory.nan {
             switch sender.currentTitle {
-            case CalcAccessory.DoubleZero:
-                currentOperand.text = CalcAccessory.Zero
+            case CalcAccessory.doubleZero, CalcAccessory.zero:
+                currentOperandLabel.text = CalcAccessory.zero
                 return
-            case CalcAccessory.Dot:
-                currentOperand.text = CalcAccessory.Zero + CalcAccessory.Dot
-                return
-            case CalcAccessory.Zero:
-                currentOperand.text = CalcAccessory.Zero
+            case CalcAccessory.dot:
+                currentOperandLabel.text = CalcAccessory.zero + CalcAccessory.dot
                 return
             default:
-                currentOperand.text = CalcAccessory.Empty
+                currentOperandLabel.text = CalcAccessory.empty
             }
         }
         
-        currentOperand?.text = (currentOperand?.text ?? CalcAccessory.Empty) + (sender.currentTitle ?? CalcAccessory.Empty)
+        currentOperandLabel?.text = (currentOperandLabel?.text ?? CalcAccessory.empty) + (sender.currentTitle ?? CalcAccessory.empty)
     }
 
     @IBAction func pressOperatorButton(_ sender: UIButton) {
-        guard currentOperand.text != CalcAccessory.Zero else {
-            currentOperator.text = (sender.currentTitle ?? CalcAccessory.Empty)
+        guard currentOperandLabel.text != CalcAccessory.zero else {
+            currentOperatorLabel.text = (sender.currentTitle ?? CalcAccessory.empty)
             return
         }
         
-        if currentOperand.text?.last == Character(CalcAccessory.Dot) {
-            currentOperand.text?.removeLast()
+        if currentOperandLabel.text?.last == Character(CalcAccessory.dot) {
+            currentOperandLabel.text?.removeLast()
         }
         
         addCurrentOperationToScrollViewContent()
-        operationStack += "\(currentOperand?.text ?? CalcAccessory.Zero) \(sender.currentTitle ?? CalcAccessory.Empty) "
-        currentOperator.text = sender.currentTitle
-        clearCurrentOperandUILabel()
-        scrollingUnder()
+        operationStack += "\(currentOperandLabel?.text ?? CalcAccessory.zero) \(sender.currentTitle ?? CalcAccessory.empty) "
+        currentOperatorLabel.text = sender.currentTitle
+        clearCurrentOperandLabel()
+        scrollToBottom()
     }
     
     @IBAction func allClearButtonDidTap(_ sender: UIButton) {
-        operationStack = CalcAccessory.Empty
+        operationStack = CalcAccessory.empty
         clearOperationScrollviewContent()
-        clearCurrentOperandUILabel()
-        clearCurrentOperatorUILabel()
+        clearCurrentOperandLabel()
+        clearCurrentOperatorLabel()
     }
     
     @IBAction func clearEntryButtonDidTap(_ sender: UIButton) {
-        clearCurrentOperandUILabel()
+        clearCurrentOperandLabel()
     }
     
     @IBAction func reverseSignButtonDidTap(_ sender: UIButton) {
-        guard let operandDisplayed = currentOperand.text, operandDisplayed != "NaN" else {
+        guard let operandDisplayed = currentOperandLabel.text, operandDisplayed != CalcAccessory.nan else {
             return
         }
         
@@ -93,25 +88,25 @@ class ViewController: UIViewController {
             return
         }
         
-        if currentOperand.text?.first == "-" {
-            currentOperand.text?.removeFirst()
+        if currentOperandLabel.text?.first == "-" {
+            currentOperandLabel.text?.removeFirst()
         } else {
-            currentOperand.text = "-" + (currentOperand.text ?? CalcAccessory.Empty)
+            currentOperandLabel.text = "-" + (currentOperandLabel.text ?? CalcAccessory.empty)
         }
     }
     
     func canAttachMinus(to operand: String) -> Bool {
-        var result = CalcAccessory.Empty
+        var result = CalcAccessory.empty
         
-        if operand.contains(CalcAccessory.Dot) {
-            result = operand.replacingOccurrences(of: CalcAccessory.Dot, with: CalcAccessory.Empty)
+        if operand.contains(CalcAccessory.dot) {
+            result = operand.replacingOccurrences(of: CalcAccessory.dot, with: CalcAccessory.empty)
         } else {
             result = operand
         }
         
-        result = result.replacingOccurrences(of: CalcAccessory.Zero, with: CalcAccessory.Empty)
+        result = result.replacingOccurrences(of: CalcAccessory.zero, with: CalcAccessory.empty)
         
-        if result == CalcAccessory.Empty {
+        if result == CalcAccessory.empty {
             return false
         }
         
@@ -119,34 +114,34 @@ class ViewController: UIViewController {
     }
     
     @IBAction func equalButtonDidTap(_ sender: UIButton) {
-        guard currentOperator.text != CalcAccessory.Empty else {
+        guard currentOperatorLabel.text != CalcAccessory.empty else {
             return
         }
         
         addCurrentOperationToScrollViewContent()
-        operationStack += currentOperand.text ?? CalcAccessory.Zero
+        operationStack += currentOperandLabel.text ?? CalcAccessory.zero
         var formula = ExpressionParser.parse(from: operationStack)
         
         do {
             let operationResult = try formula.result()
-            currentOperand.text = changeDecimalStyle(String(operationResult))
+            currentOperandLabel.text = changeDecimalStyle(String(operationResult))
         } catch CalculatorError.divideByZero {
-            currentOperand.text = "NaN"
+            currentOperandLabel.text = CalcAccessory.nan
         } catch {
             debugPrint("UNKNOWN ERROR")
         }
         
-        clearCurrentOperatorUILabel()
-        operationStack = CalcAccessory.Empty
-        scrollingUnder()
+        clearCurrentOperatorLabel()
+        operationStack = CalcAccessory.empty
+        scrollToBottom()
     }
     
-    private func clearCurrentOperandUILabel() {
-        currentOperand.text = CalcAccessory.Zero
+    private func clearCurrentOperandLabel() {
+        currentOperandLabel.text = CalcAccessory.zero
     }
     
-    private func clearCurrentOperatorUILabel() {
-        currentOperator.text = CalcAccessory.Empty
+    private func clearCurrentOperatorLabel() {
+        currentOperatorLabel.text = CalcAccessory.empty
     }
     
     private func clearOperationScrollviewContent() {
@@ -160,8 +155,8 @@ class ViewController: UIViewController {
 extension ViewController {
     private func addCurrentOperationToScrollViewContent() {
         let currentContent = createOpearionStackViewContent(
-            inputOperator: currentOperator.text ?? CalcAccessory.Empty,
-            inputOperand: currentOperand.text ?? CalcAccessory.Empty
+            inputOperator: currentOperatorLabel.text ?? CalcAccessory.empty,
+            inputOperand: currentOperandLabel.text ?? CalcAccessory.empty
         )
         operationStackView.addArrangedSubview(currentContent)
     }
@@ -174,16 +169,16 @@ extension ViewController {
     }
     
     private func createUILabel(_ text: String) -> UILabel {
-        let uiLabel = UILabel()
-        uiLabel.textColor = .white
-        uiLabel.font = .preferredFont(forTextStyle: .title3, compatibleWith: nil)
-        uiLabel.text = text
-        uiLabel.textAlignment = .center
+        let label = UILabel()
+        label.textColor = .white
+        label.font = .preferredFont(forTextStyle: .title3, compatibleWith: nil)
+        label.text = text
+        label.textAlignment = .center
         
-        return uiLabel
+        return label
     }
     
-    private func scrollingUnder() {
+    private func scrollToBottom() {
         operationScrollView.setContentOffset(CGPoint(x: 0,
                                                      y: operationScrollView.contentSize.height - operationScrollView.bounds.height), animated: true)
     }
@@ -193,6 +188,6 @@ extension ViewController {
         numberFormmater.numberStyle = .decimal
         numberFormmater.maximumSignificantDigits = 20
         
-        return numberFormmater.string(for: Double(input ?? CalcAccessory.Empty)) ?? CalcAccessory.Empty
+        return numberFormmater.string(for: Double(input ?? CalcAccessory.empty)) ?? CalcAccessory.empty
     }
 }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -21,36 +21,68 @@ class ViewController: UIViewController {
     }
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
-        isEndOperation = false
         guard currentOperand.text?.count ?? 0 < 20 else {
             return
-        }
-        if currentOperand.text?.first == "0" || currentOperand.text == "NaN"{
-            currentOperand.text = ""
-        }
-        if currentOperand.text?.contains(".") == true,
-           sender.currentTitle == "." {
+        } //20 자 제한
+        
+        guard currentOperand.text != "NaN" else {
+            currentOperand.text = sender.currentTitle
             return
+        } // Nan일때 입력한 operand로 교체
+        guard ((currentOperand.text?.contains(CalcAccessory.Dot)) != nil),
+              sender.currentTitle == CalcAccessory.Dot else {
+            return
+        } // dot 중복 제한
+        guard currentOperand.text != CalcAccessory.Zero,
+              sender.currentTitle != CalcAccessory.DoubleZero else {
+            currentOperand.text = CalcAccessory.Zero
+            return
+        } // 0일 때 00이면 0
+        
+        // 0 9 > 9
+        // 0 . > 0.
+        // 0 . 9 > 0.9
+        // 0 . 0 9 > 0.09
+        // 00 . > 0.
+        // 00 00 > 0
+        // 00 0 > 0
+        // 00 9 > 9
+        // 00
+        // 9 0 > 90
+        // 9 . > 9.
+        // 9 9 > 99
+        // 9 00 > 900
+        
+        if (currentOperand.text?.first == Character(CalcAccessory.Zero)),
+           (sender.currentTitle == CalcAccessory.DoubleZero)
+        {
+            return //  앞이 0일때 00이면 0냅두고 리턴
+        } else if (currentOperand.text?.first == Character(CalcAccessory.Zero)),
+                  (sender.currentTitle == CalcAccessory.Zero)
+        {
+            return // 앞이 0인데 0들어오면 0냅두고 리턴
         }
-        if currentOperand.text == "." {
-            currentOperand.text = "0."
-        }
-        currentOperand?.text = (currentOperand?.text ?? "") + (sender.currentTitle ?? "")
+        
+        if sender.currentTitle == CalcAccessory.Dot {
+            currentOperand.text = "0"
+        } // 현재 입력이 . 이면 0. 으로 변경
+        
+        currentOperand?.text = (currentOperand?.text ?? CalcAccessory.Empty) + (sender.currentTitle ?? CalcAccessory.Empty)
     }
     @IBAction func pressOperatorButton(_ sender: UIButton) {
-        guard currentOperand.text != ZERO else {
-            currentOperator.text = (sender.currentTitle ?? "")
+        guard currentOperand.text != CalcAccessory.Zero else {
+            currentOperator.text = (sender.currentTitle ?? CalcAccessory.Empty)
             return
         }
         addCurrentOperationToScrollViewContent()
         currentOperator.text = sender.currentTitle
-        operationStack += "\(currentOperand?.text ?? ZERO) \(sender.currentTitle ?? "") "
+        operationStack += "\(currentOperand?.text ?? CalcAccessory.Zero) \(sender.currentTitle ?? CalcAccessory.Empty) "
         //create Scrollview Content
         clearCurrentOperandUILabel()
         scrollingUnder()
     }
     @IBAction func pressAllClearButton(_ sender: UIButton) {
-        operationStack = ""
+        operationStack = CalcAccessory.Empty
         clearOperationScrollviewContent()
         clearCurrentOperandUILabel()
         clearCurrentOperatorUILabel()

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -12,36 +12,44 @@ class ViewController: UIViewController {
     @IBOutlet weak var currendOperand: UILabel!
     @IBOutlet weak var currentOperator: UILabel!
     private var operationQueue: String = ""
-    
+    private let ZERO = "0"
     override func viewDidLoad() {
         super.viewDidLoad()
         clearScrollviewContent()
+        clearCurrentOperand()
+        clearCurrentOperator()
         // Do any additional setup after loading the view.
     }
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
-        guard currendOperand.text != "0" else {
-            return
+        if currendOperand.text == "0" {
+            currendOperand.text = ""
         }
-        currendOperand?.text = currendOperand?.text ?? "" + (sender.currentTitle ?? "")
+        currendOperand?.text = (currendOperand?.text ?? "") + (sender.currentTitle ?? "")
     }
     
     @IBAction func pressOperatorButton(_ sender: UIButton) {
-        
+        guard currendOperand.text != ZERO else {
+            return
+        }
+        currentOperator.text = sender.currentTitle
+        operationQueue += "\(currendOperand?.text) \(sender.currentTitle) "
+        //create Scrollview Content
+        print(operationQueue)
+        clearCurrentOperand()
     }
     
     @IBAction func pressAllClearButton(_ sender: UIButton) {
         clearScrollviewContent()
         clearCurrentOperand()
         clearCurrentOperator()
-        
     }
     @IBAction func pressClearEntryButton(_ sender: UIButton) {
         clearCurrentOperand()
     }
     //MARK: - ViewController Method
     private func clearCurrentOperand() {
-        currendOperand.text = "0"
+        currendOperand.text = ZERO
     }
     private func clearCurrentOperator() {
         currentOperator.text = ""

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -14,6 +14,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var currentOperator: UILabel!
     private var operationQueue: String = ""
     private let ZERO = "0"
+    private var isEndOperation = false
     override func viewDidLoad() {
         super.viewDidLoad()
         clearScrollviewContent()
@@ -23,7 +24,8 @@ class ViewController: UIViewController {
     }
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
-        if currentOperand.text?.first == "0" || currentOperand.text == "NaN" {
+        isEndOperation = false
+        if currentOperand.text?.first == "0" || currentOperand.text == "NaN"{
             currentOperand.text = ""
         }
         if currentOperand.text?.contains(".") == true,
@@ -70,6 +72,9 @@ class ViewController: UIViewController {
         }
     }
     @IBAction func pressEqualButton(_ sender: UIButton) {
+        if isEndOperation {
+            return
+        }
         addScrollViewContent()
         operationQueue += currentOperand.text ?? ZERO
         operationQueue = operationQueue.filter {
@@ -87,6 +92,7 @@ class ViewController: UIViewController {
         clearCurrentOperator()
         operationQueue = ""
         scrolling()
+        isEndOperation = true
     }
     
     //MARK: - ViewController Method

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -11,10 +11,11 @@ class ViewController: UIViewController {
     @IBOutlet weak var scrollViewContents: UIStackView!
     @IBOutlet weak var currendOperand: UILabel!
     @IBOutlet weak var currentOperator: UILabel!
-    
+    private var operationQueue: String = ""
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        clearScrollviewContent()
         // Do any additional setup after loading the view.
     }
     // MARK: - IBAction
@@ -24,6 +25,23 @@ class ViewController: UIViewController {
     
     @IBAction func pressOperatorButton(_ sender: UIButton) {
         
+    }
+    
+    @IBAction func pressAllClearButton(_ sender: UIButton) {
+        clearScrollviewContent()
+        clearCurrentOperand()
+    }
+    @IBAction func pressClearEntryButton(_ sender: UIButton) {
+        clearCurrentOperand()
+    }
+    //MARK: - ViewController Method
+    private func clearCurrentOperand() {
+        currendOperand.text = "0"
+    }
+    private func clearScrollviewContent() {
+        scrollViewContents.subviews.forEach { UIView in
+            UIView.removeFromSuperview()
+        }
     }
 }
 

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -45,6 +45,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func pressAllClearButton(_ sender: UIButton) {
+        operationQueue = ""
         clearScrollviewContent()
         clearCurrentOperand()
         clearCurrentOperator()
@@ -62,6 +63,23 @@ class ViewController: UIViewController {
             currendOperand.text = "-" + (currendOperand.text ?? "")
         }
     }
+    @IBAction func pressEqualButton(_ sender: UIButton) {
+        operationQueue += currendOperand.text ?? "0"
+        print("EQUAL BUTTON, CURRENT OPERATIONQUEUE : \(operationQueue)")
+        var formula = ExpressionParser.parse(from: operationQueue)
+        do {
+            let operationResult = try formula.result()
+            print("OperationResult : \(operationResult)")
+            currendOperand.text = String(operationResult)
+            operationQueue = ""
+            clearCurrentOperator()
+        } catch CalculatorError.divideByZero {
+            
+        } catch {
+            debugPrint("UNKNOWN ERROR")
+        }
+    }
+    
     //MARK: - ViewController Method
     private func clearCurrentOperand() {
         currendOperand.text = ZERO

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -7,15 +7,20 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
-
+    // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
         
     }
     
+    @IBAction func pressOperatorButton(_ sender: UIButton) {
+        
+    }
 }
 

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -11,7 +11,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var operationStackView: UIStackView!
     @IBOutlet weak var currentOperand: UILabel!
     @IBOutlet weak var currentOperator: UILabel!
-    private var operationQueue: String = ""
+    private var operationStack: String = ""
     private let ZERO = "0"
     private var isEndOperation = false
     
@@ -48,14 +48,14 @@ class ViewController: UIViewController {
         }
         addScrollViewContent()
         currentOperator.text = sender.currentTitle
-        operationQueue += "\(currentOperand?.text ?? ZERO) \(sender.currentTitle ?? "") "
+        operationStack += "\(currentOperand?.text ?? ZERO) \(sender.currentTitle ?? "") "
         //create Scrollview Content
         clearCurrentOperand()
         scrolling()
     }
     
     @IBAction func pressAllClearButton(_ sender: UIButton) {
-        operationQueue = ""
+        operationStack = ""
         clearScrollviewContent()
         clearCurrentOperand()
         clearCurrentOperator()
@@ -78,11 +78,11 @@ class ViewController: UIViewController {
             return
         }
         addScrollViewContent()
-        operationQueue += currentOperand.text ?? ZERO
-        operationQueue = operationQueue.filter {
+        operationStack += currentOperand.text ?? ZERO
+        operationStack = operationStack.filter {
             $0 != ","
         }
-        var formula = ExpressionParser.parse(from: operationQueue)
+        var formula = ExpressionParser.parse(from: operationStack)
         do {
             let operationResult = try formula.result()
             currentOperand.text = stringToDecimal(String(operationResult))
@@ -92,7 +92,7 @@ class ViewController: UIViewController {
             debugPrint("UNKNOWN ERROR")
         }
         clearCurrentOperator()
-        operationQueue = ""
+        operationStack = ""
         scrolling()
         isEndOperation = true
     }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -111,12 +111,14 @@ class ViewController: UIViewController {
 }
 //MARK: - UI Components
 extension ViewController {
-    private func createScrollViewContent(_ inputOperator: String, _ inputOperand: String) -> UIStackView {
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.addArrangedSubview(createUILabel(inputOperator))
-        stackView.addArrangedSubview(createUILabel(inputOperand))
-        return stackView
+    private func addScrollViewContent() {
+        let currentContent = createOpearionStackViewContent(currentOperator.text ?? "", currentOperand.text ?? "")
+        operationStackView.addArrangedSubview(currentContent)
+    }
+    private func createOpearionStackViewContent(_ inputOperator: String, _ inputOperand: String) -> UILabel {
+        let currentOperation = "\(inputOperator) \(inputOperand)"
+        let currentOperationUILabel = createUILabel(currentOperation)
+        return currentOperationUILabel
     }
     private func createUILabel(_ text: String) -> UILabel {
         let uiLabel = UILabel()
@@ -124,10 +126,6 @@ extension ViewController {
         uiLabel.font = .preferredFont(forTextStyle: .title3, compatibleWith: nil)
         uiLabel.text = text
         return uiLabel
-    }
-    private func addScrollViewContent() {
-        let currentContent = createScrollViewContent(currentOperator.text ?? "", currentOperand.text ?? "")
-        operationStackView.addArrangedSubview(currentContent)
     }
     private func scrolling() {
         operationScrollView.setContentOffset(CGPoint(x: 0,

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -32,9 +32,8 @@ class ViewController: UIViewController {
            sender.currentTitle == "." {
             return
         }
-        if currentOperand.text?.first == "0",
-           sender.currentTitle == "." {
-            currentOperand.text = "0.0"
+        if currentOperand.text == "." {
+            currentOperand.text = "0."
         }
         currentOperand?.text = (currentOperand?.text ?? "") + (sender.currentTitle ?? "")
     }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -19,6 +19,7 @@ class ViewController: UIViewController {
         clearCurrentOperatorUILabel()
         // Do any additional setup after loading the view.
     }
+    
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
         let operandLabel = currentOperand.text ?? CalcAccessory.Empty
@@ -59,13 +60,18 @@ class ViewController: UIViewController {
             currentOperator.text = (sender.currentTitle ?? CalcAccessory.Empty)
             return
         }
+        
+        if currentOperand.text?.last == "." {
+            currentOperand.text?.removeLast()
+        }
+        
         addCurrentOperationToScrollViewContent()
+        operationStack += "\(currentOperand?.text ?? CalcAccessory.Zero) \(sender.currentTitle ?? CalcAccessory.Empty) "
         currentOperator.text = sender.currentTitle
-        operationStack += "\(currentOperand?.text ?? CalcAccessory.Zero) \(sender.currentTitle ?? CalcAccessory.Empty)"
-        //create Scrollview Content
         clearCurrentOperandUILabel()
         scrollingUnder()
     }
+    
     @IBAction func pressAllClearButton(_ sender: UIButton) {
         operationStack = CalcAccessory.Empty
         clearOperationScrollviewContent()

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -25,6 +25,10 @@ class ViewController: UIViewController {
         if currendOperand.text == "0" {
             currendOperand.text = ""
         }
+        if currendOperand.text?.contains(".") == true,
+           sender.currentTitle == "." {
+            return
+        }
         currendOperand?.text = (currendOperand?.text ?? "") + (sender.currentTitle ?? "")
     }
     
@@ -47,6 +51,7 @@ class ViewController: UIViewController {
     @IBAction func pressClearEntryButton(_ sender: UIButton) {
         clearCurrentOperand()
     }
+    
     //MARK: - ViewController Method
     private func clearCurrentOperand() {
         currendOperand.text = ZERO

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -112,10 +112,13 @@ class ViewController: UIViewController {
 //MARK: - UI Components
 extension ViewController {
     private func addScrollViewContent() {
-        let currentContent = createOpearionStackViewContent(currentOperator.text ?? "", currentOperand.text ?? "")
+        let currentContent = createOpearionStackViewContent(
+            inputOperator: currentOperator.text ?? "",
+            inputOperand: currentOperand.text ?? ""
+        )
         operationStackView.addArrangedSubview(currentContent)
     }
-    private func createOpearionStackViewContent(_ inputOperator: String, _ inputOperand: String) -> UILabel {
+    private func createOpearionStackViewContent(inputOperator: String, inputOperand: String) -> UILabel {
         let currentOperation = "\(inputOperator) \(inputOperand)"
         let currentOperationUILabel = createUILabel(currentOperation)
         return currentOperationUILabel

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -30,7 +30,11 @@ class ViewController: UIViewController {
            sender.currentTitle == "." {
             return
         }
-        currentOperand?.text = stringToDecimal((currentOperand?.text ?? "") + (sender.currentTitle ?? ""))
+        if currentOperand.text?.first == "0",
+           sender.currentTitle == "." {
+            currentOperand.text = "0.0"
+        }
+        currentOperand?.text = (currentOperand?.text ?? "") + (sender.currentTitle ?? "")
     }
     
     @IBAction func pressOperatorButton(_ sender: UIButton) {

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: UIViewController {
            sender.currentTitle == "." {
             return
         }
-        currentOperand?.text = (currentOperand?.text ?? "") + (sender.currentTitle ?? "")
+        currentOperand?.text = stringToDecimal((currentOperand?.text ?? "") + (sender.currentTitle ?? ""))
     }
     
     @IBAction func pressOperatorButton(_ sender: UIButton) {
@@ -67,13 +67,14 @@ class ViewController: UIViewController {
     }
     @IBAction func pressEqualButton(_ sender: UIButton) {
         addScrollViewContent()
-        operationQueue += currentOperand.text ?? "0"
-        print("EQUAL BUTTON, CURRENT OPERATIONQUEUE : \(operationQueue)")
+        operationQueue += currentOperand.text ?? ZERO
+        operationQueue = operationQueue.filter {
+            $0 != ","
+        }
         var formula = ExpressionParser.parse(from: operationQueue)
         do {
             let operationResult = try formula.result()
-            print("OperationResult : \(operationResult)")
-            currentOperand.text = String(operationResult)
+            currentOperand.text = stringToDecimal(String(operationResult))
         } catch CalculatorError.divideByZero {
             currentOperand.text = "NaN"
         } catch {
@@ -120,5 +121,14 @@ extension ViewController {
     private func scrolling() {
         scrollView.setContentOffset(CGPoint(x: 0,
                                             y: scrollView.contentSize.height - scrollView.bounds.height), animated: true)
+    }
+    private func stringToDecimal(_ input: String?) -> String {
+        let filteredInput = input?.filter {
+            $0 != ","
+        }
+        let numberFormmater = NumberFormatter()
+        numberFormmater.numberStyle = .decimal
+        numberFormmater.maximumSignificantDigits = 20
+        return numberFormmater.string(for: Double(filteredInput ?? "")) ?? ""
     }
 }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -17,9 +17,9 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        clearScrollviewContent()
-        clearCurrentOperand()
-        clearCurrentOperator()
+        clearOperationScrollviewContent()
+        clearCurrentOperandUILabel()
+        clearCurrentOperatorUILabel()
         // Do any additional setup after loading the view.
     }
     // MARK: - IBAction
@@ -40,28 +40,26 @@ class ViewController: UIViewController {
         }
         currentOperand?.text = (currentOperand?.text ?? "") + (sender.currentTitle ?? "")
     }
-    
     @IBAction func pressOperatorButton(_ sender: UIButton) {
         guard currentOperand.text != ZERO else {
             currentOperator.text = (sender.currentTitle ?? "")
             return
         }
-        addScrollViewContent()
+        addCurrentOperationToScrollViewContent()
         currentOperator.text = sender.currentTitle
         operationStack += "\(currentOperand?.text ?? ZERO) \(sender.currentTitle ?? "") "
         //create Scrollview Content
-        clearCurrentOperand()
-        scrolling()
+        clearCurrentOperandUILabel()
+        scrollingUnder()
     }
-    
     @IBAction func pressAllClearButton(_ sender: UIButton) {
         operationStack = ""
-        clearScrollviewContent()
-        clearCurrentOperand()
-        clearCurrentOperator()
+        clearOperationScrollviewContent()
+        clearCurrentOperandUILabel()
+        clearCurrentOperatorUILabel()
     }
     @IBAction func pressClearEntryButton(_ sender: UIButton) {
-        clearCurrentOperand()
+        clearCurrentOperandUILabel()
     }
     @IBAction func pressReverseSignButton(_ sender: UIButton) {
         guard currentOperand.text != ZERO else {
@@ -77,7 +75,7 @@ class ViewController: UIViewController {
         guard !isEndOperation else {
             return
         }
-        addScrollViewContent()
+        addCurrentOperationToScrollViewContent()
         operationStack += currentOperand.text ?? ZERO
         operationStack = operationStack.filter {
             $0 != ","
@@ -91,19 +89,19 @@ class ViewController: UIViewController {
         } catch {
             debugPrint("UNKNOWN ERROR")
         }
-        clearCurrentOperator()
+        clearCurrentOperatorUILabel()
         operationStack = ""
-        scrolling()
+        scrollingUnder()
         isEndOperation = true
     }
     
-    private func clearCurrentOperand() {
+    private func clearCurrentOperandUILabel() {
         currentOperand.text = ZERO
     }
-    private func clearCurrentOperator() {
+    private func clearCurrentOperatorUILabel() {
         currentOperator.text = ""
     }
-    private func clearScrollviewContent() {
+    private func clearOperationScrollviewContent() {
         operationStackView.subviews.forEach { UIView in
             UIView.removeFromSuperview()
         }
@@ -111,7 +109,7 @@ class ViewController: UIViewController {
 }
 //MARK: - UI Components
 extension ViewController {
-    private func addScrollViewContent() {
+    private func addCurrentOperationToScrollViewContent() {
         let currentContent = createOpearionStackViewContent(
             inputOperator: currentOperator.text ?? "",
             inputOperand: currentOperand.text ?? ""
@@ -130,7 +128,7 @@ extension ViewController {
         uiLabel.text = text
         return uiLabel
     }
-    private func scrolling() {
+    private func scrollingUnder() {
         operationScrollView.setContentOffset(CGPoint(x: 0,
                                             y: operationScrollView.contentSize.height - operationScrollView.bounds.height), animated: true)
     }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -97,7 +97,6 @@ class ViewController: UIViewController {
         isEndOperation = true
     }
     
-    //MARK: - ViewController Method
     private func clearCurrentOperand() {
         currentOperand.text = ZERO
     }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -2,7 +2,7 @@
 //  Calculator - ViewController.swift
 //  Created by yagom. 
 //  Copyright © yagom. All rights reserved.
-// 
+//
 
 import UIKit
 
@@ -12,9 +12,6 @@ class ViewController: UIViewController {
     @IBOutlet weak var currentOperand: UILabel!
     @IBOutlet weak var currentOperator: UILabel!
     private var operationStack: String = ""
-    private let ZERO = "0"
-    private var isEndOperation = false
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         clearOperationScrollviewContent()
@@ -62,21 +59,22 @@ class ViewController: UIViewController {
         clearCurrentOperandUILabel()
     }
     @IBAction func pressReverseSignButton(_ sender: UIButton) {
-        guard currentOperand.text != ZERO else {
+        guard currentOperand.text != CalcAccessory.Zero else {
             return
         }
         if currentOperand.text?.first == "-" {
             currentOperand.text?.removeFirst()
         } else {
-            currentOperand.text = "-" + (currentOperand.text ?? "")
+            currentOperand.text = "-" + (currentOperand.text ?? CalcAccessory.Empty)
         }
     }
     @IBAction func pressEqualButton(_ sender: UIButton) {
-        guard !isEndOperation else {
+        guard currentOperator.text != CalcAccessory.Empty else {
             return
         }
+        
         addCurrentOperationToScrollViewContent()
-        operationStack += currentOperand.text ?? ZERO
+        operationStack += currentOperand.text ?? CalcAccessory.Zero
         operationStack = operationStack.filter {
             $0 != ","
         }
@@ -90,16 +88,15 @@ class ViewController: UIViewController {
             debugPrint("UNKNOWN ERROR")
         }
         clearCurrentOperatorUILabel()
-        operationStack = ""
+        operationStack = CalcAccessory.Empty
         scrollingUnder()
-        isEndOperation = true
     }
     
     private func clearCurrentOperandUILabel() {
-        currentOperand.text = ZERO
+        currentOperand.text = CalcAccessory.Zero
     }
     private func clearCurrentOperatorUILabel() {
-        currentOperator.text = ""
+        currentOperator.text = CalcAccessory.Empty
     }
     private func clearOperationScrollviewContent() {
         operationStackView.subviews.forEach { UIView in
@@ -111,8 +108,8 @@ class ViewController: UIViewController {
 extension ViewController {
     private func addCurrentOperationToScrollViewContent() {
         let currentContent = createOpearionStackViewContent(
-            inputOperator: currentOperator.text ?? "",
-            inputOperand: currentOperand.text ?? ""
+            inputOperator: currentOperator.text ?? CalcAccessory.Empty,
+            inputOperand: currentOperand.text ?? CalcAccessory.Empty
         )
         operationStackView.addArrangedSubview(currentContent)
     }
@@ -130,7 +127,7 @@ extension ViewController {
     }
     private func scrollingUnder() {
         operationScrollView.setContentOffset(CGPoint(x: 0,
-                                            y: operationScrollView.contentSize.height - operationScrollView.bounds.height), animated: true)
+                                                     y: operationScrollView.contentSize.height - operationScrollView.bounds.height), animated: true)
     }
     private func changeDecimalStyle(_ input: String?) -> String {
         let filteredInput = input?.filter {
@@ -139,6 +136,6 @@ extension ViewController {
         let numberFormmater = NumberFormatter()
         numberFormmater.numberStyle = .decimal
         numberFormmater.maximumSignificantDigits = 20
-        return numberFormmater.string(for: Double(filteredInput ?? "")) ?? ""
+        return numberFormmater.string(for: Double(filteredInput ?? CalcAccessory.Empty)) ?? CalcAccessory.Empty
     }
 }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -7,14 +7,14 @@
 import UIKit
 
 class ViewController: UIViewController {
-    
     @IBOutlet weak var scrollView: UIScrollView!
-    @IBOutlet weak var scrollViewContents: UIStackView!
+    @IBOutlet weak var operationStackView: UIStackView!
     @IBOutlet weak var currentOperand: UILabel!
     @IBOutlet weak var currentOperator: UILabel!
     private var operationQueue: String = ""
     private let ZERO = "0"
     private var isEndOperation = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         clearScrollviewContent()
@@ -104,7 +104,7 @@ class ViewController: UIViewController {
         currentOperator.text = ""
     }
     private func clearScrollviewContent() {
-        scrollViewContents.subviews.forEach { UIView in
+        operationStackView.subviews.forEach { UIView in
             UIView.removeFromSuperview()
         }
     }
@@ -127,7 +127,7 @@ extension ViewController {
     }
     private func addScrollViewContent() {
         let currentContent = createScrollViewContent(currentOperator.text ?? "", currentOperand.text ?? "")
-        scrollViewContents.addArrangedSubview(currentContent)
+        operationStackView.addArrangedSubview(currentContent)
     }
     private func scrolling() {
         scrollView.setContentOffset(CGPoint(x: 0,

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -21,54 +21,39 @@ class ViewController: UIViewController {
     }
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
-        guard currentOperand.text?.count ?? 0 < 20 else {
-            return
-        } //20 자 제한
+        let operandLabel = currentOperand.text ?? CalcAccessory.Empty
         
-        guard currentOperand.text != "NaN" else {
-            currentOperand.text = sender.currentTitle
+        guard sender.currentTitle != "." || currentOperand.text?.contains(".") == false
+        else {
             return
-        } // Nan일때 입력한 operand로 교체
-        guard ((currentOperand.text?.contains(CalcAccessory.Dot)) != nil),
-              sender.currentTitle == CalcAccessory.Dot else {
-            return
-        } // dot 중복 제한
-        guard currentOperand.text != CalcAccessory.Zero,
-              sender.currentTitle != CalcAccessory.DoubleZero else {
-            currentOperand.text = CalcAccessory.Zero
-            return
-        } // 0일 때 00이면 0
-        
-        // 0 9 > 9
-        // 0 . > 0.
-        // 0 . 9 > 0.9
-        // 0 . 0 9 > 0.09
-        // 00 . > 0.
-        // 00 00 > 0
-        // 00 0 > 0
-        // 00 9 > 9
-        // 00
-        // 9 0 > 90
-        // 9 . > 9.
-        // 9 9 > 99
-        // 9 00 > 900
-        
-        if (currentOperand.text?.first == Character(CalcAccessory.Zero)),
-           (sender.currentTitle == CalcAccessory.DoubleZero)
-        {
-            return //  앞이 0일때 00이면 0냅두고 리턴
-        } else if (currentOperand.text?.first == Character(CalcAccessory.Zero)),
-                  (sender.currentTitle == CalcAccessory.Zero)
-        {
-            return // 앞이 0인데 0들어오면 0냅두고 리턴
         }
         
-        if sender.currentTitle == CalcAccessory.Dot {
-            currentOperand.text = "0"
-        } // 현재 입력이 . 이면 0. 으로 변경
+        if operandLabel == CalcAccessory.Zero,
+            (sender.currentTitle == CalcAccessory.Zero || sender.currentTitle == CalcAccessory.DoubleZero) {
+            return
+        } else if operandLabel == CalcAccessory.Zero, sender.currentTitle != CalcAccessory.Dot {
+            currentOperand.text = CalcAccessory.Empty
+        }
+        
+        if operandLabel == "NaN" {
+            switch sender.currentTitle {
+            case CalcAccessory.DoubleZero:
+                currentOperand.text = CalcAccessory.Zero
+                return
+            case CalcAccessory.Dot:
+                currentOperand.text = CalcAccessory.Zero + CalcAccessory.Dot
+                return
+            case CalcAccessory.Zero:
+                currentOperand.text = CalcAccessory.Zero
+                return
+            default:
+                currentOperand.text = CalcAccessory.Empty
+            }
+        }
         
         currentOperand?.text = (currentOperand?.text ?? CalcAccessory.Empty) + (sender.currentTitle ?? CalcAccessory.Empty)
     }
+
     @IBAction func pressOperatorButton(_ sender: UIButton) {
         guard currentOperand.text != CalcAccessory.Zero else {
             currentOperator.text = (sender.currentTitle ?? CalcAccessory.Empty)
@@ -76,7 +61,7 @@ class ViewController: UIViewController {
         }
         addCurrentOperationToScrollViewContent()
         currentOperator.text = sender.currentTitle
-        operationStack += "\(currentOperand?.text ?? CalcAccessory.Zero) \(sender.currentTitle ?? CalcAccessory.Empty) "
+        operationStack += "\(currentOperand?.text ?? CalcAccessory.Zero) \(sender.currentTitle ?? CalcAccessory.Empty)"
         //create Scrollview Content
         clearCurrentOperandUILabel()
         scrollingUnder()

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -33,6 +33,8 @@ class ViewController: UIViewController {
     @IBAction func pressAllClearButton(_ sender: UIButton) {
         clearScrollviewContent()
         clearCurrentOperand()
+        clearCurrentOperator()
+        
     }
     @IBAction func pressClearEntryButton(_ sender: UIButton) {
         clearCurrentOperand()
@@ -40,6 +42,9 @@ class ViewController: UIViewController {
     //MARK: - ViewController Method
     private func clearCurrentOperand() {
         currendOperand.text = "0"
+    }
+    private func clearCurrentOperator() {
+        currentOperator.text = ""
     }
     private func clearScrollviewContent() {
         scrollViewContents.subviews.forEach { UIView in

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -12,6 +12,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var currentOperand: UILabel!
     @IBOutlet weak var currentOperator: UILabel!
     private var operationStack: String = ""
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         clearOperationScrollviewContent()
@@ -134,6 +135,7 @@ class ViewController: UIViewController {
         } catch {
             debugPrint("UNKNOWN ERROR")
         }
+        
         clearCurrentOperatorUILabel()
         operationStack = CalcAccessory.Empty
         scrollingUnder()
@@ -142,15 +144,18 @@ class ViewController: UIViewController {
     private func clearCurrentOperandUILabel() {
         currentOperand.text = CalcAccessory.Zero
     }
+    
     private func clearCurrentOperatorUILabel() {
         currentOperator.text = CalcAccessory.Empty
     }
+    
     private func clearOperationScrollviewContent() {
         operationStackView.subviews.forEach { UIView in
             UIView.removeFromSuperview()
         }
     }
 }
+
 //MARK: - UI Components
 extension ViewController {
     private func addCurrentOperationToScrollViewContent() {
@@ -160,29 +165,34 @@ extension ViewController {
         )
         operationStackView.addArrangedSubview(currentContent)
     }
+    
     private func createOpearionStackViewContent(inputOperator: String, inputOperand: String) -> UILabel {
         let currentOperation = "\(inputOperator) \(inputOperand)"
         let currentOperationUILabel = createUILabel(currentOperation)
+        
         return currentOperationUILabel
     }
+    
     private func createUILabel(_ text: String) -> UILabel {
         let uiLabel = UILabel()
         uiLabel.textColor = .white
         uiLabel.font = .preferredFont(forTextStyle: .title3, compatibleWith: nil)
         uiLabel.text = text
+        uiLabel.textAlignment = .center
+        
         return uiLabel
     }
+    
     private func scrollingUnder() {
         operationScrollView.setContentOffset(CGPoint(x: 0,
                                                      y: operationScrollView.contentSize.height - operationScrollView.bounds.height), animated: true)
     }
+    
     private func changeDecimalStyle(_ input: String?) -> String {
-        let filteredInput = input?.filter {
-            $0 != ","
-        }
         let numberFormmater = NumberFormatter()
         numberFormmater.numberStyle = .decimal
         numberFormmater.maximumSignificantDigits = 20
-        return numberFormmater.string(for: Double(filteredInput ?? CalcAccessory.Empty)) ?? CalcAccessory.Empty
+        
+        return numberFormmater.string(for: Double(input ?? CalcAccessory.Empty)) ?? CalcAccessory.Empty
     }
 }

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -20,7 +20,10 @@ class ViewController: UIViewController {
     }
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
-        
+        guard currendOperand.text != "0" else {
+            return
+        }
+        currendOperand?.text = currendOperand?.text ?? "" + (sender.currentTitle ?? "")
     }
     
     @IBAction func pressOperatorButton(_ sender: UIButton) {

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -22,7 +22,7 @@ class ViewController: UIViewController {
     }
     // MARK: - IBAction
     @IBAction func pressOperandButton(_ sender: UIButton) {
-        if currendOperand.text == "0" {
+        if currendOperand.text == "0" || currendOperand.text == "NaN" {
             currendOperand.text = ""
         }
         if currendOperand.text?.contains(".") == true,
@@ -71,13 +71,13 @@ class ViewController: UIViewController {
             let operationResult = try formula.result()
             print("OperationResult : \(operationResult)")
             currendOperand.text = String(operationResult)
-            operationQueue = ""
-            clearCurrentOperator()
         } catch CalculatorError.divideByZero {
-            
+            currendOperand.text = "NaN"
         } catch {
             debugPrint("UNKNOWN ERROR")
         }
+        clearCurrentOperator()
+        operationQueue = ""
     }
     
     //MARK: - ViewController Method

--- a/Calculator/Calculator/ViewController.swift
+++ b/Calculator/Calculator/ViewController.swift
@@ -24,7 +24,7 @@ class ViewController: UIViewController {
     @IBAction func pressOperandButton(_ sender: UIButton) {
         let operandLabel = currentOperand.text ?? CalcAccessory.Empty
         
-        guard sender.currentTitle != "." || currentOperand.text?.contains(".") == false
+        guard sender.currentTitle != CalcAccessory.Dot || currentOperand.text?.contains(CalcAccessory.Dot) == false
         else {
             return
         }
@@ -61,7 +61,7 @@ class ViewController: UIViewController {
             return
         }
         
-        if currentOperand.text?.last == "." {
+        if currentOperand.text?.last == Character(CalcAccessory.Dot) {
             currentOperand.text?.removeLast()
         }
         
@@ -72,26 +72,52 @@ class ViewController: UIViewController {
         scrollingUnder()
     }
     
-    @IBAction func pressAllClearButton(_ sender: UIButton) {
+    @IBAction func allClearButtonDidTap(_ sender: UIButton) {
         operationStack = CalcAccessory.Empty
         clearOperationScrollviewContent()
         clearCurrentOperandUILabel()
         clearCurrentOperatorUILabel()
     }
-    @IBAction func pressClearEntryButton(_ sender: UIButton) {
+    
+    @IBAction func clearEntryButtonDidTap(_ sender: UIButton) {
         clearCurrentOperandUILabel()
     }
-    @IBAction func pressReverseSignButton(_ sender: UIButton) {
-        guard currentOperand.text != CalcAccessory.Zero else {
+    
+    @IBAction func reverseSignButtonDidTap(_ sender: UIButton) {
+        guard let operandDisplayed = currentOperand.text, operandDisplayed != "NaN" else {
             return
         }
+        
+        guard canAttachMinus(to: operandDisplayed) == true else {
+            return
+        }
+        
         if currentOperand.text?.first == "-" {
             currentOperand.text?.removeFirst()
         } else {
             currentOperand.text = "-" + (currentOperand.text ?? CalcAccessory.Empty)
         }
     }
-    @IBAction func pressEqualButton(_ sender: UIButton) {
+    
+    func canAttachMinus(to operand: String) -> Bool {
+        var result = CalcAccessory.Empty
+        
+        if operand.contains(CalcAccessory.Dot) {
+            result = operand.replacingOccurrences(of: CalcAccessory.Dot, with: CalcAccessory.Empty)
+        } else {
+            result = operand
+        }
+        
+        result = result.replacingOccurrences(of: CalcAccessory.Zero, with: CalcAccessory.Empty)
+        
+        if result == CalcAccessory.Empty {
+            return false
+        }
+        
+        return true
+    }
+    
+    @IBAction func equalButtonDidTap(_ sender: UIButton) {
         guard currentOperator.text != CalcAccessory.Empty else {
             return
         }


### PR DESCRIPTION
안녕하세요 코리! @corykim0829 😃 계산기2 step1 PR 보냅니다!

이번 프로젝트는 보리사랑과 예톤의 코드를 합치는 과정이 주가 됐고,
오류 처리하는 데에만 시간을 엄청 쏟은 것 같습니다!
계산기 프로젝트 1에서는 보이지 않았던 오류가 서로 코드를 합치는 과정에서 더 자세히 살펴보다보니 많이 보였던 것 같습니다.

아래는 각 타입(파일)별로 누구의 코드를 선택했는지와 그 이유에 대해 상세해봤습니다! 


## [변경해준 파일(타입)]
### 1. Node
- 보리사랑과 예톤 둘다 **링크드리스트**로 큐를 구현해주어서 전반적으로 구현 과정이 비슷했습니다.
- Node의 제너릭 타입이 CalculateItem 타입만 채택하도록 한 것 ex (T: CalculateItem)이 더 확실한 것 같아 예톤의 코드를 선택해주었습니다.  
    
### 2. CalculatorList
- 보리사랑은 단방향 연결리스트에 head, tail 변수를 사용해주었고, 예톤은 단방향 연결리스트에서 head 변수만 사용해주었다는 점에서 차이가 있었습니다.
- tail을 따로 변수로 두었을 경우의 이점은 append와 remove를 해줄 때 while문을 돌며 next Node가 nil인지 판단하는 과정을 거치지 않아도 되는 것이었습니다.
- 이번 프로젝트에서는 tail이 쓰일 수 있는 경우가 append 해주는 부분밖에 없어서 변수 tail을 삭제해주었습니다.
- 예톤과 보리사랑의 코드가 거의 비슷해 tail만 삭제해주는 방식으로 진행했습니다.
  

### 3. CalculatorItemQueue
- CalculatorItemQueue의 제너릭 타입이 CalculateItem 타입만 채택하도록 해주었습니다. 
- 나중에 호출할 때 CalculatorItemQueue<Double> 이런 식으로 타입이 명시적으로 보이는게 좋을 것 같아서 변경해주었습니다.
- 타입을 클래스/구조체 중 **구조체**로 선택해주었습니다. 그 이유는 CalculatorItemQueue 타입은 expressonParser에서만 사용하고 재활용할 일이 없어 즉, 인스턴스를 공유할 일이 생기지 않다고 생각했기 때문입니다.  
    
### 4. Formula
- 둘의 코드가 비슷하여 보리의 코드를 선택하여 수정하고, 변수명은 예톤의 코드를 참고했습니다.  
    
### 5. ExpressionParser
- 메서드(componentsByOperators)을 연산자를 기준으로 **숫자만 반환해주는 방식**으로 변경해주었습니다. 
- 그에 따라 메서드(parse) 또한 변경된 메서드(componentsByOperators)을 사용하여 변경해주었습니다.
- 둘의 코드 중 어느것도 사용하지 않았고, 모두 새로 구현해주었습니다.
  

### 6. ViewController
- 메서드(pressOperandButton)의 불어나는 오류 처리 때문에 코드를 전반적으로 모두 수정해주었습니다.
                    - "NaN"에 대한 오류 처리
                    - "."에 대한 오류 처리
                    - "00"에 대한 오류 처리
- 메서드(pressOperatorButton)은 둘의 코드가 거의 비슷하여 보리의 코드를 선택했습니다.
- 메서드(allClearButton,clearEntryButtonDidTap)는 둘의 코드가 거의 비슷하였지만, 메서드로 분리해준 보리의 코드를 선택했습니다.
- 메서드(reverseSignButtonDidTap)을 전반적으로 모두 수정해주었습니다.
        - NaN일 때, 0.00일 때, 0일 때 +/- 변경안되도록 수정
        - "-"가 붙을 수 있는지 판단하는 로직 따로 메서드(canAttachMinus)로 분리
- 저희가 기존에 구현했던 코드는 두 개의 라벨을 스택뷰에 넣어주어 이 스택뷰를 또다시 스크롤뷰 내부의 스택 뷰의 하단으로 이동해주는 것이었습니다.
- 하지만 보리의 step1에서 코리의 피드백을 참고하여 `"\(inputOperator) \(inputOperand)"` 이런 식으로 한 개의 라벨에 같이 값을 넣어주고 이 라벨 자체를 스크롤뷰 내부의 스택뷰에 넣어주는 방식으로 변경했습니다. 
    
    
## [변경하지 않은 파일(타입)]
- CalculatorError
- CalculatorItemProtocol
- Operator
- Double+Extension
- String+Extension    
    
    
## [Step1에서 처리해준 오류]
- 0일 때 -가 붙지 않도록 변경해주었습니다. 
- 0.00일 때 -가 붙지 않도록 , 0.001일 때는 -가 붙도록 변경해주었습니다.
- 9%0 = NaN이 나왔을 때 숫자를 입력하면 NaN이 지워지고 숫자가 입력되도록 해주었습니다.
- 0인 상태에서 .을 입력해주면 0.으로 입력되도록 해주었습니다.

## [아직 처리하지 못한 오류]
- 숫자 입력 시 20자 제한 *
- 4 % 3을 하면 1.333333333333 이 나옴 -> 20자 모두 출력되지 않는 오류 발생
- 입력할 때부터 decimal이 적용되도록 하기 ( 1,000,000,000)
- NaN일 때 연산자 입력 못받도록 하기 *
- 스크롤 뷰에 올라가는 Label이 한 줄씩 밀리는 상황 발생 -> 동기 처리해주기
    
    
    
## [배운 개념]
- struct의 인스턴스 생성 시 var/let으로 선언하는 것의 차이점에 대해 공부
    - class는 스택 영역에서 지역 변수의 주솟값만 가지고 있기 때문에 let으로 스택영역을 변경하지 못하도록 막아버려도 클래스 인스턴스 프로퍼티 자체는 변경할 수 있게 됩니다.
    - 이와 달리 struct는 스택 영역에 지역 변수와 인스턴스 모두 올라가기 때문에 let으로 스택영역을 변경하지 못하도록 막아버리면 아예 변경할 수가 없게 됩니다.
    - 따라서 struct의 인스턴스를 생성할 시 그 내부를 변경해주고 싶을 때는 구조체 내부의 프로퍼티를 var로 선언해주고 + 외부에서 인스턴스 선언할 때 var로 선언해주어야 한다는 것을 알게되었습니다.
    
    
## [궁금한 점]
1. 아직 숫자를 입력하면 20자가 제한되도록 하는 것에 대해 처리하지 못했습니다.
    - 프로젝트 요구사항이 숫자는 최대 20자만 입력가능하도록 하는 것이었는데, 20.11111040249220 이런 식으로 입력했을 때 소수아래자리까지 합쳐서 20자를 의미하는 것인지 혹은 정수 부분의 20자만 의미하고 소수점은 상관 없는 것인지 궁금합니다!

2. 9 % 0 을 했을 경우 NaN이 출력되는데 이 상황에서 숫자를 누르면 바로 숫자로 바뀌어서 입력되도록 해주었는데, 바로 연산자를 눌렀을 때는 연산자가 입력되면 안되는 것인지 궁금합니다!
    

그럼 이번 프로젝트 PR도 잘부탁드립니다 코리👍👍