### PR TITLE
계산기 [Step 1] Jeremy

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		DFB1B46928D99F99000D17AD /* CalculatorItemQueue .swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46828D99F99000D17AD /* CalculatorItemQueue .swift */; };
+		DFB1B46B28D99FEE000D17AD /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46A28D99FEE000D17AD /* Protocols.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +26,8 @@
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DFB1B46828D99F99000D17AD /* CalculatorItemQueue .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CalculatorItemQueue .swift"; sourceTree = "<group>"; };
+		DFB1B46A28D99FEE000D17AD /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,6 +67,8 @@
 				C713D94A2570E5ED001C3AFC /* Assets.xcassets */,
 				C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */,
 				C713D94F2570E5ED001C3AFC /* Info.plist */,
+				DFB1B46828D99F99000D17AD /* CalculatorItemQueue .swift */,
+				DFB1B46A28D99FEE000D17AD /* Protocols.swift */,
 			);
 			path = Calculator;
 			sourceTree = "<group>";
@@ -140,6 +146,8 @@
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				DFB1B46B28D99FEE000D17AD /* Protocols.swift in Sources */,
+				DFB1B46928D99F99000D17AD /* CalculatorItemQueue .swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 		DFB1B46928D99F99000D17AD /* CalculatorItemQueue .swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46828D99F99000D17AD /* CalculatorItemQueue .swift */; };
 		DFB1B46B28D99FEE000D17AD /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46A28D99FEE000D17AD /* Protocols.swift */; };
+		DFB1B46D28D9A0EF000D17AD /* Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46C28D9A0EF000D17AD /* Operations.swift */; };
+		DFB1B46F28D9A0FD000D17AD /* NumberSigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46E28D9A0FD000D17AD /* NumberSigns.swift */; };
+		DFB1B47128D9A13B000D17AD /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B47028D9A13B000D17AD /* Item.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +31,9 @@
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DFB1B46828D99F99000D17AD /* CalculatorItemQueue .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CalculatorItemQueue .swift"; sourceTree = "<group>"; };
 		DFB1B46A28D99FEE000D17AD /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
+		DFB1B46C28D9A0EF000D17AD /* Operations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operations.swift; sourceTree = "<group>"; };
+		DFB1B46E28D9A0FD000D17AD /* NumberSigns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSigns.swift; sourceTree = "<group>"; };
+		DFB1B47028D9A13B000D17AD /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +75,9 @@
 				C713D94F2570E5ED001C3AFC /* Info.plist */,
 				DFB1B46828D99F99000D17AD /* CalculatorItemQueue .swift */,
 				DFB1B46A28D99FEE000D17AD /* Protocols.swift */,
+				DFB1B46C28D9A0EF000D17AD /* Operations.swift */,
+				DFB1B46E28D9A0FD000D17AD /* NumberSigns.swift */,
+				DFB1B47028D9A13B000D17AD /* Item.swift */,
 			);
 			path = Calculator;
 			sourceTree = "<group>";
@@ -143,9 +152,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DFB1B46F28D9A0FD000D17AD /* NumberSigns.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				DFB1B47128D9A13B000D17AD /* Item.swift in Sources */,
+				DFB1B46D28D9A0EF000D17AD /* Operations.swift in Sources */,
 				DFB1B46B28D99FEE000D17AD /* Protocols.swift in Sources */,
 				DFB1B46928D99F99000D17AD /* CalculatorItemQueue .swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,12 +13,23 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
-		DFB1B46928D99F99000D17AD /* CalculatorItemQueue .swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46828D99F99000D17AD /* CalculatorItemQueue .swift */; };
 		DFB1B46B28D99FEE000D17AD /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46A28D99FEE000D17AD /* Protocols.swift */; };
 		DFB1B46D28D9A0EF000D17AD /* Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46C28D9A0EF000D17AD /* Operations.swift */; };
 		DFB1B46F28D9A0FD000D17AD /* NumberSigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46E28D9A0FD000D17AD /* NumberSigns.swift */; };
 		DFB1B47128D9A13B000D17AD /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B47028D9A13B000D17AD /* Item.swift */; };
