### PR TITLE
계산기 [Step 2] 애종

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		576EB61F28E204BA004026AF /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB61E28E204BA004026AF /* String.swift */; };
 		576EB62128E20571004026AF /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62028E20571004026AF /* Double.swift */; };
 		576EB62328E205BA004026AF /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62228E205BA004026AF /* Operator.swift */; };
+		576EB62728E207D6004026AF /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62628E207D6004026AF /* Formula.swift */; };
+		576EB62928E208D4004026AF /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62828E208D4004026AF /* ExpressionParser.swift */; };
 		57BBB9F528DAAE5C00935D19 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */; };
 		57BBBAA828DACD6E00935D19 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -41,6 +43,8 @@
 		576EB61E28E204BA004026AF /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		576EB62028E20571004026AF /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
 		576EB62228E205BA004026AF /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		576EB62628E207D6004026AF /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		576EB62828E208D4004026AF /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -148,6 +152,8 @@
 			isa = PBXGroup;
 			children = (
 				576EB62228E205BA004026AF /* Operator.swift */,
+				576EB62628E207D6004026AF /* Formula.swift */,
+				576EB62828E208D4004026AF /* ExpressionParser.swift */,
 				576EB61D28E204AE004026AF /* Extension */,
 				576EB61528DD94D4004026AF /* Model */,
 				57BBB9F228DAAE3800935D19 /* Protocol */,
@@ -273,8 +279,10 @@
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				57BBB9F528DAAE5C00935D19 /* CalculateItem.swift in Sources */,
 				576EB61F28E204BA004026AF /* String.swift in Sources */,
+				576EB62728E207D6004026AF /* Formula.swift in Sources */,
 				576EB62328E205BA004026AF /* Operator.swift in Sources */,
 				576EB62128E20571004026AF /* Double.swift in Sources */,
+				576EB62928E208D4004026AF /* ExpressionParser.swift in Sources */,
 				576EB61928DD94F0004026AF /* LinkedList.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		576EB62728E207D6004026AF /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62628E207D6004026AF /* Formula.swift */; };
 		576EB62928E208D4004026AF /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62828E208D4004026AF /* ExpressionParser.swift */; };
 		576EB62B28E29B1B004026AF /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62A28E29B1B004026AF /* FormulaTests.swift */; };
+		576EB62D28E2D600004026AF /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62C28E2D600004026AF /* CalculateError.swift */; };
 		57BBB9F528DAAE5C00935D19 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */; };
 		57BBBAA828DACD6E00935D19 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -47,6 +48,7 @@
 		576EB62628E207D6004026AF /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		576EB62828E208D4004026AF /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		576EB62A28E29B1B004026AF /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
+		576EB62C28E2D600004026AF /* CalculateError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateError.swift; sourceTree = "<group>"; };
 		57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -154,6 +156,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				576EB62C28E2D600004026AF /* CalculateError.swift */,
 				576EB62228E205BA004026AF /* Operator.swift */,
 				576EB62628E207D6004026AF /* Formula.swift */,
 				576EB62828E208D4004026AF /* ExpressionParser.swift */,
@@ -279,6 +282,7 @@
 				576EB61728DD94E5004026AF /* LinkedListNode.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				57BBBAA828DACD6E00935D19 /* CalculatorItemQueue.swift in Sources */,
+				576EB62D28E2D600004026AF /* CalculateError.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				57BBB9F528DAAE5C00935D19 /* CalculateItem.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		576EB62928E208D4004026AF /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62828E208D4004026AF /* ExpressionParser.swift */; };
 		576EB62B28E29B1B004026AF /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62A28E29B1B004026AF /* FormulaTests.swift */; };
 		576EB62D28E2D600004026AF /* CalculateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62C28E2D600004026AF /* CalculateError.swift */; };
+		576EB62F28E357FF004026AF /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62E28E357FF004026AF /* ExpressionParserTests.swift */; };
 		57BBB9F528DAAE5C00935D19 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */; };
 		57BBBAA828DACD6E00935D19 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -49,6 +50,7 @@
 		576EB62828E208D4004026AF /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		576EB62A28E29B1B004026AF /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		576EB62C28E2D600004026AF /* CalculateError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateError.swift; sourceTree = "<group>"; };
+		576EB62E28E357FF004026AF /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -84,6 +86,7 @@
 			children = (
 				576EB60E28DAFD0D004026AF /* CalculatorModelTests.swift */,
 				576EB62A28E29B1B004026AF /* FormulaTests.swift */,
+				576EB62E28E357FF004026AF /* ExpressionParserTests.swift */,
 			);
 			path = CalculatorModelTests;
 			sourceTree = "<group>";
@@ -272,6 +275,7 @@
 			files = (
 				576EB62B28E29B1B004026AF /* FormulaTests.swift in Sources */,
 				576EB60F28DAFD0D004026AF /* CalculatorModelTests.swift in Sources */,
+				576EB62F28E357FF004026AF /* ExpressionParserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		576EB60F28DAFD0D004026AF /* CalculatorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB60E28DAFD0D004026AF /* CalculatorModelTests.swift */; };
 		576EB61728DD94E5004026AF /* LinkedListNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB61628DD94E5004026AF /* LinkedListNode.swift */; };
 		576EB61928DD94F0004026AF /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB61828DD94F0004026AF /* LinkedList.swift */; };
