### PR TITLE
계산기 [Step3] Kyo

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3C3F95DC28DC8A0A00F63109 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3F95DB28DC8A0A00F63109 /* Formula.swift */; };
 		3C3F95E728DCBADA00F63109 /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3F95E628DCBADA00F63109 /* ExpressionParserTests.swift */; };
 		3C3F95F628DD42E500F63109 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3F95F528DD42E500F63109 /* FormulaTests.swift */; };
+		3CDE59B228E2887100782A38 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CDE59B128E2887100782A38 /* Constant.swift */; };
 		3CF6379828D8B51B00611FE6 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF6379728D8B51B00611FE6 /* Node.swift */; };
 		3CF637C628D9474700611FE6 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF6379928D8B5D500611FE6 /* LinkedList.swift */; };
 		3CF637C728D9475600611FE6 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF6379B28D8BA1800611FE6 /* CalculatorItemQueue.swift */; };
@@ -82,6 +83,7 @@
 		3C3F95E628DCBADA00F63109 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		3C3F95F328DD42E500F63109 /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C3F95F528DD42E500F63109 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
+		3CDE59B128E2887100782A38 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		3CF6379728D8B51B00611FE6 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		3CF6379928D8B5D500611FE6 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		3CF6379B28D8BA1800611FE6 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 		3C3EF12728DBF149003F6900 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				3CDE59B028E2885F00782A38 /* Constant */,
 				3C3C0BA628DD54BE005A9883 /* Error */,
 				3C3EF12928DBF177003F6900 /* Extension */,
 				3C3EF12828DBF16F003F6900 /* Utils */,
@@ -214,6 +217,14 @@
 				3C3F95F528DD42E500F63109 /* FormulaTests.swift */,
 			);
 			path = FormulaTests;
