### PR TITLE
계산기 [STEP 2] inho

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		B252062928D95A53009489C1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B252062828D95A53009489C1 /* CalculatorItemQueueTests.swift */; };
 		B28DD50328D9A8450072FBFF /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50228D9A8450072FBFF /* CalculateItem.swift */; };
 		B28DD50528D9BC3A0072FBFF /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50428D9BC3A0072FBFF /* Node.swift */; };
+		B28DD50728DC32E90072FBFF /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50628DC32E90072FBFF /* Formula.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -44,6 +45,7 @@
 		B252062828D95A53009489C1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
 		B28DD50228D9A8450072FBFF /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		B28DD50428D9BC3A0072FBFF /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		B28DD50628DC32E90072FBFF /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				B252062028D8B357009489C1 /* CalculatorItemQueue.swift */,
 				B28DD50228D9A8450072FBFF /* CalculateItem.swift */,
 				B28DD50428D9BC3A0072FBFF /* Node.swift */,
+				B28DD50628DC32E90072FBFF /* Formula.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				B28DD50728DC32E90072FBFF /* Formula.swift in Sources */,
 				B28DD50328D9A8450072FBFF /* CalculateItem.swift in Sources */,
 				B252062128D8B357009489C1 /* CalculatorItemQueue.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		B28DD50728DC32E90072FBFF /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50628DC32E90072FBFF /* Formula.swift */; };
 		B28DD50928DC337A0072FBFF /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50828DC337A0072FBFF /* ExpressionParser.swift */; };
 		B28DD50B28DC33EB0072FBFF /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50A28DC33EB0072FBFF /* Operator.swift */; };
+		B28DD51328DC444B0072FBFF /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD51228DC444B0072FBFF /* FormulaTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -38,6 +39,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		B28DD51428DC444B0072FBFF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -50,6 +58,8 @@
 		B28DD50628DC32E90072FBFF /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		B28DD50828DC337A0072FBFF /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		B28DD50A28DC33EB0072FBFF /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		B28DD51028DC444B0072FBFF /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B28DD51228DC444B0072FBFF /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +79,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B252062328D95A53009489C1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B28DD50D28DC444B0072FBFF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -126,11 +143,20 @@
 			path = CalculatorItemQueueTests;
 			sourceTree = "<group>";
 		};
+		B28DD51128DC444B0072FBFF /* FormulaTests */ = {
+			isa = PBXGroup;
+			children = (
+				B28DD51228DC444B0072FBFF /* FormulaTests.swift */,
+			);
+			path = FormulaTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				B252062728D95A53009489C1 /* CalculatorItemQueueTests */,
+				B28DD51128DC444B0072FBFF /* FormulaTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -141,6 +167,7 @@
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				B252061228D87A2B009489C1 /* CalculatorTests.xctest */,
 				B252062628D95A53009489C1 /* CalculatorItemQueueTests.xctest */,
+				B28DD51028DC444B0072FBFF /* FormulaTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -195,6 +222,24 @@
 			productReference = B252062628D95A53009489C1 /* CalculatorItemQueueTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		B28DD50F28DC444B0072FBFF /* FormulaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B28DD51628DC444B0072FBFF /* Build configuration list for PBXNativeTarget "FormulaTests" */;
+			buildPhases = (
+				B28DD50C28DC444B0072FBFF /* Sources */,
+				B28DD50D28DC444B0072FBFF /* Frameworks */,
+				B28DD50E28DC444B0072FBFF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B28DD51528DC444B0072FBFF /* PBXTargetDependency */,
+			);
+			name = FormulaTests;
+			productName = FormulaTests;
+			productReference = B28DD51028DC444B0072FBFF /* FormulaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -229,6 +274,10 @@
 						CreatedOnToolsVersion = 13.2.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					B28DD50F28DC444B0072FBFF = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -250,6 +299,7 @@
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				B252061128D87A2B009489C1 /* CalculatorTests */,
 				B252062528D95A53009489C1 /* CalculatorItemQueueTests */,
+				B28DD50F28DC444B0072FBFF /* FormulaTests */,
 			);
 		};
 /* End PBXProject section */
@@ -263,6 +313,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B252062428D95A53009489C1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B28DD50E28DC444B0072FBFF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -298,6 +355,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B28DD50C28DC444B0072FBFF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B28DD51328DC444B0072FBFF /* FormulaTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -326,6 +391,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = B252062A28D95A53009489C1 /* PBXContainerItemProxy */;
+		};
+		B28DD51528DC444B0072FBFF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = B28DD51428DC444B0072FBFF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -423,6 +493,47 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lnho.CalculatorItemQueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		B28DD51728DC444B0072FBFF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R4D3JSH53Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lnho.FormulaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		B28DD51828DC444B0072FBFF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R4D3JSH53Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lnho.FormulaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -609,6 +720,15 @@
 			buildConfigurations = (
 				B252062D28D95A53009489C1 /* Debug */,
 				B252062E28D95A53009489C1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B28DD51628DC444B0072FBFF /* Build configuration list for PBXNativeTarget "FormulaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B28DD51728DC444B0072FBFF /* Debug */,
+				B28DD51828DC444B0072FBFF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B24F646B28E2E6AC0038E0C2 /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24F646A28E2E6AC0038E0C2 /* ExpressionParserTests.swift */; };
 		B252061B28D87CFB009489C1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
 		B252062128D8B357009489C1 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B252062028D8B357009489C1 /* CalculatorItemQueue.swift */; };
 		B252062928D95A53009489C1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B252062828D95A53009489C1 /* CalculatorItemQueueTests.swift */; };