+		576EB61F28E204BA004026AF /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB61E28E204BA004026AF /* String.swift */; };
+		576EB62128E20571004026AF /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62028E20571004026AF /* Double.swift */; };
+		576EB62328E205BA004026AF /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62228E205BA004026AF /* Operator.swift */; };
 		57BBB9F528DAAE5C00935D19 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */; };
 		57BBBAA828DACD6E00935D19 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -35,6 +38,9 @@
 		576EB60E28DAFD0D004026AF /* CalculatorModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorModelTests.swift; sourceTree = "<group>"; };
 		576EB61628DD94E5004026AF /* LinkedListNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListNode.swift; sourceTree = "<group>"; };
 		576EB61828DD94F0004026AF /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		576EB61E28E204BA004026AF /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		576EB62028E20571004026AF /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
+		576EB62228E205BA004026AF /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -81,6 +87,15 @@
 				576EB61828DD94F0004026AF /* LinkedList.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		576EB61D28E204AE004026AF /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				576EB61E28E204BA004026AF /* String.swift */,
+				576EB62028E20571004026AF /* Double.swift */,
+			);
+			path = Extension;
 			sourceTree = "<group>";
 		};
 		57BBB9EF28DAAE0F00935D19 /* View */ = {
@@ -132,6 +147,8 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				576EB62228E205BA004026AF /* Operator.swift */,
+				576EB61D28E204AE004026AF /* Extension */,
 				576EB61528DD94D4004026AF /* Model */,
 				57BBB9F228DAAE3800935D19 /* Protocol */,
 				57BBB9F028DAAE1B00935D19 /* Controller */,
@@ -255,6 +272,9 @@
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				57BBB9F528DAAE5C00935D19 /* CalculateItem.swift in Sources */,
+				576EB61F28E204BA004026AF /* String.swift in Sources */,
+				576EB62328E205BA004026AF /* Operator.swift in Sources */,
+				576EB62128E20571004026AF /* Double.swift in Sources */,
 				576EB61928DD94F0004026AF /* LinkedList.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		576EB62328E205BA004026AF /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62228E205BA004026AF /* Operator.swift */; };
 		576EB62728E207D6004026AF /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62628E207D6004026AF /* Formula.swift */; };
 		576EB62928E208D4004026AF /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62828E208D4004026AF /* ExpressionParser.swift */; };