+			sourceTree = "<group>";
+		};
+		3CDE59B028E2885F00782A38 /* Constant */ = {
+			isa = PBXGroup;
+			children = (
+				3CDE59B128E2887100782A38 /* Constant.swift */,
+			);
+			path = Constant;
 			sourceTree = "<group>";
 		};
 		3CF6379628D8B50F00611FE6 /* Models */ = {
@@ -566,6 +577,7 @@
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				3C3EF12D28DBF1C9003F6900 /* CalculateItem.swift in Sources */,
 				3C3C0BA528DD52C7005A9883 /* CalculatorError.swift in Sources */,
+				3CDE59B228E2887100782A38 /* Constant.swift in Sources */,
 				3CF637C628D9474700611FE6 /* LinkedList.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				3C3F95CB28DC68B800F63109 /* Operator.swift in Sources */,

--- a/Calculator/Calculator/Common/Constant/Constant.swift
+++ b/Calculator/Calculator/Common/Constant/Constant.swift
@@ -5,14 +5,12 @@
 //  Created by Kyo on 2022/09/27.
 //
 
-struct Constant {
-    private init() { }
-    
-    static let zero = "0"
-    static let defaultZero = "D0"
-    static let doubleZero = "00"
-    static let negative = "-"
-    static let empty = ""
-    static let calculate = "="
-    static let dot = "."
+enum Constant {
+    static let zero: String = "0"
+    static let defaultZero: String = "D0"
+    static let doubleZero: String = "00"
+    static let negative: String = "-"
+    static let empty: String = ""
+    static let calculate: String = "="
+    static let dot: String = "."
 }

--- a/Calculator/Calculator/Common/Constant/Constant.swift
+++ b/Calculator/Calculator/Common/Constant/Constant.swift
@@ -13,5 +13,6 @@ struct Constant {
     static let doubleZero = "00"
     static let negative = "-"
     static let empty = ""
+    static let calculate = "="
     static let dot = "."
 }

--- a/Calculator/Calculator/Common/Constant/Constant.swift
+++ b/Calculator/Calculator/Common/Constant/Constant.swift
@@ -1,0 +1,17 @@
+//
+//  Constant.swift
+//  Calculator
+//
+//  Created by Kyo on 2022/09/27.
+//
+
+struct Constant {
+    private init() { }
+    
+    static let zero = "0"
+    static let defaultZero = "D0"
+    static let doubleZero = "00"
+    static let negative = "-"
+    static let empty = ""
+    static let dot = "."
+}

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -8,8 +8,8 @@ import UIKit
 
 final class ViewController: UIViewController {
     
-    @IBOutlet weak var mainOperatorLabel: UILabel!
-    @IBOutlet weak var mainResultLabel: UILabel!
+    @IBOutlet weak var operatorLabel: UILabel!
+    @IBOutlet weak var resultLabel: UILabel!
     
     @IBOutlet weak var historyScrollView: UIScrollView!
     @IBOutlet weak var historyStackView: UIStackView!
@@ -25,12 +25,12 @@ final class ViewController: UIViewController {
     }
     
     private func setUILabel() {
-        mainOperatorLabel.text = Constant.empty
-        mainResultLabel.text = Constant.zero
+        operatorLabel.text = Constant.empty
+        resultLabel.text = Constant.zero
     }
     
     private func setDefaultOperand() {
-        mainResultLabel.text = Constant.zero
+        resultLabel.text = Constant.zero
         currentOperand = Constant.defaultZero
     }
 
@@ -38,8 +38,8 @@ final class ViewController: UIViewController {
         historyStackView.subviews.forEach{ $0.removeFromSuperview() }
     }
     
-    private func updateMainResultLabel() {
-        mainResultLabel.text = currentOperand
+    private func updateResultLabel() {
+        resultLabel.text = currentOperand
     }
     
     private func applyNumberFormatter(number: Double) -> String {
@@ -106,7 +106,7 @@ final class ViewController: UIViewController {
             currentOperand += number
         }
         
-        updateMainResultLabel()
+        updateResultLabel()
     }
     
     @IBAction func tappedOperatorPads(_ sender: UIButton) {
@@ -117,12 +117,12 @@ final class ViewController: UIViewController {
         let tappedOperator = sender.currentTitle
         guard let operators = tappedOperator else { return }
         
-        mainOperatorLabel.text = operators
+        operatorLabel.text = operators
         
         if currentOperator == Constant.calculate {
             currentOperand = Constant.defaultZero
             currentOperator = operators
-            mainResultLabel.text = Constant.zero
+            resultLabel.text = Constant.zero
             return
         }
         
@@ -153,16 +153,16 @@ final class ViewController: UIViewController {
         removeFirstHistory.removeFirst()
         
         currentOperator = Constant.calculate
-        mainOperatorLabel.text = Constant.empty
+        operatorLabel.text = Constant.empty
         
         let formula = ExpressionParser.parse(from: removeFirstHistory.joined())
         
         do {
             let result = try formula.result()
             if result.isNaN {
-                mainResultLabel.text = "NaN"
+                resultLabel.text = "NaN"
             } else {
-                mainResultLabel.text = applyNumberFormatter(number: result)
+                resultLabel.text = applyNumberFormatter(number: result)
             }
             currentOperand = Constant.zero
         } catch CalculatorError.noneOperand {
@@ -179,7 +179,7 @@ final class ViewController: UIViewController {
             return
         } else {
             currentOperand += Constant.dot
-            updateMainResultLabel()
+            updateResultLabel()
         }
     }
     
@@ -194,7 +194,7 @@ final class ViewController: UIViewController {
             currentOperand = Constant.negative + currentOperand
         }
         
-        updateMainResultLabel()
+        updateResultLabel()
     }
     
     @IBAction func tappedAllClear(_ sender: UIButton) {
@@ -207,6 +207,6 @@ final class ViewController: UIViewController {
     
     @IBAction func tappedClearEntry(_ sender: UIButton) {
         currentOperand = Constant.defaultZero
-        mainResultLabel.text = Constant.zero
+        resultLabel.text = Constant.zero
     }
 }

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -66,7 +66,25 @@ class ViewController: UIViewController {
     }
     
     @IBAction func tappedCalculate(_ sender: UIButton) {
+        if currentOperand == Constant.defaultZero || calculateHistory.isEmpty {
+            return
+        }
         
+        calculateHistory.append(currentOperator)
+        calculateHistory.append(currentOperand)
+        calculateHistory.removeFirst()
+        
+        let formula = ExpressionParser.parse(from: calculateHistory.joined())
+        
+        do {
+            mainResultLabel.text = try String(formula.result())
+        } catch CalculatorError.noneOperand {
+            
+        } catch CalculatorError.noneOperator {
+            
+        } catch {
+            
+        }
     }
     
     @IBAction func tappedDotPads(_ sender: UIButton) {

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -21,7 +21,7 @@ final class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUILabel()
-        setClearCalculateHistory()
+        clearCalculateHistory()
     }
     
     private func setUILabel() {
@@ -34,7 +34,7 @@ final class ViewController: UIViewController {
         currentOperand = Constant.defaultZero
     }
 
-    private func setClearCalculateHistory() {
+    private func clearCalculateHistory() {
         historyStackView.subviews.forEach{ $0.removeFromSuperview() }
     }
     
@@ -199,7 +199,7 @@ final class ViewController: UIViewController {
     
     @IBAction func tappedAllClear(_ sender: UIButton) {
         setUILabel()
-        setClearCalculateHistory()
+        clearCalculateHistory()
         currentOperand = Constant.defaultZero
         currentOperator = Constant.empty
         calculateHistory.removeAll()

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -34,6 +34,10 @@ class ViewController: UIViewController {
         currentOperand = Constant.defaultZero
     }
 
+    func updateMainResultLabel() {
+        mainResultLabel.text = currentOperand
+    }
+    
     @IBAction func tappedNumberPads(_ sender: UIButton) {
         let tappedNumber = sender.currentTitle
         guard let number = tappedNumber else { return }
@@ -46,6 +50,8 @@ class ViewController: UIViewController {
         } else {
             currentOperand += number
         }
+        
+        updateMainResultLabel()
     }
     
     @IBAction func tappedOperatorPads(_ sender: UIButton) {
@@ -93,10 +99,22 @@ class ViewController: UIViewController {
         } else {
             currentOperand += Constant.dot
         }
+        
+        updateMainResultLabel()
     }
     
     @IBAction func tappedChangePositiveNegative(_ sender: UIButton) {
-
+        if currentOperand == Constant.defaultZero || currentOperand == Constant.zero {
+            return
+        }
+        
+        if currentOperand.contains(Constant.negative) {
+            currentOperand.removeFirst()
+        } else {
+            currentOperand = Constant.negative + currentOperand
+        }
+        
+        updateMainResultLabel()
     }
     
     @IBAction func tappedAllClear(_ sender: UIButton) {

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -46,7 +46,6 @@ final class ViewController: UIViewController {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         numberFormatter.maximumFractionDigits = 20
-        
         guard let result = numberFormatter.string(for: number) else { return Constant.empty }
         
         return result
@@ -117,7 +116,9 @@ final class ViewController: UIViewController {
         
         let tappedOperator = sender.currentTitle
         guard let operators = tappedOperator else { return }
+        
         mainOperatorLabel.text = operators
+        
         if currentOperator == Constant.calculate {
             currentOperand = Constant.defaultZero
             currentOperator = operators
@@ -157,7 +158,6 @@ final class ViewController: UIViewController {
         mainOperatorLabel.text = Constant.empty
         
         let formula = ExpressionParser.parse(from: removeFirstHistory.joined())
-        
         
         do {
             mainResultLabel.text = applyNumberFormatter(number: try formula.result())

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -123,13 +123,11 @@ final class ViewController: UIViewController {
             currentOperand = Constant.defaultZero
             currentOperator = operators
             mainResultLabel.text = Constant.zero
-            
             return
         }
         
         if currentOperand == Constant.defaultZero {
             currentOperator = operators
-            
             return
         }
         

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -160,7 +160,12 @@ final class ViewController: UIViewController {
         let formula = ExpressionParser.parse(from: removeFirstHistory.joined())
         
         do {
-            mainResultLabel.text = applyNumberFormatter(number: try formula.result())
+            let result = try formula.result()
+            if result.isNaN {
+                mainResultLabel.text = "NaN"
+            } else {
+                mainResultLabel.text = applyNumberFormatter(number: result)
+            }
             currentOperand = Constant.zero
         } catch CalculatorError.noneOperand {
             print("None Operand Error")

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -7,12 +7,69 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
+    @IBOutlet weak var mainOperatorLabel: UILabel!
+    @IBOutlet weak var mainResultLabel: UILabel!
+    
+    @IBOutlet weak var historyScrollView: UIScrollView!
+    @IBOutlet weak var historyStackView: UIStackView!
+    
+    var currentOperand: String = Constant.defaultZero
+    var currentOperator: String = Constant.empty
+    var calculateHistory: [String] = []
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        setUILabel()
+    }
+    
+    func setUILabel() {
+        mainOperatorLabel.text = Constant.empty
+        mainResultLabel.text = Constant.zero
+    }
+    
+    func setDefaultOperand() {
+        mainResultLabel.text = Constant.zero
+        currentOperand = Constant.defaultZero
     }
 
+    @IBAction func tappedNumberPads(_ sender: UIButton) {
+        let tappedNumber = sender.currentTitle
+        guard let number = tappedNumber else { return }
+        
+        if currentOperand == Constant.defaultZero || currentOperand == Constant.zero {
+            if number == Constant.doubleZero {
+                return
+            }
+            currentOperand = number
+        } else {
+            currentOperand += number
+        }
+    }
+    
+    @IBAction func tappedOperatorPads(_ sender: UIButton) {
 
+    }
+    
+    @IBAction func tappedCalculate(_ sender: UIButton) {
+        
+    }
+    
+    @IBAction func tappedDotPads(_ sender: UIButton) {
+
+    }
+    
+    @IBAction func tappedChangePositiveNegative(_ sender: UIButton) {
+
+    }
+    
+    @IBAction func tappedAllClear(_ sender: UIButton) {
+        
+    }
+    
+    @IBAction func tappedClearEntry(_ sender: UIButton) {
+
+    }
 }
 

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -49,7 +49,20 @@ class ViewController: UIViewController {
     }
     
     @IBAction func tappedOperatorPads(_ sender: UIButton) {
-
+        let tappedOperator = sender.currentTitle
+        guard let operators = tappedOperator else { return }
+        mainOperatorLabel.text = operators
+        
+        if currentOperand == Constant.defaultZero {
+            currentOperator = operators
+            return
+        }
+        
+        calculateHistory.append(currentOperator)
+        calculateHistory.append(currentOperand)
+        
+        currentOperator = operators
+        setDefaultOperand()
     }
     
     @IBAction func tappedCalculate(_ sender: UIButton) {

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -76,6 +76,10 @@ class ViewController: UIViewController {
         let stackView = makeHistoryStackView(operatorLabel: operatorLabel, operandLabel: operandLabel)
         
         historyStackView.addArrangedSubview(stackView)
+        
+        view.layoutIfNeeded()
+        let contentOffsetValue: CGFloat = historyScrollView.contentSize.height - historyScrollView.frame.height
+        historyScrollView.setContentOffset(CGPoint(x: 0, y: contentOffsetValue), animated: true)
     }
     
     @IBAction func tappedNumberPads(_ sender: UIButton) {

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -125,7 +125,8 @@ class ViewController: UIViewController {
     }
     
     @IBAction func tappedClearEntry(_ sender: UIButton) {
-
+        currentOperand = Constant.defaultZero
+        mainResultLabel.text = Constant.zero
     }
 }
 

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -42,6 +42,16 @@ final class ViewController: UIViewController {
         mainResultLabel.text = currentOperand
     }
     
+    private func applyNumberFormatter(number: Double) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumFractionDigits = 20
+        
+        guard let result = numberFormatter.string(for: number) else { return Constant.empty }
+        
+        return result
+    }
+    
     private func makeHistoryStackViewLabel(item: String) -> UILabel {
         let label: UILabel = {
             let label = UILabel()
@@ -71,8 +81,10 @@ final class ViewController: UIViewController {
     }
     
     private func updateCalculateHistory(currentOperator: String, currentOperand: String) {
+        guard let operand = Double(currentOperand) else { return }
+        
         let operatorLabel = makeHistoryStackViewLabel(item: currentOperator)
-        let operandLabel = makeHistoryStackViewLabel(item: currentOperand)
+        let operandLabel = makeHistoryStackViewLabel(item: applyNumberFormatter(number: operand) )
         let stackView = makeHistoryStackView(operatorLabel: operatorLabel, operandLabel: operandLabel)
         
         historyStackView.addArrangedSubview(stackView)
@@ -107,11 +119,13 @@ final class ViewController: UIViewController {
             currentOperand = Constant.zero
             currentOperator = operators
             mainResultLabel.text = Constant.zero
+            
             return
         }
         
         if currentOperand == Constant.defaultZero {
             currentOperator = operators
+            
             return
         }
         
@@ -141,8 +155,9 @@ final class ViewController: UIViewController {
         
         let formula = ExpressionParser.parse(from: removeFirstHistory.joined())
         
+        
         do {
-            mainResultLabel.text = try String(formula.result())
+            mainResultLabel.text = applyNumberFormatter(number: try formula.result())
             currentOperand = Constant.zero
         } catch CalculatorError.noneOperand {
             print("None Operand Error")

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -66,6 +66,14 @@ class ViewController: UIViewController {
         return stackView
     }
     
+    func updateCalculateHistory(currentOperator: String, currentOperand: String) {
+        let operatorLabel = makeHistoryStackViewLabel(item: currentOperator)
+        let operandLabel = makeHistoryStackViewLabel(item: currentOperand)
+        let stackView = makeHistoryStackView(operatorLabel: operatorLabel, operandLabel: operandLabel)
+        
+        historyStackView.addArrangedSubview(stackView)
+    }
+    
     @IBAction func tappedNumberPads(_ sender: UIButton) {
         let tappedNumber = sender.currentTitle
         guard let number = tappedNumber else { return }
@@ -95,6 +103,7 @@ class ViewController: UIViewController {
         calculateHistory.append(currentOperator)
         calculateHistory.append(currentOperand)
         
+        updateCalculateHistory(currentOperator: currentOperator, currentOperand: currentOperand)
         currentOperator = operators
         setDefaultOperand()
     }
@@ -103,6 +112,8 @@ class ViewController: UIViewController {
         if currentOperand == Constant.defaultZero || calculateHistory.isEmpty {
             return
         }
+        
+        updateCalculateHistory(currentOperator: currentOperator, currentOperand: currentOperand)
         
         calculateHistory.append(currentOperator)
         calculateHistory.append(currentOperand)

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -111,12 +111,15 @@ final class ViewController: UIViewController {
     }
     
     @IBAction func tappedOperatorPads(_ sender: UIButton) {
+        if calculateHistory.isEmpty && currentOperand == Constant.defaultZero {
+            return
+        }
         
         let tappedOperator = sender.currentTitle
         guard let operators = tappedOperator else { return }
         mainOperatorLabel.text = operators
         if currentOperator == Constant.calculate {
-            currentOperand = Constant.zero
+            currentOperand = Constant.defaultZero
             currentOperator = operators
             mainResultLabel.text = Constant.zero
             

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -52,6 +52,20 @@ class ViewController: UIViewController {
         return label
     }
     
+    func makeHistoryStackView(operatorLabel: UILabel, operandLabel: UILabel) -> UIStackView {
+        let stackView: UIStackView = {
+            let stackView = UIStackView(arrangedSubviews: [operatorLabel, operandLabel])
+            stackView.spacing = 8
+            stackView.axis = .horizontal
+            stackView.distribution = .fill
+            stackView.alignment = .fill
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+            return stackView
+        }()
+        
+        return stackView
+    }
+    
     @IBAction func tappedNumberPads(_ sender: UIButton) {
         let tappedNumber = sender.currentTitle
         guard let number = tappedNumber else { return }

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -18,7 +18,6 @@ class ViewController: UIViewController {
     var currentOperator: String = Constant.empty
     var calculateHistory: [String] = []
     
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setUILabel()
@@ -35,12 +34,12 @@ class ViewController: UIViewController {
         currentOperand = Constant.defaultZero
     }
 
-    func updateMainResultLabel() {
-        mainResultLabel.text = currentOperand
-    }
-    
     func setClearCalculateHistory() {
         historyStackView.subviews.forEach{ $0.removeFromSuperview() }
+    }
+    
+    func updateMainResultLabel() {
+        mainResultLabel.text = currentOperand
     }
     
     func makeHistoryStackViewLabel(item: String) -> UILabel {
@@ -173,4 +172,3 @@ class ViewController: UIViewController {
         mainResultLabel.text = Constant.zero
     }
 }
-

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -145,11 +145,11 @@ class ViewController: UIViewController {
             mainResultLabel.text = try String(formula.result())
             currentOperand = Constant.zero
         } catch CalculatorError.noneOperand {
-            
+            print("None Operand Error")
         } catch CalculatorError.noneOperator {
-            
+            print("None Operator Error")
         } catch {
-            
+            print("Some Error")
         }
     }
     

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -22,6 +22,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUILabel()
+        setClearCalculateHistory()
     }
     
     func setUILabel() {
@@ -36,6 +37,10 @@ class ViewController: UIViewController {
 
     func updateMainResultLabel() {
         mainResultLabel.text = currentOperand
+    }
+    
+    func setClearCalculateHistory() {
+        historyStackView.subviews.forEach{ $0.removeFromSuperview() }
     }
     
     func makeHistoryStackViewLabel(item: String) -> UILabel {
@@ -137,9 +142,8 @@ class ViewController: UIViewController {
             return
         } else {
             currentOperand += Constant.dot
+            updateMainResultLabel()
         }
-        
-        updateMainResultLabel()
     }
     
     @IBAction func tappedChangePositiveNegative(_ sender: UIButton) {
@@ -158,6 +162,7 @@ class ViewController: UIViewController {
     
     @IBAction func tappedAllClear(_ sender: UIButton) {
         setUILabel()
+        setClearCalculateHistory()
         currentOperand = Constant.defaultZero
         currentOperator = Constant.empty
         calculateHistory.removeAll()

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -83,7 +83,7 @@ class ViewController: UIViewController {
         guard let number = tappedNumber else { return }
         
         if currentOperand == Constant.defaultZero || currentOperand == Constant.zero {
-            if number == Constant.doubleZero {
+            if number == Constant.doubleZero || currentOperator == Constant.calculate {
                 return
             }
             currentOperand = number
@@ -95,9 +95,16 @@ class ViewController: UIViewController {
     }
     
     @IBAction func tappedOperatorPads(_ sender: UIButton) {
+        
         let tappedOperator = sender.currentTitle
         guard let operators = tappedOperator else { return }
         mainOperatorLabel.text = operators
+        if currentOperator == Constant.calculate {
+            currentOperand = Constant.zero
+            currentOperator = operators
+            mainResultLabel.text = Constant.zero
+            return
+        }
         
         if currentOperand == Constant.defaultZero {
             currentOperator = operators
@@ -113,7 +120,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func tappedCalculate(_ sender: UIButton) {
-        if currentOperand == Constant.defaultZero || calculateHistory.isEmpty {
+        if currentOperand == Constant.defaultZero || calculateHistory.isEmpty || currentOperator == Constant.calculate {
             return
         }
         
@@ -121,12 +128,18 @@ class ViewController: UIViewController {
         
         calculateHistory.append(currentOperator)
         calculateHistory.append(currentOperand)
-        calculateHistory.removeFirst()
         
-        let formula = ExpressionParser.parse(from: calculateHistory.joined())
+        var removeFirstHistory = calculateHistory
+        removeFirstHistory.removeFirst()
+        
+        currentOperator = Constant.calculate
+        mainOperatorLabel.text = Constant.empty
+        
+        let formula = ExpressionParser.parse(from: removeFirstHistory.joined())
         
         do {
             mainResultLabel.text = try String(formula.result())
+            currentOperand = Constant.zero
         } catch CalculatorError.noneOperand {
             
         } catch CalculatorError.noneOperator {
@@ -137,7 +150,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func tappedDotPads(_ sender: UIButton) {
-        if currentOperand.contains(Constant.dot) || currentOperand == Constant.defaultZero {
+        if currentOperand.contains(Constant.dot) || currentOperand == Constant.defaultZero || currentOperator == Constant.calculate {
             return
         } else {
             currentOperand += Constant.dot

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -88,7 +88,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func tappedDotPads(_ sender: UIButton) {
-
+        if currentOperand.contains(Constant.dot) || currentOperand == Constant.defaultZero {
+            return
+        } else {
+            currentOperand += Constant.dot
+        }
     }
     
     @IBAction func tappedChangePositiveNegative(_ sender: UIButton) {

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -38,6 +38,20 @@ class ViewController: UIViewController {
         mainResultLabel.text = currentOperand
     }
     
+    func makeHistoryStackViewLabel(item: String) -> UILabel {
+        let label: UILabel = {
+            let label = UILabel()
+            label.font = UIFont.preferredFont(forTextStyle: .title3)
+            label.textAlignment = .right
+            label.text = item
+            label.textColor = .white
+            label.translatesAutoresizingMaskIntoConstraints = false
+            return label
+        }()
+        
+        return label
+    }
+    
     @IBAction func tappedNumberPads(_ sender: UIButton) {
         let tappedNumber = sender.currentTitle
         guard let number = tappedNumber else { return }

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -118,7 +118,10 @@ class ViewController: UIViewController {
     }
     
     @IBAction func tappedAllClear(_ sender: UIButton) {
-        
+        setUILabel()
+        currentOperand = Constant.defaultZero
+        currentOperator = Constant.empty
+        calculateHistory.removeAll()
     }
     
     @IBAction func tappedClearEntry(_ sender: UIButton) {

--- a/Calculator/Calculator/Controllers/ViewController.swift
+++ b/Calculator/Calculator/Controllers/ViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+final class ViewController: UIViewController {
     
     @IBOutlet weak var mainOperatorLabel: UILabel!
     @IBOutlet weak var mainResultLabel: UILabel!
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     
     var currentOperand: String = Constant.defaultZero
     var currentOperator: String = Constant.empty
-    var calculateHistory: [String] = []
+    private var calculateHistory: [String] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,25 +24,25 @@ class ViewController: UIViewController {
         setClearCalculateHistory()
     }
     
-    func setUILabel() {
+    private func setUILabel() {
         mainOperatorLabel.text = Constant.empty
         mainResultLabel.text = Constant.zero
     }
     
-    func setDefaultOperand() {
+    private func setDefaultOperand() {
         mainResultLabel.text = Constant.zero
         currentOperand = Constant.defaultZero
     }
 
-    func setClearCalculateHistory() {
+    private func setClearCalculateHistory() {
         historyStackView.subviews.forEach{ $0.removeFromSuperview() }
     }
     
-    func updateMainResultLabel() {
+    private func updateMainResultLabel() {
         mainResultLabel.text = currentOperand
     }
     
-    func makeHistoryStackViewLabel(item: String) -> UILabel {
+    private func makeHistoryStackViewLabel(item: String) -> UILabel {
         let label: UILabel = {
             let label = UILabel()
             label.font = UIFont.preferredFont(forTextStyle: .title3)
@@ -56,7 +56,7 @@ class ViewController: UIViewController {
         return label
     }
     
-    func makeHistoryStackView(operatorLabel: UILabel, operandLabel: UILabel) -> UIStackView {
+    private func makeHistoryStackView(operatorLabel: UILabel, operandLabel: UILabel) -> UIStackView {
         let stackView: UIStackView = {
             let stackView = UIStackView(arrangedSubviews: [operatorLabel, operandLabel])
             stackView.spacing = 8
@@ -70,7 +70,7 @@ class ViewController: UIViewController {
         return stackView
     }
     
-    func updateCalculateHistory(currentOperator: String, currentOperand: String) {
+    private func updateCalculateHistory(currentOperator: String, currentOperand: String) {
         let operatorLabel = makeHistoryStackViewLabel(item: currentOperator)
         let operandLabel = makeHistoryStackViewLabel(item: currentOperand)
         let stackView = makeHistoryStackView(operatorLabel: operatorLabel, operandLabel: operandLabel)

--- a/Calculator/Calculator/Models/Operator.swift
+++ b/Calculator/Calculator/Models/Operator.swift
@@ -18,7 +18,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
         case .subtract:
             return self.subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            return self.divide(lhs: lhs, rhs: rhs)
+            return rhs == Double.zero ? .nan : self.divide(lhs: lhs, rhs: rhs)
         case .multifly:
             return self.multifly(lhs: lhs, rhs: rhs)
         }

--- a/Calculator/Calculator/Views/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Views/Base.lproj/Main.storyboard
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedAllClear:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gvr-bZ-i6m"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -93,6 +96,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedClearEntry:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CPu-jo-ZFj"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -101,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedChangePositiveNegative:" destination="BYZ-38-t0r" eventType="touchUpInside" id="f5E-n0-dRY"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -109,6 +118,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedOperatorPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9gB-KO-Ydc"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -122,6 +134,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="m2k-m5-1dx"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -130,6 +145,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="N8R-iv-bJt"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -138,6 +156,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Jg8-hO-FhX"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -146,6 +167,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedOperatorPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="SGy-qG-uIu"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -159,6 +183,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fDz-oh-gtC"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -167,6 +194,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="24M-3b-YQL"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -175,6 +205,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Lht-55-xB4"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -183,6 +216,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedOperatorPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="d9h-4G-Ye6"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -196,6 +232,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Dpn-6d-mqL"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -204,6 +243,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ear-fh-9tj"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -212,6 +254,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ibB-sK-3cb"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -220,6 +265,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedOperatorPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="txY-7y-WMd"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -233,6 +281,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VUn-t3-2ap"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -241,6 +292,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedNumberPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Zdq-D0-8n8"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -249,6 +303,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedDotPads:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RzL-9w-rlr"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -260,6 +317,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="tappedCalculate:" destination="BYZ-38-t0r" eventType="touchUpInside" id="imO-Bt-kxY"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -303,6 +363,12 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="historyScrollView" destination="BOT-7g-vxv" id="2Wr-GT-dX7"/>
+                        <outlet property="historyStackView" destination="XRe-QE-UJf" id="YDg-kX-HkP"/>
+                        <outlet property="mainOperatorLabel" destination="HPC-iy-qdm" id="fKh-Xb-U01"/>
+                        <outlet property="mainResultLabel" destination="Lwz-OF-XHD" id="UVX-Jg-CXF"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/Views/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Views/Base.lproj/Main.storyboard
@@ -366,8 +366,8 @@
                     <connections>
                         <outlet property="historyScrollView" destination="BOT-7g-vxv" id="2Wr-GT-dX7"/>
                         <outlet property="historyStackView" destination="XRe-QE-UJf" id="YDg-kX-HkP"/>
-                        <outlet property="mainOperatorLabel" destination="HPC-iy-qdm" id="fKh-Xb-U01"/>
-                        <outlet property="mainResultLabel" destination="Lwz-OF-XHD" id="UVX-Jg-CXF"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="9Ba-Lx-6XN"/>
+                        <outlet property="resultLabel" destination="Lwz-OF-XHD" id="f1m-HY-Gaa"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
@uuu1101 
안녕하세요! 태태! Kyo 입니다.
계산기 Step-3 PR 드립니다. 이번 Step은 로직적으로 생각할 부분이 많아서 고생했습니다..
추가로 완성도를 위해서 몇 가지 기능을 추가해보았습니다.
그리고 코드에서 계산 내역을 History라고 표현을 해서 PR에서도 History라고 표현하겠습니다!

1. `=` 버튼을 눌러서 계산을 완료한 후에도 연산자를 누르면 다시 계산을 이어나갈수 있도록했습니다.
    - 계산결과가 나왔을 때는 Operator와 AC, EC 버튼만 누를수 있게 끔 하였습니다.
2. NumberFormatter 적용을 계산 결과 Label 뿐만 아니라 History에도 적용하였습니다. 
3. 0을 따로 누르면 0을 포함한 계산 기능 구현했습니다. 

추가적으로 설명이 필요하신 부분이 있다면 메세지 주시면 바로 달려가겠습니다! ㅎㅎ
이번에도 좋은 피드백 잘 부탁드립니다!!🙇

### 진행 단계 : Step3
## ⭐️ 구현한 기능
- `makeHistoryStackViewLabel()`
    - ScrollView 내부의 StackView에 들어갈 Label들을 생성하는 메서드 입니다.
- `makeHistoryStackView()`
    - makeHistoryStackViewLabel()를 이용하여 만든 Label들을 하나의 StackView로 생성하는 메서드입니다.
- `updateCalculateHistory()`
    - 계산 History를 추가해줄때마다 호출이 되며, 내부에서 호출될때마다 layoutIfNeeded()함수로 바로 레이아웃을 다시 그린 후에, ContentSize의 높이와 frameSize의 높이의 차이 만큼 ScrollView의 y축이 내려가게끔 하는 메서드입니다.
```swift
view.layoutIfNeeded()
let contentOffsetValue: CGFloat = historyScrollView.contentSize.height - historyScrollView.frame.height
historyScrollView.setContentOffset(CGPoint(x: 0, y: contentOffsetValue), animated: true)
```

- `tappedNumberPads()` : (1~9, 0, 00) 버튼 클릭시 동작 메서드
 `tappedOperatorPads()` : (+, -, ÷, ×) 버튼 클릭시 동작 메서드 
`tappedCalculate()` : (=) 버튼 클릭시 동작 메서드
`tappedDotPads()` : (.) 버튼 클릭시 동작 메서드 
`tappedChangePositiveNegative()` : (⁺⁄₋) 버튼 클릭시 동작 메서드
`tappedAllClear()` : (AC) 버튼 클릭시 동작 메서드
`tappedClearEntry()` :  (EC) 버튼 클릭시 동작 메서드

- `tappedNumberPads()`
    - 이 메서드 기능을 차례대로 기재하겠습니다.
        1. 현재 입력값이 DefaultZero이거나 zero일 경우에서 내부에서 "00"입력과 Operator가 `=` 이 아닐 경우에 현재 currentOperand에 값 대입.
        2. 입력값이 이미 있을 경우에는 누르는 값들이 덧붙여져서 추가되는 방식으로 구현
- `tappedOperatorPads()` 
    - 이 메서드 기능을 차례대로 기재하겠습니다.
        1. 가장 첫번째 숫자 입력 전에 Operator 입력 방지.
        2. 계산의 결과 이후에 또 Oerator을 입력한다면 mainLabel값을 Zero로 바꾸고  currentOperant값을 defaultZero로 바꾸어 연속해서 연산할수 있도록 구현.
        3. currentOperand가 defaultZero인 경우에는 연산 안되게 구현.
        4. 계산 History에 추가



## ⭐️ 코드를 작성할 때 고민되었던 점

- 실제로 0을 사용하고 싶은 경우와 Default 0(사용되면 안되는 0)과의 비교
    - 실제로 0을 계산에 추가할 때와 기본 `mainResultLabel`이 0일 때 구분이 필요하였습니다.
    - 실제로 유저가 0을 입력할 때와, 기본 Default 0을 사용할때 둘을 구분하기 위해서 `mainResultLabel`의 값은 모두 `Constant.zero`라는 값을 사용하였고, 그 내부 로직을 사용할 때는  currentOperand의 값을 `Contant.defaultZero(D0)`, `Constant.zero(0)` 라는 각각의 값으로 변경하며 구분하였습니다.
```swift
static let zero = "0"
static let defaultZero = "D0"
```
- ScrollView
    - 일단 ContentSize와 FrameSize의 차이가 발생할 때 ScrollView의 위치를 그 차이만큼 내렸다고 생각됩니다. 그리고 layoutIfNeeded()의 호출위치에 대해서도 헷갈리는 점이 많았습니다. `layoutIfNeeded()`를 언제 호출하느냐에 따라서 동작이 달라지는데 이 부분은 조금 더 고민해봐야할 것 같습니다.
- 전체적인 로직
    - 전체적인 로직을 구현하는 것은 시간이 오래걸리지않았지만 세부적인 로직들을 추가하는 과정에서 고민을 많이 했습니다. 그 결과로 코드상에서 조건문들이 많아지고 조금 복잡하게 되었습니다. 
    - 기본으로 셋팅되어지는 0 (유저가 입력한 0아님)에서는 계산이 안되어야 한다는점이 로직적으로 헷갈리는 부분이었습니다.
    - 이해는 되었으나 유저가 0을 입력한 (9+0+1)과 같은 경우도 고려를 해서 두 개를 구분해나가면서 로직 구현을 하였습니다.
- `=` 버튼을 누르고 계산을 이어나갈수 있는 기능
    - 이 기능을 구현하는게 제일 까다로웠던 것 같습니다. calculate 상태인지도 검증해야했고 현재 입력된 Operand, Operator값도 검증을 해야했습니다. 그리고 다시 계산을 이어나간다면  계산 결과값을 레이블에서 지워야했고, 숫자입력을 방지하고 Operator을 입력했을 때만 이어나가게끔해야 원활하게 구동이 되었습니다.
    - `=` 버튼을 누른 후에 Operator들을 누르면 다시 DefaultZero값이 되고 숫자만 입력이 되게끔 구현을 하였는데, calculate 상태인지를 알기위해 플래그가 필요로 하였고, Constant.calculate를 플래그로 사용하였습니다.


## ⭐️ 해결이 되지 않은 점
- 아직 테스트에서 발생된 오류는 없습니다만..태태가 동작해보실때 오류를 찾는다면 전달 꼭 부탁드립니다.🤣

## ⭐️ 조언을 얻고 싶은 부분 
- 이렇게 동작이 중요한 프로그램 Step을 진행해나갈때는 테스트 방식을 어떻게 진행하는지 궁금합니다.
    - 직접 실행을 해보며 오류 부분을 찾거나 lldb를 이용해서 변수에 대입되는 값들을 찾는 방식으로 테스트를 진행하는지, 혹은 별도의 Unit테스트와 유사한 방법이 또 있는지 궁금합니다.
- 로직이 복잡해짐에 따라서 플래그가 많아지고 조건문이 많아졌습니다. 이럴수록 코드를 읽는 사람은 가독성이 떨어질것이라고 생각되는데 향후 Step진행시에 mark로 주석처리를 해서 기능을 명시해도 괜찮을지 궁금합니다.
- ScrollView를 내리는 방법을 `layoutIfNeeded()`와 `contenSize.height`와 `frame.height`의 차이로 구현을 하였는데 다른 방법이 떠오르지 않는데 태태의 생각이 궁금합니다! 
- 전체적으로 메서드의 이름, 코드컨벤션, 로직부분을 피드백 받고 싶습니다..!
- view.layoutIfNeeded() 를 100%이해하고 사용하지 못했습니다. View를 즉각 업데이트하는 함수라는 것은 알고 있었지만, 이 코드를 삽입하는 위치에 대해서 이해가 잘 되지않습니다.. 크기가 재조정되고 난후에 호출이 되어도 동일하게 스크롤뷰가 확장되어야한다고 생각하는데 직접해본결과 그렇지 않았습니다. 태태의 생각은 어떤가요..?