@@ -27,6 +28,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		B24F646428E2E6720038E0C2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 		B252061628D87A2B009489C1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
@@ -51,6 +59,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B24F646028E2E6720038E0C2 /* ExpressionParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B24F646A28E2E6AC0038E0C2 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		B252061228D87A2B009489C1 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B252062028D8B357009489C1 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		B252062628D95A53009489C1 /* CalculatorItemQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -75,6 +85,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		B24F645D28E2E6720038E0C2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B252060F28D87A2B009489C1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -106,6 +123,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B24F646128E2E6720038E0C2 /* ExpressionParserTests */ = {
+			isa = PBXGroup;
+			children = (
+				B24F646A28E2E6AC0038E0C2 /* ExpressionParserTests.swift */,
+			);
+			path = ExpressionParserTests;
+			sourceTree = "<group>";
+		};
 		B252061D28D8B269009489C1 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
@@ -163,6 +188,7 @@
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				B252062728D95A53009489C1 /* CalculatorItemQueueTests */,
 				B28DD51128DC444B0072FBFF /* FormulaTests */,
+				B24F646128E2E6720038E0C2 /* ExpressionParserTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -174,6 +200,7 @@
 				B252061228D87A2B009489C1 /* CalculatorTests.xctest */,
 				B252062628D95A53009489C1 /* CalculatorItemQueueTests.xctest */,
 				B28DD51028DC444B0072FBFF /* FormulaTests.xctest */,
+				B24F646028E2E6720038E0C2 /* ExpressionParserTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -192,6 +219,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		B24F645F28E2E6720038E0C2 /* ExpressionParserTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B24F646828E2E6720038E0C2 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */;
+			buildPhases = (
+				B24F645C28E2E6720038E0C2 /* Sources */,
+				B24F645D28E2E6720038E0C2 /* Frameworks */,
+				B24F645E28E2E6720038E0C2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B24F646528E2E6720038E0C2 /* PBXTargetDependency */,
+			);
+			name = ExpressionParserTests;
+			productName = ExpressionParserTests;
+			productReference = B24F646028E2E6720038E0C2 /* ExpressionParserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		B252061128D87A2B009489C1 /* CalculatorTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B252061A28D87A2B009489C1 /* Build configuration list for PBXNativeTarget "CalculatorTests" */;
@@ -272,6 +317,11 @@
 				LastSwiftUpdateCheck = 1320;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					B24F645F28E2E6720038E0C2 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					B252061128D87A2B009489C1 = {
 						CreatedOnToolsVersion = 13.2.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
@@ -306,11 +356,19 @@
 				B252061128D87A2B009489C1 /* CalculatorTests */,
 				B252062528D95A53009489C1 /* CalculatorItemQueueTests */,
 				B28DD50F28DC444B0072FBFF /* FormulaTests */,
+				B24F645F28E2E6720038E0C2 /* ExpressionParserTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		B24F645E28E2E6720038E0C2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B252061028D87A2B009489C1 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -345,6 +403,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		B24F645C28E2E6720038E0C2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B24F646B28E2E6AC0038E0C2 /* ExpressionParserTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B252060E28D87A2B009489C1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -390,6 +456,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		B24F646528E2E6720038E0C2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = B24F646428E2E6720038E0C2 /* PBXContainerItemProxy */;
+		};
 		B252061728D87A2B009489C1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
@@ -427,6 +498,62 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		B24F646628E2E6720038E0C2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R4D3JSH53Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lnho.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "ExpressionParserTests/ExpressionParserTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		B24F646728E2E6720038E0C2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R4D3JSH53Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lnho.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "ExpressionParserTests/ExpressionParserTests-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
 		B252061828D87A2B009489C1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -714,6 +841,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		B24F646828E2E6720038E0C2 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B24F646628E2E6720038E0C2 /* Debug */,
+				B24F646728E2E6720038E0C2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B252061A28D87A2B009489C1 /* Build configuration list for PBXNativeTarget "CalculatorTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B28DD50928DC337A0072FBFF /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50828DC337A0072FBFF /* ExpressionParser.swift */; };
 		B28DD50B28DC33EB0072FBFF /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50A28DC33EB0072FBFF /* Operator.swift */; };
 		B28DD51328DC444B0072FBFF /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD51228DC444B0072FBFF /* FormulaTests.swift */; };
+		B28DD51A28DC4CAA0072FBFF /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD51928DC4CA90072FBFF /* Extension.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -60,6 +61,7 @@
 		B28DD50A28DC33EB0072FBFF /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		B28DD51028DC444B0072FBFF /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B28DD51228DC444B0072FBFF /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
+		B28DD51928DC4CA90072FBFF /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				B28DD50628DC32E90072FBFF /* Formula.swift */,
 				B28DD50828DC337A0072FBFF /* ExpressionParser.swift */,
 				B28DD50A28DC33EB0072FBFF /* Operator.swift */,
+				B28DD51928DC4CA90072FBFF /* Extension.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -372,6 +375,7 @@
 				B28DD50328D9A8450072FBFF /* CalculateItem.swift in Sources */,
 				B252062128D8B357009489C1 /* CalculatorItemQueue.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				B28DD51A28DC4CAA0072FBFF /* Extension.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				B28DD50928DC337A0072FBFF /* ExpressionParser.swift in Sources */,
 				B28DD50B28DC33EB0072FBFF /* Operator.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		B28DD50328D9A8450072FBFF /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50228D9A8450072FBFF /* CalculateItem.swift */; };
 		B28DD50528D9BC3A0072FBFF /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50428D9BC3A0072FBFF /* Node.swift */; };
 		B28DD50728DC32E90072FBFF /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50628DC32E90072FBFF /* Formula.swift */; };