+		576EB62B28E29B1B004026AF /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EB62A28E29B1B004026AF /* FormulaTests.swift */; };
 		57BBB9F528DAAE5C00935D19 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */; };
 		57BBBAA828DACD6E00935D19 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -45,6 +46,7 @@
 		576EB62228E205BA004026AF /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		576EB62628E207D6004026AF /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		576EB62828E208D4004026AF /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		576EB62A28E29B1B004026AF /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		57BBB9F428DAAE5C00935D19 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		57BBB9F628DAAE8700935D19 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -79,6 +81,7 @@
 			isa = PBXGroup;
 			children = (
 				576EB60E28DAFD0D004026AF /* CalculatorModelTests.swift */,
+				576EB62A28E29B1B004026AF /* FormulaTests.swift */,
 			);
 			path = CalculatorModelTests;
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				576EB62B28E29B1B004026AF /* FormulaTests.swift in Sources */,
 				576EB60F28DAFD0D004026AF /* CalculatorModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator/CalculateError.swift
+++ b/Calculator/Calculator/CalculateError.swift
@@ -1,0 +1,6 @@
+//  Created by Aejong on 2022/09/27
+
+enum CalculateError: Error {
+    case divideByZero
+}
+

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -2,7 +2,7 @@
 
 enum ExpressionParser {
     func parse(from input: String) -> Formula {
-        return Formula(operands: CalculatorItemQueueByLinkedList<Any>.init(), operators: CalculatorItemQueueByLinkedList<Any>.init())
+        return Formula(operands: CalculatorItemQueueByLinkedList<Double>.init(), operators: CalculatorItemQueueByLinkedList<Operator>.init())
     }
     
     private func componentsByOperator(from input: String) -> [String] {

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -1,17 +1,31 @@
 //  Created by Aejong on 2022/09/27
 
 enum ExpressionParser {
-    func parse(from input: String) -> Formula {
-        return Formula(operands: CalculatorItemQueueByLinkedList<Double>.init(), operators: CalculatorItemQueueByLinkedList<Operator>.init())
+    static func parse(from input: String) -> Formula {
+        var operands: CalculatorItemQueueByLinkedList<Double> = CalculatorItemQueueByLinkedList<Double>()
+        var operators: CalculatorItemQueueByLinkedList<Operator> = CalculatorItemQueueByLinkedList<Operator>()
+        let operandsArray: [Double] = componentsByOperator(from: input).compactMap { Double($0) }
+        
+        let operatorsArray: [Operator] = input.compactMap { Operator(rawValue: $0) }
+        
+        for singleOperand in operandsArray {
+            operands.enqueue(singleOperand)
+        }
+        
+        for singleOperator in operatorsArray {
+            operators.enqueue(singleOperator)
+        }
+        
+        return Formula(operands: operands, operators: operators)
     }
     
-    private func componentsByOperator(from input: String) -> [String] {
+    private static func componentsByOperator(from input: String) -> [String] {
         var inputString: String = input
         
         for caseOperator in Operator.allCases {
             inputString = inputString.replacingOccurrences(of: "\(caseOperator.rawValue)", with: " ")
         }
-
+        
         return inputString.split(with: " ")
     }
 }

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -2,10 +2,9 @@
 
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        var operands: CalculatorItemQueueByLinkedList<Double> = CalculatorItemQueueByLinkedList<Double>()
-        var operators: CalculatorItemQueueByLinkedList<Operator> = CalculatorItemQueueByLinkedList<Operator>()
+        var operands = CalculatorItemQueueByLinkedList<Double>()
+        var operators = CalculatorItemQueueByLinkedList<Operator>()
         let operandsArray: [Double] = componentsByOperator(from: input).compactMap { Double($0) }
-        
         let operatorsArray: [Operator] = input.compactMap { Operator(rawValue: $0) }
         
         for singleOperand in operandsArray {

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -1,0 +1,11 @@
+//  Created by Aejong on 2022/09/27
+
+enum ExpressionParser {
+    func parse(from input: String) -> Formula {
+        return Formula(operands: CalculatorItemQueueByLinkedList<Any>.init(), operators: CalculatorItemQueueByLinkedList<Any>.init())
+    }
+    
+    private func componentsByOperator(from input: String) -> [String] {
+        return [""]
+    }
+}

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -6,6 +6,12 @@ enum ExpressionParser {
     }
     
     private func componentsByOperator(from input: String) -> [String] {
-        return [""]
+        var inputString: String = input
+        
+        for caseOperator in Operator.allCases {
+            inputString = inputString.replacingOccurrences(of: "\(caseOperator.rawValue)", with: " ")
+        }
+
+        return inputString.split(with: " ")
     }
 }

--- a/Calculator/Calculator/Extension/Double.swift
+++ b/Calculator/Calculator/Extension/Double.swift
@@ -1,0 +1,5 @@
+//  Created by Victor on 2022/09/27.
+
+extension Double: CalculateItem {
+    
+}

--- a/Calculator/Calculator/Extension/Double.swift
+++ b/Calculator/Calculator/Extension/Double.swift
@@ -1,4 +1,4 @@
-//  Created by Victor on 2022/09/27.
+//  Created by Aejong on 2022/09/27.
 
 extension Double: CalculateItem {
     

--- a/Calculator/Calculator/Extension/String.swift
+++ b/Calculator/Calculator/Extension/String.swift
@@ -1,0 +1,7 @@
+//  Created by Aejong on 2022/09/27.
+
+extension String {
+    func split(with target: Character) -> [String] {
+        return [""]
+    }
+}

--- a/Calculator/Calculator/Extension/String.swift
+++ b/Calculator/Calculator/Extension/String.swift
@@ -2,6 +2,6 @@
 
 extension String {
     func split(with target: Character) -> [String] {
-        return [""]
+        return self.split(separator: target).map { String($0) }
     }
 }

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -4,7 +4,7 @@ struct Formula {
     var operands: CalculatorItemQueueByLinkedList<Double>
     var operators: CalculatorItemQueueByLinkedList<Operator>
     
-    mutating func result() -> Double {
+    mutating func result() throws -> Double {
         var result: Double
         
         guard let initialValue: Double = operands.dequeue() else { return 0 }
@@ -14,7 +14,7 @@ struct Formula {
             guard let rhs = operands.dequeue(),
                   let unitOperator = operators.dequeue() else { return 0 }
             
-            calculatingValue = unitOperator.calculate(lhs: calculatingValue, rhs: rhs)
+            calculatingValue = try unitOperator.calculate(lhs: calculatingValue, rhs: rhs)
         }
         result = calculatingValue
         

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -5,11 +5,19 @@ struct Formula {
     var operators: CalculatorItemQueueByLinkedList<Operator>
     
     mutating func result() -> Double {
-        guard let lhs = operands.dequeue(),
-              let rhs = operands.dequeue(),
-              let unitOperator = operators.dequeue() else { return 0 }
+        var result: Double
         
+        guard let initialValue: Double = operands.dequeue() else { return 0 }
+        var calculatingValue: Double = initialValue
         
-        return unitOperator.calculatee(lhs: lhs, rhs: rhs)
+        while operands.isEmpty != true {
+            guard let rhs = operands.dequeue(),
+                  let unitOperator = operators.dequeue() else { return 0 }
+            
+            calculatingValue = unitOperator.calculate(lhs: calculatingValue, rhs: rhs)
+        }
+        result = calculatingValue
+        
+        return result
     }
 }

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -1,10 +1,15 @@
 //  Created by Aejong on 2022/09/27.
 
 struct Formula {
-    let operands: CalculatorItemQueueByLinkedList<Any>
-    let operators: CalculatorItemQueueByLinkedList<Any>
+    var operands: CalculatorItemQueueByLinkedList<Double>
+    var operators: CalculatorItemQueueByLinkedList<Operator>
     
-    func result() -> Double {
-        return 0
+    mutating func result() -> Double {
+        guard let lhs = operands.dequeue(),
+              let rhs = operands.dequeue(),
+              let unitOperator = operators.dequeue() else { return 0 }
+        
+        
+        return unitOperator.calculatee(lhs: lhs, rhs: rhs)
     }
 }

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -1,0 +1,10 @@
+//  Created by Aejong on 2022/09/27.
+
+struct Formula {
+    let operands: CalculatorItemQueueByLinkedList<Any>
+    let operators: CalculatorItemQueueByLinkedList<Any>
+    
+    func result() -> Double {
+        return 0
+    }
+}

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -10,7 +10,7 @@ struct Formula {
         guard let initialValue: Double = operands.dequeue() else { return 0 }
         var calculatingValue: Double = initialValue
         
-        while operands.isEmpty != true {
+        while !operands.isEmpty {
             guard let rhs = operands.dequeue(),
                   let unitOperator = operators.dequeue() else { return 0 }
             

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -1,6 +1,6 @@
 //  Created by Aejong on 2022/09/21.
 
-struct CalculatorItemQueueByLinkedList<T> {
+struct CalculatorItemQueueByLinkedList<T: CalculateItem> {
     var linkedList = LinkedList<T>()
     
     var isEmpty: Bool {

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -1,7 +1,6 @@
 //  Created by Aejong on 2022/09/21.
 
 struct CalculatorItemQueueByLinkedList<T> {
-    
     var linkedList = LinkedList<T>()
     
     var isEmpty: Bool {

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -1,7 +1,6 @@
 //  Created by Aejong on 2022/09/23.
 
 struct LinkedList<T> {
-    
     private(set) var head: LinkedListNode<T>?
     private(set) var tail: LinkedListNode<T>?
     

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -1,7 +1,10 @@
 //  Created by Aejong on 2022/09/27
 
 enum Operator: Character, CaseIterable, CalculateItem {
-    case add = "+", subtract = "-", divide = "/", multiply = "*"
+    case add = "+"
+    case subtract = "-"
+    case divide = "/"
+    case multiply = "*"
     
     func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -8,18 +8,31 @@ enum Operator: Character, CaseIterable, CalculateItem {
     }
     
     private func add(lhs: Double, rhs: Double) -> Double {
-        return 0
+        return lhs + rhs
     }
     
     private func substract(lhs: Double, rhs: Double) -> Double {
-        return 0
+        return lhs - rhs
     }
     
     private func divide(lhs: Double, rhs: Double) -> Double {
-        return 0
+        return lhs / rhs
     }
     
     private func multiply(lhs: Double, rhs: Double) -> Double {
-        return 0
+        return lhs * rhs
+    }
+    
+    func calculatee(lhs: Double, rhs: Double) -> Double {
+        switch self {
+        case .add :
+            return add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            return substract(lhs: lhs, rhs: rhs)
+        case .divide:
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
+        }
     }
 }

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -3,14 +3,14 @@
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+", subtract = "-", divide = "/", multiply = "*"
     
-    func calculate(lhs: Double, rhs: Double) -> Double {
+    func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {
         case .add :
             return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return substract(lhs: lhs, rhs: rhs)
         case .divide:
-            return divide(lhs: lhs, rhs: rhs)
+            return try divide(lhs: lhs, rhs: rhs)
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
         }
@@ -24,7 +24,10 @@ enum Operator: Character, CaseIterable, CalculateItem {
         return lhs - rhs
     }
     
-    private func divide(lhs: Double, rhs: Double) -> Double {
+    private func divide(lhs: Double, rhs: Double) throws -> Double {
+        guard rhs != 0 else {
+            throw CalculateError.divideByZero
+        }
         return lhs / rhs
     }
     

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -1,0 +1,25 @@
+//  Created by Victor on 2022/09/27
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+", subtract = "-", divide = "/", multiply = "*"
+    
+    func calculate(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+    
+    private func add(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+    
+    private func substract(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+    
+    private func divide(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+    
+    private func multiply(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+}

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -4,7 +4,16 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+", subtract = "-", divide = "/", multiply = "*"
     
     func calculate(lhs: Double, rhs: Double) -> Double {
-        return 0
+        switch self {
+        case .add :
+            return add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            return substract(lhs: lhs, rhs: rhs)
+        case .divide:
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
+        }
     }
     
     private func add(lhs: Double, rhs: Double) -> Double {
@@ -21,18 +30,5 @@ enum Operator: Character, CaseIterable, CalculateItem {
     
     private func multiply(lhs: Double, rhs: Double) -> Double {
         return lhs * rhs
-    }
-    
-    func calculatee(lhs: Double, rhs: Double) -> Double {
-        switch self {
-        case .add :
-            return add(lhs: lhs, rhs: rhs)
-        case .subtract:
-            return substract(lhs: lhs, rhs: rhs)
-        case .divide:
-            return divide(lhs: lhs, rhs: rhs)
-        case .multiply:
-            return multiply(lhs: lhs, rhs: rhs)
-        }
     }
 }

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -1,4 +1,4 @@
-//  Created by Victor on 2022/09/27
+//  Created by Aejong on 2022/09/27
 
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+", subtract = "-", divide = "/", multiply = "*"

--- a/Calculator/CalculatorModelTests/CalculatorModelTests.swift
+++ b/Calculator/CalculatorModelTests/CalculatorModelTests.swift
@@ -5,20 +5,20 @@ import XCTest
 @testable import Calculator
 
 class CalculatorModelTests: XCTestCase {
-    var sutByLinkedList: CalculatorItemQueueByLinkedList<String>!
+    var sutByLinkedList: CalculatorItemQueueByLinkedList<Double>!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        sutByLinkedList = CalculatorItemQueueByLinkedList<String>()
+        sutByLinkedList = CalculatorItemQueueByLinkedList<Double>()
     }
     
     override func tearDownWithError() throws {
         try super.tearDownWithError()
     }
     
-    func test_1_더하기연산자_3요소가_순서대로linkedList에_append되어야한다() {
+    func test_1_2_3요소가_순서대로linkedList에_append되어야한다() {
         // given
-        let input = ["1", "+", "3"]
+        let input: [Double] = [1,2,3]
         
         // when
         for element in input {
@@ -26,25 +26,25 @@ class CalculatorModelTests: XCTestCase {
         }
         
         // then
-        XCTAssertEqual(sutByLinkedList.linkedList.head?.value, "1")
-        XCTAssertEqual(sutByLinkedList.linkedList.tail?.value, "3")
+        XCTAssertEqual(sutByLinkedList.linkedList.head?.value, 1)
+        XCTAssertEqual(sutByLinkedList.linkedList.tail?.value, 3)
     }
     
     func test_비어있는list에_1을enqueue한후_dequeue가1을반환해야한다() {
         // given
-        let input = "1"
+        let input: Double = 1
         sutByLinkedList.enqueue(input)
         
         // when
         let result = sutByLinkedList.dequeue()
         
         // then
-        XCTAssertEqual(result, "1")
+        XCTAssertEqual(result, 1)
     }
     
     func test_1_2_3_을enqueue한후_dequeue를호출했을때_1을반환해야한다() {
         // given
-        let input = ["1", "+", "3"]
+        let input: [Double] = [1, 2, 3]
         for element in input {
             sutByLinkedList.enqueue(element)
         }
@@ -53,6 +53,6 @@ class CalculatorModelTests: XCTestCase {
         let result = sutByLinkedList.dequeue()
         
         // then
-        XCTAssertEqual(result, "1")
+        XCTAssertEqual(result, 1)
     }
 }

--- a/Calculator/CalculatorModelTests/CalculatorModelTests.swift
+++ b/Calculator/CalculatorModelTests/CalculatorModelTests.swift
@@ -15,7 +15,7 @@ class CalculatorModelTests: XCTestCase {
         try super.tearDownWithError()
     }
     
-    func test_1_2_3요소가_순서대로linkedList에_append되어야한다() {
+    func test_배열의요소가_순서대로linkedList에_append되어야한다() {
         // given
         let input: [Double] = [1,2,3]
         
@@ -29,7 +29,7 @@ class CalculatorModelTests: XCTestCase {
         XCTAssertEqual(sutByLinkedList.linkedList.tail?.value, 3)
     }
     
-    func test_비어있는list에_1을enqueue한후_dequeue가1을반환해야한다() {
+    func test_큐에하나의요소를enqueue한후_dequeue가그값을반환해야한다() {
         // given
         let input: Double = 1
         sutByLinkedList.enqueue(input)
@@ -41,7 +41,7 @@ class CalculatorModelTests: XCTestCase {
         XCTAssertEqual(result, 1)
     }
     
-    func test_1_2_3_을enqueue한후_dequeue를호출했을때_1을반환해야한다() {
+    func test_배열의요소들을enqueue한후_dequeue를호출했을때_가장먼저enqueue된값을반환해야한다() {
         // given
         let input: [Double] = [1, 2, 3]
         for element in input {

--- a/Calculator/CalculatorModelTests/CalculatorModelTests.swift
+++ b/Calculator/CalculatorModelTests/CalculatorModelTests.swift
@@ -1,6 +1,5 @@
 //  Created by Aejong on 2022/09/21.
 
-
 import XCTest
 @testable import Calculator
 

--- a/Calculator/CalculatorModelTests/CalculatorModelTests.swift
+++ b/Calculator/CalculatorModelTests/CalculatorModelTests.swift
@@ -11,10 +11,6 @@ class CalculatorModelTests: XCTestCase {
         sutByLinkedList = CalculatorItemQueueByLinkedList<Double>()
     }
     
-    override func tearDownWithError() throws {
-        try super.tearDownWithError()
-    }
-    
     func test_배열의요소가_순서대로linkedList에_append되어야한다() {
         // given
         let input: [Double] = [1,2,3]

--- a/Calculator/CalculatorModelTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorModelTests/ExpressionParserTests.swift
@@ -7,7 +7,7 @@ class ExpressionParserTests: XCTestCase {
     
     func test_문자열로수식을입력받았을때_parse호출및result호출시_피연산자와연산자가분리돼계산되어야한다() {
         // given
-        let input = "1+2-3*0"
+        let input = "1 + 2 - 3 * 0"
         
         // when
         var formula = ExpressionParser.parse(from: input)

--- a/Calculator/CalculatorModelTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorModelTests/ExpressionParserTests.swift
@@ -1,0 +1,37 @@
+//  Created by Aejong on 2022/09/28
+
+
+import XCTest
+@testable import Calculator
+
+class ExpressionParserTests: XCTestCase {
+    var sutFormula: Formula!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+    }
+    
+    func test_문자열로수식을입력받았을때_parse호출및result호출시_피연산자와연산자가분리돼계산되어야한다() {
+        // given
+        let input = "1+2-3*0"
+
+        // when
+        var formula = ExpressionParser.parse(from: input)
+        var result:Double = 0
+        
+        do {
+            result = try formula.result()
+        } catch CalculateError.divideByZero {
+            print("0으로 나눌 수 없습니다")
+        } catch {
+            
+        }
+        
+        // then
+        XCTAssertEqual(result, 0)
+    }
+}

--- a/Calculator/CalculatorModelTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorModelTests/ExpressionParserTests.swift
@@ -5,14 +5,6 @@ import XCTest
 
 class ExpressionParserTests: XCTestCase {
     
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-    }
-    
-    override func tearDownWithError() throws {
-        try super.tearDownWithError()
-    }
-    
     func test_문자열로수식을입력받았을때_parse호출및result호출시_피연산자와연산자가분리돼계산되어야한다() {
         // given
         let input = "1+2-3*0"

--- a/Calculator/CalculatorModelTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorModelTests/ExpressionParserTests.swift
@@ -1,16 +1,14 @@
 //  Created by Aejong on 2022/09/28
 
-
 import XCTest
 @testable import Calculator
 
 class ExpressionParserTests: XCTestCase {
-    var sutFormula: Formula!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
     }
-
+    
     override func tearDownWithError() throws {
         try super.tearDownWithError()
     }
@@ -18,7 +16,7 @@ class ExpressionParserTests: XCTestCase {
     func test_문자열로수식을입력받았을때_parse호출및result호출시_피연산자와연산자가분리돼계산되어야한다() {
         // given
         let input = "1+2-3*0"
-
+        
         // when
         var formula = ExpressionParser.parse(from: input)
         var result:Double = 0

--- a/Calculator/CalculatorModelTests/FormulaTests.swift
+++ b/Calculator/CalculatorModelTests/FormulaTests.swift
@@ -35,7 +35,7 @@ class FormulaTests: XCTestCase {
         XCTAssertEqual(result, 3.0)
     }
     
-    func test_피연산자3개_같은연산자2개로이루어진Formula에서_result함수호출시_연산결과가반환되어야한다() {
+    func test_3개이상의피연산자와_모두같은연산자로만이루어진Formula에서_result함수호출시_연산결과가반환되어야한다() {
         // given
         operands.enqueue(1)
         operands.enqueue(2)
@@ -58,7 +58,7 @@ class FormulaTests: XCTestCase {
         XCTAssertEqual(result, 6.0)
     }
     
-    func test_5개의피연산자와4개의각각다른연산자를통해_순서대로연산완료후결과를반환해야한다() {
+    func test_3개이상의피연산자를_각각다른연산자를통해서도_연산이가능해야한다() {
         // given
         operands.enqueue(1)
         operands.enqueue(2)

--- a/Calculator/CalculatorModelTests/FormulaTests.swift
+++ b/Calculator/CalculatorModelTests/FormulaTests.swift
@@ -5,9 +5,13 @@ import XCTest
 
 class FormulaTests: XCTestCase {
     var sut: Formula!
+    var operands: CalculatorItemQueueByLinkedList<Double>!
+    var operators: CalculatorItemQueueByLinkedList<Operator>!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
+        operands = CalculatorItemQueueByLinkedList()
+        operators = CalculatorItemQueueByLinkedList()
     }
 
     override func tearDownWithError() throws {
@@ -16,17 +20,22 @@ class FormulaTests: XCTestCase {
     
     func test_formula인스턴스생성해준상태로_1_add_2의결과가_3이반환되야한다() {
         // given
-        var operands: CalculatorItemQueueByLinkedList<Double> = CalculatorItemQueueByLinkedList()
-        var operators: CalculatorItemQueueByLinkedList<Operator> = CalculatorItemQueueByLinkedList()
-        
         operands.enqueue(1)
         operands.enqueue(2)
         
         operators.enqueue(.add)
         
         sut = Formula(operands: operands, operators: operators)
+        
         // when
-        let result = sut.result()
+        var result:Double = 0
+        do {
+            result = try sut.result()
+        } catch CalculateError.divideByZero {
+            print("0으로 나눌 수 없습니다")
+        } catch {
+            
+        }
         
         // then
         XCTAssertEqual(result, 3.0)
@@ -34,9 +43,6 @@ class FormulaTests: XCTestCase {
     
     func test_1_2_3의피연산자와2개의add연산자를enqueue하고_result에서6이반환되어야한다() {
         // given
-        var operands: CalculatorItemQueueByLinkedList<Double> = CalculatorItemQueueByLinkedList()
-        var operators: CalculatorItemQueueByLinkedList<Operator> = CalculatorItemQueueByLinkedList()
-        
         operands.enqueue(1)
         operands.enqueue(2)
         operands.enqueue(3)
@@ -47,7 +53,14 @@ class FormulaTests: XCTestCase {
         sut = Formula(operands: operands, operators: operators)
         
         // when
-        let result = sut.result()
+        var result:Double = 0
+        do {
+            result = try sut.result()
+        } catch CalculateError.divideByZero {
+            print("0으로 나눌 수 없습니다")
+        } catch {
+            
+        }
         
         // then
         XCTAssertEqual(result, 6.0)
@@ -55,9 +68,6 @@ class FormulaTests: XCTestCase {
     
     func test_5개의피연산자와4개의각각다른연산자를통해_구현되어야한다() {
         // given
-        var operands: CalculatorItemQueueByLinkedList<Double> = CalculatorItemQueueByLinkedList()
-        var operators: CalculatorItemQueueByLinkedList<Operator> = CalculatorItemQueueByLinkedList()
-        
         operands.enqueue(1)
         operands.enqueue(2)
         operands.enqueue(3)
@@ -69,13 +79,34 @@ class FormulaTests: XCTestCase {
         operators.enqueue(.divide)
         operators.enqueue(.subtract)
         
-        
         sut = Formula(operands: operands, operators: operators)
         
         // when
-        let result = sut.result()
+        var result:Double = 0
+        do {
+            result = try sut.result()
+        } catch CalculateError.divideByZero {
+            print("0으로 나눌 수 없습니다")
+        } catch {
+            
+        }
         
         // then
         XCTAssertEqual(result, -2.75)
+    }
+    
+    func test_0으로나누었을때_오류를발생시켜야한다() {
+        // given
+        operands.enqueue(1)
+        operands.enqueue(0)
+        
+        operators.enqueue(.divide)
+        
+        sut = Formula(operands: operands, operators: operators)
+        
+        // when, then
+        XCTAssertThrowsError(try sut.result()) {error in
+            print(error,"가 발생했습니다")
+        }
     }
 }

--- a/Calculator/CalculatorModelTests/FormulaTests.swift
+++ b/Calculator/CalculatorModelTests/FormulaTests.swift
@@ -14,10 +14,6 @@ class FormulaTests: XCTestCase {
         operators = CalculatorItemQueueByLinkedList()
     }
     
-    override func tearDownWithError() throws {
-        try super.tearDownWithError()
-    }
-    
     func test_피연산자2개_연산자1개로_이루어진Formula에서_result함수호출시_연산결과가반환되어야한다() {
         // given
         operands.enqueue(1)

--- a/Calculator/CalculatorModelTests/FormulaTests.swift
+++ b/Calculator/CalculatorModelTests/FormulaTests.swift
@@ -1,0 +1,34 @@
+//  Created by Aejong on 2022/09/27
+
+import XCTest
+@testable import Calculator
+
+class FormulaTests: XCTestCase {
+    var sut: Formula!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+    }
+    
+    func test_formula인스턴스생성해준상태로_1_add_2의결과가_3이반환되야한다() {
+        // given
+        var operands: CalculatorItemQueueByLinkedList<Double> = CalculatorItemQueueByLinkedList()
+        var operators: CalculatorItemQueueByLinkedList<Operator> = CalculatorItemQueueByLinkedList()
+        
+        operands.enqueue(1)
+        operands.enqueue(2)
+        
+        operators.enqueue(.add)
+        
+        sut = Formula(operands: operands, operators: operators)
+        // when
+        let result = sut.result()
+        
+        // then
+        XCTAssertEqual(result, 3.0)
+    }
+}

--- a/Calculator/CalculatorModelTests/FormulaTests.swift
+++ b/Calculator/CalculatorModelTests/FormulaTests.swift
@@ -18,7 +18,7 @@ class FormulaTests: XCTestCase {
         try super.tearDownWithError()
     }
     
-    func test_formula인스턴스생성해준상태로_1_add_2의결과가_3이반환되야한다() {
+    func test_피연산자2개_연산자1개로_이루어진Formula에서_result함수호출시_연산결과가반환되어야한다() {
         // given
         operands.enqueue(1)
         operands.enqueue(2)
@@ -31,8 +31,6 @@ class FormulaTests: XCTestCase {
         var result:Double = 0
         do {
             result = try sut.result()
-        } catch CalculateError.divideByZero {
-            print("0으로 나눌 수 없습니다")
         } catch {
             
         }
@@ -41,7 +39,7 @@ class FormulaTests: XCTestCase {
         XCTAssertEqual(result, 3.0)
     }
     
-    func test_1_2_3의피연산자와2개의add연산자를enqueue하고_result에서6이반환되어야한다() {
+    func test_피연산자3개_같은연산자2개로이루어진Formula에서_result함수호출시_연산결과가반환되어야한다() {
         // given
         operands.enqueue(1)
         operands.enqueue(2)
@@ -56,8 +54,6 @@ class FormulaTests: XCTestCase {
         var result:Double = 0
         do {
             result = try sut.result()
-        } catch CalculateError.divideByZero {
-            print("0으로 나눌 수 없습니다")
         } catch {
             
         }
@@ -66,7 +62,7 @@ class FormulaTests: XCTestCase {
         XCTAssertEqual(result, 6.0)
     }
     
-    func test_5개의피연산자와4개의각각다른연산자를통해_구현되어야한다() {
+    func test_5개의피연산자와4개의각각다른연산자를통해_순서대로연산완료후결과를반환해야한다() {
         // given
         operands.enqueue(1)
         operands.enqueue(2)
@@ -85,8 +81,6 @@ class FormulaTests: XCTestCase {
         var result:Double = 0
         do {
             result = try sut.result()
-        } catch CalculateError.divideByZero {
-            print("0으로 나눌 수 없습니다")
         } catch {
             
         }

--- a/Calculator/CalculatorModelTests/FormulaTests.swift
+++ b/Calculator/CalculatorModelTests/FormulaTests.swift
@@ -13,7 +13,7 @@ class FormulaTests: XCTestCase {
         operands = CalculatorItemQueueByLinkedList()
         operators = CalculatorItemQueueByLinkedList()
     }
-
+    
     override func tearDownWithError() throws {
         try super.tearDownWithError()
     }

--- a/Calculator/CalculatorModelTests/FormulaTests.swift
+++ b/Calculator/CalculatorModelTests/FormulaTests.swift
@@ -31,4 +31,51 @@ class FormulaTests: XCTestCase {
         // then
         XCTAssertEqual(result, 3.0)
     }
+    
+    func test_1_2_3의피연산자와2개의add연산자를enqueue하고_result에서6이반환되어야한다() {
+        // given
+        var operands: CalculatorItemQueueByLinkedList<Double> = CalculatorItemQueueByLinkedList()
+        var operators: CalculatorItemQueueByLinkedList<Operator> = CalculatorItemQueueByLinkedList()
+        
+        operands.enqueue(1)
+        operands.enqueue(2)
+        operands.enqueue(3)
+        
+        operators.enqueue(.add)
+        operators.enqueue(.add)
+        
+        sut = Formula(operands: operands, operators: operators)
+        
+        // when
+        let result = sut.result()
+        
+        // then
+        XCTAssertEqual(result, 6.0)
+    }
+    
+    func test_5개의피연산자와4개의각각다른연산자를통해_구현되어야한다() {
+        // given
+        var operands: CalculatorItemQueueByLinkedList<Double> = CalculatorItemQueueByLinkedList()
+        var operators: CalculatorItemQueueByLinkedList<Operator> = CalculatorItemQueueByLinkedList()
+        
+        operands.enqueue(1)
+        operands.enqueue(2)
+        operands.enqueue(3)
+        operands.enqueue(4)
+        operands.enqueue(5)
+        
+        operators.enqueue(.add)
+        operators.enqueue(.multiply)
+        operators.enqueue(.divide)
+        operators.enqueue(.subtract)
+        
+        
+        sut = Formula(operands: operands, operators: operators)
+        
+        // when
+        let result = sut.result()
+        
+        // then
+        XCTAssertEqual(result, -2.75)
+    }
 }


### PR DESCRIPTION
@hyunable 
# 계산기 [STEP 2] p.r


잘 지내셨나요 hyunable!
벌써 수요일이네요 시간이 정말 빨라요 ㅎㅎ 😅 STEP-2도 열심히 해봤습니다. 잘 부탁드립니다!

---
## UML 분석과 구현
![](https://i.imgur.com/KarAmRY.png)

> 가장 먼저 UML을 보고 틀부터 구현해봤습니다.
>  +/- 의 개방적인 것과 폐쇄적인 것은 -된 녀석들만 private처리해 주었습니다.
>  밑줄 그어진 녀석들은 static을 붙여주었습니다.


## [고민되었던 점]
### private을 왜 해주었을까
- UML 을 따라 몇몇 함수는 private처리해주고나서 왜 폐쇄적으로 설정해놓았을까 고민했습니다. 처음엔 그 의미를 잘 몰랐지만 하나씩 함수를 구현해나가다보니 의도를 알 수 있었습니다. 외부에서는 사용할 일이 없고, `내부적으로만 사용`되는 함수이다보니 폐쇄적으로 처리했다는 걸 알게되었습니다.

### Operator내부 함수 구현 고민
- Operator는 연산자를 담고있는 열거형 타입입니다. 4개의 사칙연산함수 외에도 `calculate()`라는 함수만이 `개방성`을 띄고 있습니다. 사칙연산을 하려면 다른 4개의 함수에도 접근할 수 있어야 할텐데 UML상에 이렇게 표현한 이유를 고민해봤습니다.
```swift
func calculate(lhs: Double, rhs: Double) throws -> Double {
        switch self {
        case .add :
            return add(lhs: lhs, rhs: rhs)
        case .subtract:
            return substract(lhs: lhs, rhs: rhs)
        case .divide:
            return try divide(lhs: lhs, rhs: rhs)
        case .multiply:
            return multiply(lhs: lhs, rhs: rhs)
        }
    }

```
- 그 결과 위처럼 사칙연산 case에 따라 ***case***.calculate()을 통해 내부적으로 접근 가능하게 구현해봤습니다.

### case가 없는 enum의 namespace화
 - ExpressionParser 열거형 타입은 Case가 존재하지 않고 UML상의 함수에도 밑줄이 그어진, static한 함수를 가지는 namespace라고 할 수 있습니다. 검색결과 namespace는 관련있는 것들끼리 모아놓은 공간?이라고 표현한다고 보았습니다. case가 없는 경우엔 ExpressionParser() 이런식으로 초기화하려고 하면 오류가 발생한다고 합니다. 이는 다른 개발자와 협업하는 경우에 다른 개발자가 namespace임을 몰라도 오류발생을 통해 알 수 있도록 하기도 한다고 배웠습니다. 
 - 제 경우엔 static으로 선언하기 전 unitTest에서 `ExpressionParser.parse()` 함수가 호출이 되지 않아 그 이유를 찾다가 UML에서 표현된 밑줄을 보고 알게되었습니다.

### CalculateItem프로토콜은 무엇이고, 채택하는 것의 의미는 뭘까
- calculateItem을 채택하는 녀석들은 Double과 Operator타입입니다. 이 둘은 사칙연산에 필요한 피연산자와 연산자이기 때문입니다.
- 만약 *CalculatorItemQueueByLinkedList<T: CalculateItem>* 이런 식으로 넣어준다면, 큐에 들어올 수 있는 요소는 Double과 Operator만으로 제한하는 역할을 한다고 생각합니다.

### Formula
- Formula 구조체는 operands, operators라는 피연산자와 연산자를 담는 큐가 존재하고 이 큐를 조작해 최종 연산 값을 도출하는 result()함수로 이루어졌습니다.
- result()함수는 계속해서 2개의 피연산자들을 연산하고, 그 결과를 다시 lhs에 해당하는 피연산자로 할당해주었습니다. 피연산자가 더이상 남아있지 않을 때까지 이 과정을 반복해 최종 결과값을 반환했습니다.
```swift
 mutating func result() throws -> Double {
        var result: Double
        
        guard let initialValue: Double = operands.dequeue() else { return 0 }
        var calculatingValue: Double = initialValue
        
        while operands.isEmpty != true {
            guard let rhs = operands.dequeue(),
                  let unitOperator = operators.dequeue() else { return 0 }
            
            calculatingValue = try unitOperator.calculate(lhs: calculatingValue, rhs: rhs)
        }
        result = calculatingValue
        
        return result
    }
```
### componentsByOperator 과 Split
- formula에서 큐에 존재하는 피연산자와 연산자를 통해 사칙연산을 해주었다면, 문자열로 이루어진 식을 parsing 후 큐에 담아주는 작업을 ExpressionParser에서 해준다고 생각했습니다.
- componentsByOperator함수는 이름 그대로 연산자를 제외한 피연산자만을 반환하는 함수라고 생각했습니다. 

```swift
private static func componentsByOperator(from input: String) -> [String] {
        var inputString: String = input
        
        for caseOperator in Operator.allCases {
            inputString = inputString.replacingOccurrences(of: "\(caseOperator.rawValue)", with: " ")
        }
        
        return inputString.split(with: " ")
    }
```
- allCases를 통해 모든 연산자를 " " 빈 스페이스로 바꿔주었고, split메서드를 사용해 피연산자로 이루어진 [String] 형태로 변환해주었습니다.


### ExpressionParser.parse
- 피연산자로 이루어진 배열까지 만들어줬으니 금방 해결될거라고 생각했지만 제 착각이였습니다. 이를 Double타입으로 바꿔주고 큐에 enqueue해주는 작업은 또 다른 종류의 고민이었습니다.
- compactMap을 통해 피연산자들을 String에서 Double로 형변환 해줌과 동시에 optional binding처리도 되게 구현했습니다.
```swift=
let operandsArray: [Double] = componentsByOperator(from: input).compactMap { Double($0) }
```
- [Operator]도 마찬가지로 Operator들의 rawValue(Character) 를 통해 Operator타입으로 변환시켜주고 배열로 담아주었습니다.
```swift=
let operatorsArray: [Operator] = input.compactMap { Operator(rawValue: $0) }
```

- 이후 for문을 사용해 enqueue해주었고 반환되는 formula로 unitTest까지 해본 결과 정상적인 사칙연산이 이루어지는 것을 알게 되었습니다.



---