+		DFB1B49028D9A405000D17AD /* CalculatorItemQueue .swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B46828D99F99000D17AD /* CalculatorItemQueue .swift */; };
+		DFB1B49128D9A406000D17AD /* CalculatorTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB1B47828D9A1BF000D17AD /* CalculatorTesting.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		DFB1B47A28D9A1BF000D17AD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -34,10 +45,19 @@
 		DFB1B46C28D9A0EF000D17AD /* Operations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operations.swift; sourceTree = "<group>"; };
 		DFB1B46E28D9A0FD000D17AD /* NumberSigns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSigns.swift; sourceTree = "<group>"; };
 		DFB1B47028D9A13B000D17AD /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+		DFB1B47628D9A1BF000D17AD /* CalculatorTesting.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTesting.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFB1B47828D9A1BF000D17AD /* CalculatorTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTesting.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		C713D93B2570E5EB001C3AFC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DFB1B47328D9A1BF000D17AD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -51,6 +71,7 @@
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
+				DFB1B47728D9A1BF000D17AD /* CalculatorTesting */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -59,6 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
+				DFB1B47628D9A1BF000D17AD /* CalculatorTesting.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -82,6 +104,14 @@
 			path = Calculator;
 			sourceTree = "<group>";
 		};
+		DFB1B47728D9A1BF000D17AD /* CalculatorTesting */ = {
+			isa = PBXGroup;
+			children = (
+				DFB1B47828D9A1BF000D17AD /* CalculatorTesting.swift */,
+			);
+			path = CalculatorTesting;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -102,17 +132,39 @@
 			productReference = C713D93E2570E5EB001C3AFC /* Calculator.app */;
 			productType = "com.apple.product-type.application";
 		};
+		DFB1B47528D9A1BF000D17AD /* CalculatorTesting */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DFB1B47C28D9A1BF000D17AD /* Build configuration list for PBXNativeTarget "CalculatorTesting" */;
+			buildPhases = (
+				DFB1B47228D9A1BF000D17AD /* Sources */,
+				DFB1B47328D9A1BF000D17AD /* Frameworks */,
+				DFB1B47428D9A1BF000D17AD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DFB1B47B28D9A1BF000D17AD /* PBXTargetDependency */,
+			);
+			name = CalculatorTesting;
+			productName = CalculatorTesting;
+			productReference = DFB1B47628D9A1BF000D17AD /* CalculatorTesting.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C713D9362570E5EB001C3AFC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1340;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
+					};
+					DFB1B47528D9A1BF000D17AD = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
 				};
 			};
@@ -130,6 +182,7 @@
 			projectRoot = "";
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
+				DFB1B47528D9A1BF000D17AD /* CalculatorTesting */,
 			);
 		};
 /* End PBXProject section */
@@ -145,6 +198,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DFB1B47428D9A1BF000D17AD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -157,13 +217,29 @@
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				DFB1B47128D9A13B000D17AD /* Item.swift in Sources */,
+				DFB1B49028D9A405000D17AD /* CalculatorItemQueue .swift in Sources */,
 				DFB1B46D28D9A0EF000D17AD /* Operations.swift in Sources */,
 				DFB1B46B28D99FEE000D17AD /* Protocols.swift in Sources */,
-				DFB1B46928D99F99000D17AD /* CalculatorItemQueue .swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DFB1B47228D9A1BF000D17AD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DFB1B49128D9A406000D17AD /* CalculatorTesting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		DFB1B47B28D9A1BF000D17AD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = DFB1B47A28D9A1BF000D17AD /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C713D9472570E5EB001C3AFC /* Main.storyboard */ = {
@@ -344,6 +420,47 @@
 			};
 			name = Release;
 		};