+		B28DD50928DC337A0072FBFF /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50828DC337A0072FBFF /* ExpressionParser.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -46,6 +47,7 @@
 		B28DD50228D9A8450072FBFF /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		B28DD50428D9BC3A0072FBFF /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		B28DD50628DC32E90072FBFF /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		B28DD50828DC337A0072FBFF /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -98,6 +100,7 @@
 				B28DD50228D9A8450072FBFF /* CalculateItem.swift */,
 				B28DD50428D9BC3A0072FBFF /* Node.swift */,
 				B28DD50628DC32E90072FBFF /* Formula.swift */,
+				B28DD50828DC337A0072FBFF /* ExpressionParser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -302,6 +305,7 @@
 				B252062128D8B357009489C1 /* CalculatorItemQueue.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				B28DD50928DC337A0072FBFF /* ExpressionParser.swift in Sources */,
 				B28DD50528D9BC3A0072FBFF /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		B28DD50528D9BC3A0072FBFF /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50428D9BC3A0072FBFF /* Node.swift */; };
 		B28DD50728DC32E90072FBFF /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50628DC32E90072FBFF /* Formula.swift */; };
 		B28DD50928DC337A0072FBFF /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50828DC337A0072FBFF /* ExpressionParser.swift */; };
+		B28DD50B28DC33EB0072FBFF /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50A28DC33EB0072FBFF /* Operator.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -48,6 +49,7 @@
 		B28DD50428D9BC3A0072FBFF /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		B28DD50628DC32E90072FBFF /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		B28DD50828DC337A0072FBFF /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		B28DD50A28DC33EB0072FBFF /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 				B28DD50428D9BC3A0072FBFF /* Node.swift */,
 				B28DD50628DC32E90072FBFF /* Formula.swift */,
 				B28DD50828DC337A0072FBFF /* ExpressionParser.swift */,
+				B28DD50A28DC33EB0072FBFF /* Operator.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -306,6 +309,7 @@
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				B28DD50928DC337A0072FBFF /* ExpressionParser.swift in Sources */,
+				B28DD50B28DC33EB0072FBFF /* Operator.swift in Sources */,
 				B28DD50528D9BC3A0072FBFF /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		B252061B28D87CFB009489C1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
 		B252062128D8B357009489C1 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B252062028D8B357009489C1 /* CalculatorItemQueue.swift */; };
 		B252062928D95A53009489C1 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B252062828D95A53009489C1 /* CalculatorItemQueueTests.swift */; };
+		B256478A28E2E162003151F3 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B256478928E2E162003151F3 /* CalculatorError.swift */; };
 		B28DD50328D9A8450072FBFF /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50228D9A8450072FBFF /* CalculateItem.swift */; };
 		B28DD50528D9BC3A0072FBFF /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50428D9BC3A0072FBFF /* Node.swift */; };
 		B28DD50728DC32E90072FBFF /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28DD50628DC32E90072FBFF /* Formula.swift */; };
@@ -54,6 +55,7 @@
 		B252062028D8B357009489C1 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		B252062628D95A53009489C1 /* CalculatorItemQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B252062828D95A53009489C1 /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
+		B256478928E2E162003151F3 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
 		B28DD50228D9A8450072FBFF /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		B28DD50428D9BC3A0072FBFF /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		B28DD50628DC32E90072FBFF /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 				B28DD50828DC337A0072FBFF /* ExpressionParser.swift */,
 				B28DD50A28DC33EB0072FBFF /* Operator.swift */,
 				B28DD51928DC4CA90072FBFF /* Extension.swift */,
+				B256478928E2E162003151F3 /* CalculatorError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -377,6 +380,7 @@
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				B28DD51A28DC4CAA0072FBFF /* Extension.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				B256478A28E2E162003151F3 /* CalculatorError.swift in Sources */,
 				B28DD50928DC337A0072FBFF /* ExpressionParser.swift in Sources */,
 				B28DD50B28DC33EB0072FBFF /* Operator.swift in Sources */,
 				B28DD50528D9BC3A0072FBFF /* Node.swift in Sources */,

--- a/Calculator/Calculator/Model/CalculatorError.swift
+++ b/Calculator/Calculator/Model/CalculatorError.swift
@@ -9,5 +9,5 @@ import Foundation
 
 enum CalculatorError: Error {
     case emptyOperator
-    
+    case dividedByZero
 }

--- a/Calculator/Calculator/Model/CalculatorError.swift
+++ b/Calculator/Calculator/Model/CalculatorError.swift
@@ -1,0 +1,13 @@
+//
+//  CalculatorError.swift
+//  Calculator
+//
+//  Created by 김인호 on 2022/09/27.
+//
+
+import Foundation
+
+enum CalculatorError: Error {
+    case emptyOperator
+    
+}

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -9,22 +9,22 @@ import Foundation
 class CalculatorItemQueue<T>: CalculateItem {
     private(set) var head: Node<T>? = nil
     var last: Node<T>? {
-        if head == nil {
+        guard head != nil else {
             return nil
-        } else {
-            var node = head
-            while node?.next != nil {
-                node = node?.next
-            }
-            return node
         }
+        
+        var node = head
+        while node?.next != nil {
+            node = node?.next
+        }
+        return node
     }
     var isEmpty: Bool {
-        if head == nil && last == nil {
+        guard head != nil else {
             return true
-        } else {
-            return false
         }
+        
+        return false
     }
     
     func enqueue(element: T) {

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-class CalculatorItemQueue<T>: CalculateItem {
+class CalculatorItemQueue<T> {
     private(set) var head: Node<T>? = nil
     var last: Node<T>? {
         guard head != nil else {

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -12,7 +12,9 @@ enum ExpressionParser {
         let operands: CalculatorItemQueue<Double> = .init()
         let operators: CalculatorItemQueue<Operator> = .init()
         let operandsInInput = componentsByOperators(from: input).compactMap { Double($0) }
-        let operatorsInInput = input.compactMap { Operator(rawValue: $0) }
+        let operatorsInInput = input.split(with: " ")
+                                    .filter({ $0.count == 1 })
+                                    .compactMap { Operator(rawValue: Character($0)) }
         
         operandsInInput.forEach({ operand in
             operands.enqueue(element: operand)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -26,11 +26,9 @@ enum ExpressionParser {
     }
     
     private static func componentsByOperators(from input: String) -> [String] {
-        let operators = CharacterSet(charactersIn: Operator.allCases.map {
-            String($0.rawValue)
-        }.joined())
-        let result = input.components(separatedBy: operators)
+        let separatedInput = input.split(with: " ")
+        let components = separatedInput.filter({ $0.filter({ $0.isNumber }).count != 0 })
         
-        return result
+        return components
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,0 +1,18 @@
+//
+//  ExpressionParser.swift
+//  Calculator
+//
+//  Created by 김인호 on 2022/09/22.
+//
+
+import Foundation
+
+enum ExpressionParser {
+    static func parse(from input: String) -> Formula {
+        
+    }
+    
+    private static func componentsByOperators(from input: String) -> [String] {
+        
+    }
+}

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -13,23 +13,19 @@ enum ExpressionParser {
         let operators: CalculatorItemQueue<Operator> = .init()
         let operandsInInput = componentsByOperators(from: input).compactMap { Double($0) }
         let operatorsInInput = input.split(with: " ")
-                                    .filter({ $0.count == 1 })
+                                    .filter { $0.count == 1 }
                                     .compactMap { Operator(rawValue: Character($0)) }
         
-        operandsInInput.forEach({ operand in
-            operands.enqueue(element: operand)
-        })
+        operandsInInput.forEach { operands.enqueue(element: $0) }
         
-        operatorsInInput.forEach({ `operator` in
-            operators.enqueue(element: `operator`)
-        })
+        operatorsInInput.forEach { operators.enqueue(element: $0) }
         
         return Formula(operands: operands, operators: operators)
     }
     
     private static func componentsByOperators(from input: String) -> [String] {
         let separatedInput = input.split(with: " ")
-        let components = separatedInput.filter({ $0.filter({ $0.isNumber }).count != 0 })
+        let components = separatedInput.filter { $0.filter({ $0.isNumber }).count != 0 }
         
         return components
     }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -13,6 +13,11 @@ enum ExpressionParser {
     }
     
     private static func componentsByOperators(from input: String) -> [String] {
+        let operators = CharacterSet(charactersIn: Operator.allCases.map {
+            String($0.rawValue)
+        }.joined())
+        let result = input.components(separatedBy: operators)
         
+        return result
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -9,7 +9,20 @@ import Foundation
 
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
+        let operands: CalculatorItemQueue<Double> = .init()
+        let operators: CalculatorItemQueue<Operator> = .init()
+        let operandsInInput = componentsByOperators(from: input).compactMap { Double($0) }
+        let operatorsInInput = input.compactMap { Operator(rawValue: $0) }
         
+        operandsInInput.forEach({ operand in
+            operands.enqueue(element: operand)
+        })
+        
+        operatorsInInput.forEach({ `operator` in
+            operators.enqueue(element: `operator`)
+        })
+        
+        return Formula(operands: operands, operators: operators)
     }
     
     private static func componentsByOperators(from input: String) -> [String] {

--- a/Calculator/Calculator/Model/Extension.swift
+++ b/Calculator/Calculator/Model/Extension.swift
@@ -9,7 +9,8 @@ import Foundation
 
 extension String {
     func split(with target: Character) -> [String] {
-        
+        let result = self.components(separatedBy: String(target))
+        return result
     }
 }
 

--- a/Calculator/Calculator/Model/Extension.swift
+++ b/Calculator/Calculator/Model/Extension.swift
@@ -1,0 +1,18 @@
+//
+//  Extension.swift
+//  Calculator
+//
+//  Created by 김인호 on 2022/09/22.
+//
+
+import Foundation
+
+extension String {
+    func split(with target: Character) -> [String] {
+        
+    }
+}
+
+extension Double: CalculateItem {
+    
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -12,7 +12,6 @@ struct Formula {
     var operators: CalculatorItemQueue<Operator>
     
     func result() -> Double {
-        var result: Double = 0.0
         guard var lhs = operands.dequeue() else { return 0 }
         
         while !operands.isEmpty {
@@ -20,7 +19,7 @@ struct Formula {
             guard let `operator` = operators.dequeue() else { return 0.0 }
             lhs = `operator`.calculate(lhs: lhs, rhs: rhs)
         }
-        result = lhs
+        let result = lhs
         
         return result
     }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -18,7 +18,7 @@ struct Formula {
             guard let rhs = operands.dequeue() else { return lhs }
             guard let `operator` = operators.dequeue() else { throw CalculatorError.emptyOperator }
             
-            lhs = `operator`.calculate(lhs: lhs, rhs: rhs)
+            lhs = try `operator`.calculate(lhs: lhs, rhs: rhs)
         }
         let result = lhs
         

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -8,10 +8,20 @@
 import Foundation
 
 struct Formula {
-    var operands: CalculatorItemQueue<Int>
+    var operands: CalculatorItemQueue<Double>
     var operators: CalculatorItemQueue<Operator>
     
-    func resut() -> Double {
+    func result() -> Double {
+        var result: Double = 0.0
+        guard var lhs = operands.dequeue() else { return 0 }
         
+        while !operands.isEmpty {
+            guard let rhs = operands.dequeue() else { return lhs }
+            guard let `operator` = operators.dequeue() else { return 0.0 }
+            lhs = `operator`.calculate(lhs: lhs, rhs: rhs)
+        }
+        result = lhs
+        
+        return result
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,0 +1,17 @@
+//
+//  Formula.swift
+//  Calculator
+//
+//  Created by 김인호 on 2022/09/22.
+//
+
+import Foundation
+
+struct Formula {
+    var operands: CalculatorItemQueue<Int>
+    var operators: CalculatorItemQueue<Operator>
+    
+    func resut() -> Double {
+        
+    }
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -11,12 +11,13 @@ struct Formula {
     var operands: CalculatorItemQueue<Double>
     var operators: CalculatorItemQueue<Operator>
     
-    func result() -> Double {
+    func result() throws -> Double {
         guard var lhs = operands.dequeue() else { return 0 }
         
         while !operands.isEmpty {
             guard let rhs = operands.dequeue() else { return lhs }
-            guard let `operator` = operators.dequeue() else { return 0.0 }
+            guard let `operator` = operators.dequeue() else { throw CalculatorError.emptyOperator }
+            
             lhs = `operator`.calculate(lhs: lhs, rhs: rhs)
         }
         let result = lhs

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -14,7 +14,18 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case multiply = "*"
     
     func calculate(lhs: Double, rhs: Double) -> Double {
-        return 0.0
+        let result: Double
+        switch self {
+        case .add:
+            result = add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            result = subtract(lhs: lhs, rhs: rhs)
+        case .divide:
+            result = divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            result = multiply(lhs: lhs, rhs: rhs)
+        }
+        return result
     }
     
     private func add(lhs: Double, rhs: Double) -> Double {
@@ -28,9 +39,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
     }
     
     private func divide(lhs: Double, rhs: Double) -> Double {
-        let quotient = lhs / rhs
-        let remainder = lhs.truncatingRemainder(dividingBy: rhs)
-        let result = quotient + remainder
+        let result = lhs / rhs
         return result
     }
     

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -1,0 +1,41 @@
+//
+//  Operator.swift
+//  Calculator
+//
+//  Created by 김인호 on 2022/09/22.
+//
+
+import Foundation
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+"
+    case subtract = "-"
+    case divide = "%"
+    case multiply = "*"
+    
+    func calculate(lhs: Double, rhs: Double) -> Double {
+        return 0.0
+    }
+    
+    private func add(lhs: Double, rhs: Double) -> Double {
+        let result = lhs + rhs
+        return result
+    }
+    
+    private func subtract(lhs: Double, rhs: Double) -> Double {
+        let result = lhs - rhs
+        return result
+    }
+    
+    private func divide(lhs: Double, rhs: Double) -> Double {
+        let quotient = lhs / rhs
+        let remainder = lhs.truncatingRemainder(dividingBy: rhs)
+        let result = quotient + remainder
+        return result
+    }
+    
+    private func multiply(lhs: Double, rhs: Double) -> Double {
+        let result = lhs * rhs
+        return result
+    }
+}

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -13,7 +13,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "%"
     case multiply = "*"
     
-    func calculate(lhs: Double, rhs: Double) -> Double {
+    func calculate(lhs: Double, rhs: Double) throws -> Double {
         let result: Double
         switch self {
         case .add:
@@ -21,7 +21,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
         case .subtract:
             result = subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            result = divide(lhs: lhs, rhs: rhs)
+            result = try divide(lhs: lhs, rhs: rhs)
         case .multiply:
             result = multiply(lhs: lhs, rhs: rhs)
         }
@@ -38,7 +38,9 @@ enum Operator: Character, CaseIterable, CalculateItem {
         return result
     }
     
-    private func divide(lhs: Double, rhs: Double) -> Double {
+    private func divide(lhs: Double, rhs: Double) throws -> Double {
+        guard rhs != 0 else { throw CalculatorError.dividedByZero }
+        
         let result = lhs / rhs
         return result
     }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -10,7 +10,7 @@ import Foundation
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
     case subtract = "-"
-    case divide = "%"
+    case divide = "/"
     case multiply = "*"
     
     func calculate(lhs: Double, rhs: Double) throws -> Double {

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -1,0 +1,47 @@
+//
+//  ExpressionParserTest.swift
+//  ExpressionParserTest
+//
+//  Created by 김인호 on 2022/09/27.
+//
+
+import XCTest
+@testable import Calculator
+
+class ExpressionParserTest: XCTestCase {
+    func test_parse실행시_input의_부호변환기호를_연산자에담지않는가() {
+        //given
+        let input = "3 / -3 + -6"
+        
+        //when
+        let operators = ExpressionParser.parse(from: input).operators
+        
+        //then
+        XCTAssertEqual(Operator.divide, operators.dequeue())
+        XCTAssertEqual(Operator.add, operators.dequeue())
+        XCTAssertNil(operators.dequeue())
+    }
+
+    func test_parse실행시_input의요소를_큐에담는가() {
+        //given
+        let input = "1 + 2 - -4 / 93 * 3.2"
+        
+        //when
+        let components = ExpressionParser.parse(from: input)
+        let operands = components.operands
+        let operators = components.operators
+        
+        //then
+        XCTAssertEqual(1, operands.dequeue())
+        XCTAssertEqual(2, operands.dequeue())
+        XCTAssertEqual(-4, operands.dequeue())
+        XCTAssertEqual(93, operands.dequeue())
+        XCTAssertEqual(3.2, operands.dequeue())
+        
+        XCTAssertEqual(Operator.add, operators.dequeue())
+        XCTAssertEqual(Operator.subtract, operators.dequeue())
+        XCTAssertEqual(Operator.divide, operators.dequeue())
+        XCTAssertEqual(Operator.multiply, operators.dequeue())
+    }
+    
+}

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -1,0 +1,35 @@
+//
+//  FormulaTests.swift
+//  FormulaTests
+//
+//  Created by 김인호 on 2022/09/22.
+//
+
+import XCTest
+@testable import Calculator
+
+class FormulaTests: XCTestCase {
+    var sut: Formula!
+    let operandsQueue = CalculatorItemQueue<Double>()
+    let operatorsQueue = CalculatorItemQueue<Operator>()
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Formula(operands: operandsQueue, operators: operatorsQueue)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_result실행시_피연산자큐가비어있으면_0을리턴하는가() {
+        //given
+        
+        //when
+        let result = sut.result()
+        
+        //then
+        XCTAssertEqual(0, result)
+    }
+}

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -32,4 +32,18 @@ class FormulaTests: XCTestCase {
         //then
         XCTAssertEqual(0, result)
     }
+    
+    func test_result실행시_두번째연산자가없으면_첫번째연산자를리턴하는가() {
+        //given
+        operandsQueue.enqueue(element: 3)
+        operatorsQueue.enqueue(element: Operator.add)
+        operandsQueue.enqueue(element: 6)
+        operatorsQueue.enqueue(element: Operator.divide)
+        
+        //when
+        let result = sut.result()
+        
+        //then
+        XCTAssertEqual(9, result)
+    }
 }

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -27,7 +27,7 @@ class FormulaTests: XCTestCase {
         //given
         
         //when
-        let result = sut.result()
+        let result = try? sut.result()
         
         //then
         XCTAssertEqual(0, result)
@@ -41,9 +41,49 @@ class FormulaTests: XCTestCase {
         operatorsQueue.enqueue(element: Operator.divide)
         
         //when
-        let result = sut.result()
+        let result = try? sut.result()
         
         //then
         XCTAssertEqual(9, result)
+    }
+    
+    func test_result실행시_연산자가없으면_에러를throw하는가() {
+        //given
+        operandsQueue.enqueue(element: 3)
+        operandsQueue.enqueue(element: 5)
+        
+        //when
+        let result = try? sut.result()
+        
+        //then
+        XCTAssertNil(result)
+    }
+    
+    func test_result실행시_조건이모충족되면_연산이제대로작동하는가() {
+        //given
+        operandsQueue.enqueue(element: 6)
+        operatorsQueue.enqueue(element: Operator.divide)
+        operandsQueue.enqueue(element: -3)
+        operatorsQueue.enqueue(element: Operator.add)
+        operandsQueue.enqueue(element: 5)
+        
+        //when
+        let result = try? sut.result()
+        
+        //then
+        XCTAssertEqual(6.0 / -3.0 + 5.0, result)
+    }
+    
+    func test_result실행시_0으로나누면_에러를throw하는가() {
+        //given
+        operandsQueue.enqueue(element: 10)
+        operatorsQueue.enqueue(element: Operator.divide)
+        operandsQueue.enqueue(element: 0)
+        
+        //when
+        let result = try? sut.result()
+        
+        //then
+        XCTAssertNil(result)
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,97 @@
 
 ### 계산기 프로젝트 저장소
 
-## Step1
+목차
+1. [제목](#제목)
+2. [소개](#소개)
+3. [앱실행화면](#앱-실행-화면)
+4. [타임라인](#타임라인)
+5. [트러블 슈팅](#트러블-슈팅)
+6. [참고 링크](#참고-링크)
+ 
+# 제목
+계산기
+## 소개
+계산기를 구현하는 프로젝트 입니다.
+|![CCF2339F-606F-4EE9-97EC-88620DE7174A (1) (1)](https://user-images.githubusercontent.com/71054048/188081997-a9ac5789-ddd6-4682-abb1-90d2722cf998.jpg)|
+|:---:|
+|인호|
 
-### UML
-![](https://i.imgur.com/NtEh2WQ.png)
+## 타임라인
+시간 순으로 프로젝트의 주요 진행 척도를 표시
+| 날짜 | 중요 진행 상황 | 코드 관련 사항
+|---|---|---|
+|9/20| `STEP1` 시작, 계산기에 필요한 리스트와 큐 구현 | 리스트 형식의 `CalculatorItemQueue`구현, 큐의 `enqueue`,`dequeue`,`removeAll`메서드와 `head`프로퍼티 구현, 리스트의 요소인`Node`타입 구현
+|9/21| 추가 기능 및 코드 수정| `CalculatorItemQueue`에 `last`,`isEmpty`프로퍼티 추가, `removeAll`메서드 리팩토링
+|9/22| `STEP2` 시작, UML을 바탕으로 타입 구성 | `Formula`, `ExpressionParser`,`Operator`타입 생성 및 내부 메서드 생성, `Extension` 구현
+|9/23| 각 타입의 메서드 기능 수정 | `split`메서드 구현, `componentsByOperators`메서드 수정, 부호랑 연산자 구분하도록 수정
+
+## 앱 실행 화면
+추가 예정
+
+## 트러블 슈팅
+<!-- <details>
+<summary id="Step1"><h4>Step1</h4></summary>
+<div markdown="1">
+#### 큐를 구현하는 방법
+
+</div>
+</details>
+ -->
+### Step1
+#### `CalculatorItemQueue` 구현 방법
+계산기의 연산과정을 고민했을때, 단계적으로 계산을 할때마다 `dequeue`를 하게 될텐데, 해당 부분을 배열로 구현하면 매번 인덱스이 이동이 일어나야해서 리스트가 더 효율적일 것이라고 생각하여 단방향 연결 리스트를 이용했다.
+(리스트를 공부하기 위함도 있었다.)
+
+### Step2
+#### 계산기에서 전달받을 `input`
+- 처음에는 입력이 `1+3-6*3%9-1`과 같이 전달될 것이라고 생각하고 프로젝트를 진행했는데, 다른 캠퍼들과 얘기하다 보니 부호 변환 부분이 문제였다. 기존의 코드대로면 부호를 변환기호도 음수 연산자로 분류되는 상황이었다.
+- 어떻게 문제를 해결할까 고민하면서 계산기 앱의 구동 화면을 보고 입력이 `1 + 3 + -6 * 3 % -9 - 1`과 같이 연산자와 피연산자 사이에 공백이 있는 상태로 들어올 수 있겠다는 생각을 했고, 이를 기준으로 다시 작성했다.
+
+#### `split(with target:) -> [String] `메서드
+- UML에 작성되어 있던 위 메서드를 어떻게 해결할지 몰라 공백으로 남겨두었는데, 위에서 말한 입력의 공백을 지우는데 사용했다.
+```swift
+func split(with target: Character) -> [String] {
+    let result = self.components(separatedBy: String(target))
+    return result
+}
+
+let separatedInput = input.split(with: " ")
+//1 + 3 + -6 * 3 % 9 -> [1, +, 3, +, -6, *, 3, %, 9]반환
+```
+
+#### `componentsByOperators(from input:) -> [String]`메서드의 역할
+- 위 메서드이 역할이 가장 헷갈리는 부분이었다. 역할을 고려해서 연산자, 피연산자를 나누어서 하나의 배열로 리턴할까 하다가 네이밍과 맞지 않다고 생각했고,
+네이밍으로 해석했을땐 처음에는 "Operators로 이루어진 요소들"이라고 해석하여 연산자를 리턴할까 하다가
+최종적으로는 "Operators 옆에있는 요소들"이라는 해석이 적절하다고 판단했다. 입력받은 문자열을 보면 연산자 양옆에 피연산자들이 있는 구조이므로 근거있는 해석이라고 생각했다.
+- 그래서 위 메서드는 숫자를 포함하고 있는 피연산자들을 배열로 리턴한다.
+```swift
+private static func componentsByOperators(from input: String) -> [String] {
+    let separatedInput = input.split(with: " ")
+    let components = separatedInput.filter({ $0.filter({ $0.isNumber }).count != 0 })
+        
+    return components
+}
+```
+#### `parse(from input:) -> Formula`메서드의 역할
+- `input`에서 연산자, 피연산자를 분리하여 `operandsInInput`,`operatorsInInput`에 담고, `forEach`를 이용하여 각 큐에 담는다.(`enqueue`)
+
+#### `input`을 원하는 형태로 변경하는 방법
+> 변수보다는 상수를, 반복문 조건문 보다는 고차함수를 더 활용하도록 노력해보세요.
+
+- 과제의 요구사항대로 고차함수를 활용하려 고민했는데 `filter`메서드를 활용하고, `compactMap`함수를 이해하고 사용해봤다. 
+```swift
+let components = separatedInput.filter({ $0.filter({ $0.isNumber }).count != 0 })
+let operandsInInput = componentsByOperators(from: input).compactMap { Double($0) }
+```
+<!-- <details>
+<summary id="Step2"><h4>Step2</h4></summary>
+<div markdown="1">
+
+
+</div>
+</details>
+ -->
+
+## 참고 링크
+추가 예정


### PR DESCRIPTION
안녕하세요, @lina0322 
인호입니다ㅎㅎ
이번 PR도 잘부탁드립니다🙌

## UML
![](https://i.imgur.com/B8KGbFd.png)
UML에 작성된 내용을 바탕으로 과제를 진행했습니다!

## 고민했던 점
### Step1 연장선
#### `CalculateItem`프로토콜의 역할
지난 스텝에서 `CalculatorItemQueue`가 `CalculateItem`을 채택하는게 아닌것 같다는 생각을 했는데, 이번 스텝에 와보니 큐 요소가 프로토콜을 채택하는 것이었습니다.(`Double`과 `Operator`) 
그래서 기존에 `CalculatorItemQueue`에 채택되어 있던 프로토콜은 삭제했습니다!

---
### Step2
> 변수보다는 상수를, 반복문 조건문 보다는 고차함수를 더 활용하도록 노력해보세요.

과제의 요구사항을 계속 고려하면서 작성하였습니다.
### UML 이해
- UML을 기반으로 접근 제어를 사용하고, `ExpressionParser`에 밑줄된 메서드가 타입 메서드를 의미한다는 걸 알게되고 적용했습니다.
### `Formula` 타입과 메서드
- `Formula`타입의 `result`메서드는 연산자와 피연산자 큐를 이용하여 결과를 리턴합니다.
- 피연산자큐인 `operands`가 비워질때까지 `dequeue`와 `calculate`을 시행하고, 이전의 연산 결과가 `lhs`에 할당됩니다.
(1+2+4-7 -> 3+4-7 -> 7-7 )
- 계산기에서 입력된 요소 없이`=`을 누르면(결과를 호출하면) 0을 리턴합니다. 입력된 요소가 없다는 것은 `oprands`의 큐가 비어있고, `lhs`가 없는 상황을 의미합니다.
- `rhs`가 없는 상황은 `lhs`와 연산자까지만 입력하고 결과를 호출하는 상황인데, 이때는 연산자는 무시하고 마지막 연산결과인 `lhs`를 리턴합니다.
```swift
func result() -> Double {
    guard var lhs = operands.dequeue() else { return 0 }
        
    while !operands.isEmpty {
        guard let rhs = operands.dequeue() else { return lhs }
        guard let `operator` = operators.dequeue() else { return 0.0 }
        lhs = `operator`.calculate(lhs: lhs, rhs: rhs)
    }
    let result = lhs
        
    return result
}
```

### 입력된 문자열을 큐로 변경하는 방법
- 계산기의 입력이 끝났을때, 연산할 `input`이 어떤 형태로 전달될까 고민했습니다. 
처음에는 `1+2+6*4%9`와 같이 들어올 것이라고 생각했는데
계산기 동작 화면에서 아래 사진과 같이 연산자의 `-`와 부호를 나타내는 `-`를 구분짓기 위해 `1 + 2 + 6 * 8 % -9`와 같이
**연산자와 피연산자를 공백으로 구분하여** 전달 될것이라고 판단했습니다. 이런 입력을 가정으로 나머지 코드가 작성되었습니다.
![](https://i.imgur.com/2mCLauC.png)

### String extension의 `split()`메서드
- 입력받은 문자열을 매개변수인 `target`을 기준으로 자르고, 배열에 담아 리턴하는 함수입니다.
프로젝트에서는 공백을 기준으로 문자열을 자르는 곳에 사용됩니다.
```swift
let input = "1 + 2 - 5 % -4"
let separatedInput = input.split(with: " ")
//[1, +, 2, -, 5, %, -4]
```
### `ExpressionParser`의 `componentsByOperators()`메서드
- `componentsByOperators`의 역할을 네이밍과 parse와의 관계를 바탕으로 오래 고민했는데요, 최종적으로는 "operator 옆의 요소들"이라고 해석하여 입력받은 문자열(`inpuut`)에서 피연산자 배열만을 리턴하는 함수라고 결정했습니다.
- 위의 `split`메서드를 이용해서 먼저 공백을 제거한 문자열 배열을 만든 뒤, 각 문자열 요소 중에 숫자를 포함하는 요소들만 `filter`하여 리턴합니다.
```swift
let separatedInput = input.split(with: " ")
let components = separatedInput.filter({ $0.filter({ $0.isNumber }).count != 0 })
        
return components
```
### `ExpressionParser`의 `parse()`메서드
- `parse`메서드의 역할을 "입력 요소 중 원하는 정보를 추출한다"라고 생각했습니다. 
- `operandsInInput`은 `componentsByOperators()`메서드에서 전달받은 값을 `Double`의 형태로 변환합니다.
- `operatorsInInput`은 `input`중에서 연산자의 `rawValue`와 같은 요소를 `fliter`합니다.
- `input`에서 받은 연산자와 피연산자는 각각 `forEach`를 이용해 큐에 담습니다.(`enqueue`)

```swift
static func parse(from input: String) -> Formula {
    let operands: CalculatorItemQueue<Double> = .init()
    let operators: CalculatorItemQueue<Operator> = .init()
    let operandsInInput = componentsByOperators(from: input).compactMap { Double($0) }
    let operatorsInInput = input.split(with: " ")
                                .filter({ $0.count == 1 })
                                .compactMap { Operator(rawValue: Character($0)) }
        
    operandsInInput.forEach({ operand in
        operands.enqueue(element: operand)
    })
        
    operatorsInInput.forEach({ `operator` in
        operators.enqueue(element: `operator`)
    })
        
    return Formula(operands: operands, operators: operators)
}
```

## 조언을 얻고싶은 부분
### Extension 파일 분리
- `String`과 `Double`의 `Extension`을 파일을 분리하여 만들었는데, 지금 방식도 괜찮은지, 아니면 타입 별로도 나누어야하는지 궁금합니다!
#### `ExpressionParser`과 `split()`메서드
- 지금 구현해 놓은 `componentsByOperator()`과 `split()`메서드들에 대해서 확실하지 않은 부분이 있습니다. 다른 방법이 더 있을것 같다는 생각도 들고, 지금 방법에서도 굳이? 싶은 부분이 있는데 엘림 의견도 궁금합니다..!!