+		DFB1B47D28D9A1BF000D17AD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 299MY3M6HX;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = yjjem.CalculatorTesting;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		DFB1B47E28D9A1BF000D17AD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 299MY3M6HX;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = yjjem.CalculatorTesting;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -361,6 +478,15 @@
 			buildConfigurations = (
 				C713D9532570E5ED001C3AFC /* Debug */,
 				C713D9542570E5ED001C3AFC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DFB1B47C28D9A1BF000D17AD /* Build configuration list for PBXNativeTarget "CalculatorTesting" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DFB1B47D28D9A1BF000D17AD /* Debug */,
+				DFB1B47E28D9A1BF000D17AD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+               BuildableName = "Calculator.app"
+               BlueprintName = "Calculator"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DFB1B47528D9A1BF000D17AD"
+               BuildableName = "CalculatorTesting.xctest"
+               BlueprintName = "CalculatorTesting"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Calculator/Calculator/CalculatorItemQueue .swift
+++ b/Calculator/Calculator/CalculatorItemQueue .swift
@@ -1,0 +1,17 @@
+//
+//  CalculatorItemQueue .swift
+//  Calculator
+//
+//  Created by 유제민 on 2022/09/20.
+//
+
+struct CalculatorItemQueue {
+    private var elementCount: Int = 0
+    var queue:[String: [Int: Item]] = [
+        "queue": [: ]
+    ]
+}
+
+struct Item: Hashable {
+
+}

--- a/Calculator/Calculator/CalculatorItemQueue .swift
+++ b/Calculator/Calculator/CalculatorItemQueue .swift
@@ -7,6 +7,7 @@
 
 struct CalculatorItemQueue {
     private var elementCount: Int = 0
+    private var firstElementIndex: Int = 0
     var queue:[String: [Int: Item]] = [
         "queue": [: ]
     ]
@@ -14,18 +15,18 @@ struct CalculatorItemQueue {
 
 extension CalculatorItemQueue: QueueManager {
     mutating func add(item: Item) {
-        var myQue = queue["queue"]
-        myQue?[self.elementCount] = item
+        self.queue["queue"]?[self.elementCount] = item
         elementCount += 1
     }
     
     mutating func getFirst() -> Item? {
-        return queue["queue"]?.first?.value ?? nil
+        let firstItem = queue["queue"]?[self.firstElementIndex]
+        return firstItem
     }
     
     mutating func getLast() -> Item? {
-        let lastItem = queue["queue"]?.removeValue(forKey: elementCount)
         elementCount -= 1
+        let lastItem = queue["queue"]?.removeValue(forKey: elementCount)
         return lastItem ?? nil
     }
 

--- a/Calculator/Calculator/CalculatorItemQueue .swift
+++ b/Calculator/Calculator/CalculatorItemQueue .swift
@@ -2,7 +2,7 @@
 //  CalculatorItemQueue .swift
 //  Calculator
 //
-//  Created by 유제민 on 2022/09/20.
+//  Created by Jeremy on 2022/09/20.
 //
 
 struct CalculatorItemQueue {
@@ -12,6 +12,25 @@ struct CalculatorItemQueue {
     ]
 }
 
-struct Item: Hashable {
+extension CalculatorItemQueue: QueueManager {
+    mutating func add(item: Item) {
+        var myQue = queue["queue"]
+        myQue?[self.elementCount] = item
+        elementCount += 1
+    }
+    
+    mutating func getFirst() -> Item? {
+        return queue["queue"]?.first?.value ?? nil
+    }
+    
+    mutating func getLast() -> Item? {
+        let lastItem = queue["queue"]?.removeValue(forKey: elementCount)
+        elementCount -= 1
+        return lastItem ?? nil
+    }
 
+    mutating func removeAll() {
+        queue["queue"] = [:]
+        elementCount = 0
+    }
 }

--- a/Calculator/Calculator/Item.swift
+++ b/Calculator/Calculator/Item.swift
@@ -1,0 +1,12 @@
+//
+//  Item.swift
+//  Calculator
+//
+//  Created by Jeremy on 2022/09/20.
+//
+
+struct Item: Hashable {
+    var operation: Operations?
+    var sign: NumberSigns?
+    var number: Double
+}

--- a/Calculator/Calculator/NumberSigns.swift
+++ b/Calculator/Calculator/NumberSigns.swift
@@ -1,0 +1,12 @@
+//
+//  NumberSigns.swift
+//  Calculator
+//
+//  Created by Jeremy on 2022/09/20.
+//
+
+enum NumberSigns {
+    case positive
+    case negative
+    case zero
+}

--- a/Calculator/Calculator/Operations.swift
+++ b/Calculator/Calculator/Operations.swift
@@ -1,0 +1,13 @@
+//
+//  Operations.swift
+//  Calculator
+//
+//  Created by Jeremy on 2022/09/20.
+//
+
+enum Operations {
+    case add
+    case substract
+    case multiply
+    case divide
+}

--- a/Calculator/Calculator/Protocols.swift
+++ b/Calculator/Calculator/Protocols.swift
@@ -1,0 +1,14 @@
+//
+//  Protocols.swift
+//  Calculator
+//
+//  Created by 유제민 on 2022/09/20.
+//
+
+protocol CalculatorItem { }
+protocol QueueManager {
+    mutating func add(item: Item)
+    mutating func getFirst() -> Item?
+    mutating func getLast() -> Item?
+    mutating func removeAll()
+}

--- a/Calculator/Calculator/Protocols.swift
+++ b/Calculator/Calculator/Protocols.swift
@@ -2,7 +2,7 @@
 //  Protocols.swift
 //  Calculator
 //
-//  Created by 유제민 on 2022/09/20.
+//  Created by Jeremy on 2022/09/20.
 //
 
 protocol CalculatorItem { }

--- a/Calculator/CalculatorTesting/CalculatorTesting.swift
+++ b/Calculator/CalculatorTesting/CalculatorTesting.swift
@@ -1,0 +1,35 @@
+//
+//  CalculatorTesting.swift
+//  CalculatorTesting
+//
+//  Created by 유제민 on 2022/09/20.
+//
+
+import XCTest
+@testable import Calculator
+class CalculatorTesting: XCTestCase {
+    var sut: CalculatorItemQueue!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = CalculatorItemQueue()
+    }
+    
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func test_queueu_첫번쨰_add_아이템_key_0인지_확인() {
+        
+        //given
+        let myItem = Item(number: 10)
+        sut.add(item: myItem)
+        
+        //when
+        let expected = Optional([0 : Item(number: 10)])
+        
+        //then
+        XCTAssertEqual(expected, sut.queue["queue"])
+    }
+}

--- a/Calculator/CalculatorTesting/CalculatorTesting.swift
+++ b/Calculator/CalculatorTesting/CalculatorTesting.swift
@@ -52,4 +52,16 @@ class CalculatorTesting: XCTestCase {
         //then
         XCTAssertEqual(myItem, sut.getLast())
     }
+    
+    func test_removeAll_메소드가_작동하는지_확인() {
+        //given
+        let myItem = Item(number: 123)
+        sut.add(item: myItem)
+        
+        //when
+        sut.removeAll()
+        
+        //then
+        XCTAssertEqual(sut.queue["queue"], [:])
+    }
 }

--- a/Calculator/CalculatorTesting/CalculatorTesting.swift
+++ b/Calculator/CalculatorTesting/CalculatorTesting.swift
@@ -41,4 +41,15 @@ class CalculatorTesting: XCTestCase {
         //then
         XCTAssertEqual(myItem, sut.getFirst())
     }
+    
+    func test_getLast_메소드가_작동하는지_확인() {
+        
+        //given
+        let myItem = Item(operation: .multiply, sign: .positive, number: 10)
+        sut.add(item: myItem)
+        
+        
+        //then
+        XCTAssertEqual(myItem, sut.getLast())
+    }
 }

--- a/Calculator/CalculatorTesting/CalculatorTesting.swift
+++ b/Calculator/CalculatorTesting/CalculatorTesting.swift
@@ -32,4 +32,13 @@ class CalculatorTesting: XCTestCase {
         //then
         XCTAssertEqual(expected, sut.queue["queue"])
     }
+    
+    func test_getFirst_메소드가_작동하는지_확인() {
+        //given
+        let myItem = Item(number: 10)
+        sut.add(item: myItem)
+        
+        //then
+        XCTAssertEqual(myItem, sut.getFirst())
+    }
 }


### PR DESCRIPTION
---
### 🍠 안녕하세요! 🙌
---
@leejun6694
안녕하세여 쿠마 🍠

무려 큐 구현에 딕셔너리를 써보겠다는 생각을 실현시켜 본 7기 제레미입니다...
생각보다 오래 걸려서 시간 내에 못 올렸지만.. 리뷰 잘 부탁드리겠습니다.
태클 너무 좋아요.  🫡

# 🧬UML
![](https://i.imgur.com/wnlPvtF.jpg)

# 🛠 구현 내용

- ***Dictionary***
    - **딕셔너리 선택 이유**
    List의 overhead문제, Insertion, Deletion 시간복잡도 문제 그리고 Linked List의 Search, Acess 시간복잡도 문제를 해결할 수 있는 것이 딕셔너리라는 생각이 들어 아래와 같이 구현을 시도했습니다. 다르게 표현해보자면 요소의 순서 문제만 해결된다면 딕셔너리가 Array와 Linked List의 장점들을 가지게 되겠다는 생각이 선택의 이유입니다.
    
    - **구현하면서..**
    key값으로 순서를 정의해주고 `firstElementIndex`를 정의하여 FIFO을 가능하게 만들었습니다. 딕셔너리로 구현을 해보면서 `KeyValuePairs`를 사용하면 순서가 정의된 딕셔너리를 만들 수 있다는 것을 알게되었지만 제대로 된 사용법을 몰라 사용하지 않았습니다.
    
    ``` swift
    private var elementCount: Int = 0
    private var firstElementIndex: Int = 0
    var queue = [
        0:Item,
        1:Item,
        2:Item,
        3:Item
    ]
    ```
- ***Dictionary 메소드 removeValue(forkey:)***
    ```swift
    mutating func getFirst() -> Item? {
        let firstItem = queue.removeValue(forKey: firstElementIndex)
        firstElementIndex += 1
        return firstItem
    }
    ```
- ***Item*** 구조 
    ```swift
    struct Item: Hashable, CalculatorItem {
        var operation: Operations?
        var sign: NumberSigns?
        var number: Double
    }
    ```
# 🌝 궁금한 점
- 쿠마의 "큐의 올바른 구현"에 대한 견해가 궁금합니다.
- 큐를 딕셔너리로 구현하는 것에 대해서 array의 장점과 linked list의 장점 모두 가지면서 구현할 수 있다고 생각을 하는데. 이는 일리있는 생각인지 궁금합니다.
- private func 를 Unit Test에서 private을 해재하지 않고 사용할 수 있는 방법이 있을까요?
