### PR TITLE
계산기 [STEP 3] 써니쿠키

### DIFF
--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -11,6 +11,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var modifiableOperatorLabel: UILabel!
     @IBOutlet weak var overallOperationLabelStackView: UIStackView!
     
+    var overallOperation: String = ""
+    var result: Double = 0.0
     var operand: String = "" {
         willSet {
             guard newValue != "" && newValue != "-" else {
@@ -47,7 +49,7 @@ class ViewController: UIViewController {
             modifiableOperatorLabel.text = sender.titleLabel?.text
             return
         }
-        
+        collecOperation()
         MakeOperationStackView()
         operand = ""
         modifiableOperatorLabel.text = sender.titleLabel?.text
@@ -69,6 +71,35 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
         // 이전 라벨 텍스트들까지 지우는 방식으로 변경
+    }
+    
+    @IBAction func touchUpEqualSignButton(_ sender: UIButton) {
+        guard modifiableOperandLabel.text != String(result) else { return }
+        collecOperation()
+        MakeOperationStackView()
+        operand = ""
+        
+        do {
+            var formula = ExpressionParser.parse(from: overallOperation)
+            result = try formula.result()
+            modifiableOperandLabel.text = String(result)
+        } catch CalculatorError.divideByZeroError {
+            modifiableOperandLabel.text = "NaN"
+        } catch {
+            modifiableOperandLabel.text = "Error: Please retry"
+        }
+    }
+    
+    func collecOperation() {
+        guard let`operator` = modifiableOperatorLabel.text,
+              let operand = modifiableOperandLabel.text else {
+            return
+        }
+        if `operator` == " " {
+            overallOperation += ("+" + operand)
+        } else {
+            overallOperation += (`operator` + operand)
+        }
     }
     
     func MakeOperationStackView() {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -11,6 +11,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var modifiableOperatorLabel: UILabel!
     @IBOutlet weak var operationsStackView: UIStackView!    
     @IBOutlet weak var operationsScrollView: UIScrollView!
+    
     var overallOperation: String = ""
     var result: Double = 0.0
     var operand: String = "" {
@@ -19,7 +20,7 @@ class ViewController: UIViewController {
                 modifiableOperandLabel.text = "0"
                 return
             }
-            
+        
             modifiableOperandLabel.text = newValue
         }
     }
@@ -77,6 +78,7 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpEqualSignButton(_ sender: UIButton) {
         guard modifiableOperandLabel.text != String(result) else { return }
+        
         collecOperation()
         MakeOperationStackView()
         operand = ""
@@ -84,7 +86,7 @@ class ViewController: UIViewController {
         do {
             var formula = ExpressionParser.parse(from: overallOperation)
             result = try formula.result()
-            modifiableOperandLabel.text = String(result)
+            modifiableOperandLabel.text = String(changeStyle(result))
         } catch CalculatorError.divideByZeroError {
             modifiableOperandLabel.text = "NaN"
         } catch {
@@ -147,5 +149,16 @@ class ViewController: UIViewController {
         return label
     }
     
+    func changeStyle(_ operationResult: Double) -> String {
+        let numberFormatter = NumberFormatter()
+        
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = 20
+        numberFormatter.roundingMode = .up
+        
+        let result = numberFormatter.string(from: operationResult as NSNumber) ?? "0"
+        
+        return result
+    }
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
     @IBOutlet private weak var scrollView: UIScrollView!
     
     private let numberFormatter = NumberFormatter()
-    private var formula: String = ""
+    private var rawFormula: String = ""
     private var result: Double = 0.0
     private var inputNumber: String = "" {
         willSet {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -70,7 +70,10 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
-        // 이전 라벨 텍스트들까지 지우는 방식으로 변경
+        overallOperationLabelStackView.subviews.forEach { $0.removeFromSuperview() }
+        overallOperation = ""
+        operand = ""
+        modifiableOperatorLabel.text = " "
     }
     
     @IBAction func touchUpEqualSignButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -50,6 +50,13 @@ class ViewController: UIViewController {
             return
         }
         
+        guard inputNumber.split(with: ".").count <= 2,
+              inputNumber != "." else {
+            inputNumber = noValue
+            operandLabel.text = numberFormatter.notANumberSymbol
+            return
+        }
+        
         addFormula()
         MakeOperationStackView()
         scrollTobottom()
@@ -80,12 +87,13 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpResultButton(_ sender: UIButton) {
         guard operandLabel.text != changeStyle(result) else { return }
-        
+
         addFormula()
         MakeOperationStackView()
+        scrollTobottom()
         inputNumber = noValue
         operatorLabel.text = blank
-        
+       
         do {
             var formulaQueue = ExpressionParser.parse(from: formula)
             result = try formulaQueue.result()

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -77,7 +77,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpResultButton(_ sender: UIButton) {
-        guard operandLabel.text != String(result) else { return }
+        guard operandLabel.text != changeStyle(result) else { return }
         
         addFormula()
         MakeOperationStackView()

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -104,22 +104,17 @@ class ViewController: UIViewController {
     }
     
     func MakeOperationStackView() {
-        let operationStackView = makeOperationStackVie()
+        let operationStackView = UIStackView()
+        operationStackView.axis = .horizontal
+        operationStackView.translatesAutoresizingMaskIntoConstraints = false
+        operationStackView.distribution = .fill
+        operationStackView.alignment = .fill
+        operationStackView.spacing = 8
+        
         operationStackView.addArrangedSubview(makeOperatorLabel())
         operationStackView.addArrangedSubview(makeOperandLabel())
-
-        overallOperationLabelStackView.insertArrangedSubview(operationStackView,at: overallOperationLabelStackView.arrangedSubviews.count)
-    }
-    
-    func makeOperationStackVie() -> UIStackView {
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.distribution = .fill
-        stackView.alignment = .fill
-        stackView.spacing = 8
         
-        return stackView
+        overallOperationLabelStackView.insertArrangedSubview(operationStackView,at: overallOperationLabelStackView.arrangedSubviews.count)
     }
     
     func makeOperandLabel() -> UILabel {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -6,15 +6,15 @@
 
 import UIKit
 
-struct Text {
-    fileprivate static let zero: String = "0"
-    fileprivate static let noValue: String = ""
-    fileprivate static let blank: String = " "
-    fileprivate static let negativeSymbol: String = "-"
-    fileprivate static let dot: Character = "."
-}
-
 class ViewController: UIViewController {
+    private enum Text {
+        static let zero: String = "0"
+        static let noValue: String = ""
+        static let blank: String = " "
+        static let negativeSymbol: String = "-"
+        static let dot: Character = "."
+    }
+    
     @IBOutlet private weak var operandLabel: UILabel!
     @IBOutlet private weak var operatorLabel: UILabel!
     @IBOutlet private weak var showingOperationsStackView: UIStackView!

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -7,17 +7,18 @@
 import UIKit
 
 class ViewController: UIViewController {
-    @IBOutlet weak var operandLabel: UILabel!
-    @IBOutlet weak var operatorLabel: UILabel!
+    @IBOutlet weak var modifiableOperandLabel: UILabel!
+    @IBOutlet weak var modifiableOperatorLabel: UILabel!
+    @IBOutlet weak var overallOperationLabelStackView: UIStackView!
     
-    var operandItem: String = "" {
+    var operand: String = "" {
         willSet {
             guard newValue != "" && newValue != "-" else {
-                operandLabel.text = "0"
+                modifiableOperandLabel.text = "0"
                 return
             }
             
-            operandLabel.text = newValue
+            modifiableOperandLabel.text = newValue
         }
     }
     
@@ -31,36 +32,85 @@ class ViewController: UIViewController {
         
         switch number {
         case "0", "00":
-            guard operandItem != "0" else { return }
+            guard operand != "0" else { return }
         default:
-            if operandItem == "0" {
-                operandItem.removeFirst()
+            if operand == "0" {
+                operand.removeFirst()
             }
         }
         
-        operandItem += number
+        operand += number
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
-        operatorLabel.text = sender.titleLabel?.text
+        guard operand != "" else {
+            modifiableOperatorLabel.text = sender.titleLabel?.text
+            return
+        }
+        
+        MakeOperationStackView()
+        operand = ""
+        modifiableOperatorLabel.text = sender.titleLabel?.text
     }
     
     @IBAction func touchUpPositiveNegativeNumberButton() {
-        guard operandItem != "" else { return }
+        guard operand != "" else { return }
         
-        if operandItem.prefix(1) == "-" {
-            operandItem.removeFirst()
+        if operand.prefix(1) == "-" {
+            operand.removeFirst()
         } else {
-            operandItem.insert("-", at: operandItem.startIndex)
+            operand.insert("-", at: operand.startIndex)
         }
     }
     
     @IBAction func touchUpCEButton(_ sender: UIButton) {
-        operandItem = ""
+        operand = ""
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
         // 이전 라벨 텍스트들까지 지우는 방식으로 변경
     }
+    
+    func MakeOperationStackView() {
+        let operationStackView = makeOperationStackVie()
+        operationStackView.addArrangedSubview(makeOperatorLabel())
+        operationStackView.addArrangedSubview(makeOperandLabel())
+
+        overallOperationLabelStackView.insertArrangedSubview(operationStackView,at: overallOperationLabelStackView.arrangedSubviews.count)
+    }
+    
+    func makeOperationStackVie() -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.spacing = 8
+        
+        return stackView
+    }
+    
+    func makeOperandLabel() -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = modifiableOperandLabel.text
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultHigh , for: .horizontal)
+        
+        return label
+    }
+    
+    func makeOperatorLabel() -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = modifiableOperatorLabel.text
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        
+        return label
+    }
+    
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -9,14 +9,14 @@ import UIKit
 class ViewController: UIViewController {
     @IBOutlet weak var operandLabel: UILabel!
     @IBOutlet weak var operatorLabel: UILabel!
-
+    
     var operandItem: String = "" {
         willSet {
-            guard newValue != "" else {
+            guard newValue != "" && newValue != "-" else {
                 operandLabel.text = "0"
                 return
             }
-
+            
             operandLabel.text = newValue
         }
     }
@@ -43,6 +43,25 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         operatorLabel.text = sender.titleLabel?.text
+    }
+    
+    @IBAction func touchUpPositiveNegativeNumberButton() {
+        guard operandItem != "" else { return }
+        
+        if operandItem.prefix(1) == "-" {
+            operandItem.removeFirst()
+        } else {
+            operandItem.insert("-", at: operandItem.startIndex)
+        }
+    }
+    
+    @IBAction func touchUpCEButton(_ sender: UIButton) {
+        guard operandItem != "" else { return }
+        operandItem.removeLast()
+    }
+    
+    @IBAction func touchUpACButton(_ sender: UIButton) {
+        operandItem = ""
     }
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -7,10 +7,42 @@
 import UIKit
 
 class ViewController: UIViewController {
+    @IBOutlet weak var operandLabel: UILabel!
+    @IBOutlet weak var operatorLabel: UILabel!
 
+    var operandItem: String = "" {
+        willSet {
+            guard newValue != "" else {
+                operandLabel.text = "0"
+                return
+            }
+
+            operandLabel.text = newValue
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+    }
+    
+    @IBAction func touchUpNumberButton(_ sender: UIButton) {
+        guard let number = sender.titleLabel?.text else { return }
+        
+        switch number {
+        case "0", "00":
+            guard operandItem != "0" else { return }
+        default:
+            if operandItem == "0" {
+                operandItem.removeFirst()
+            }
+            
+            operandItem += number
+        }
+    }
+    
+    @IBAction func touchUpOperatorButton(_ sender: UIButton) {
+        operatorLabel.text = sender.titleLabel?.text
     }
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -6,6 +6,14 @@
 
 import UIKit
 
+struct Text {
+    fileprivate static let zero: String = "0"
+    fileprivate static let noValue: String = ""
+    fileprivate static let blank: String = " "
+    fileprivate static let negativeSymbol: String = "-"
+    fileprivate static let dot: Character = "."
+}
+
 class ViewController: UIViewController {
     @IBOutlet private weak var operandLabel: UILabel!
     @IBOutlet private weak var operatorLabel: UILabel!
@@ -13,15 +21,13 @@ class ViewController: UIViewController {
     @IBOutlet private weak var scrollView: UIScrollView!
     
     private let numberFormatter = NumberFormatter()
-    private let zero = "0"
-    private let noValue = ""
-    private let blank = " "
     private var formula: String = ""
     private var result: Double = 0.0
     private var inputNumber: String = "" {
         willSet {
-            guard newValue != noValue, newValue != "-" else {
-                operandLabel.text = zero
+            guard newValue != Text.noValue,
+                  newValue != Text.negativeSymbol else {
+                operandLabel.text = Text.zero
                 return
             }
             
@@ -34,9 +40,9 @@ class ViewController: UIViewController {
         
         switch number {
         case "0", "00":
-            guard inputNumber != zero else { return }
+            guard inputNumber != Text.zero else { return }
         default:
-            if inputNumber == zero {
+            if inputNumber == Text.zero {
                 inputNumber.removeFirst()
             }
         }
@@ -45,44 +51,44 @@ class ViewController: UIViewController {
     }
     
     @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
-        guard inputNumber != noValue else {
+        guard inputNumber != Text.noValue else {
             operatorLabel.text = sender.titleLabel?.text
             return
         }
         
-        guard inputNumber.split(with: ".").count <= 2,
-              inputNumber != "." else {
-            inputNumber = noValue
-            operandLabel.text = numberFormatter.notANumberSymbol
-            return
-        }
+        guard inputNumber.split(with: Text.dot).count <= 2,
+              inputNumber != String(Text.dot) else {
+                  inputNumber = Text.noValue
+                  operandLabel.text = numberFormatter.notANumberSymbol
+                  return
+              }
         
         addFormula()
         MakeOperationStackView()
         scrollTobottom()
-        inputNumber = noValue
+        inputNumber = Text.noValue
         operatorLabel.text = sender.titleLabel?.text
     }
     
     @IBAction private func touchUpConvertingPositiveNegativeButton() {
-        guard inputNumber != zero else { return }
+        guard inputNumber != Text.zero else { return }
     
-        if inputNumber.prefix(1) == "-" {
+        if inputNumber.prefix(1) == Text.negativeSymbol {
             inputNumber.removeFirst()
         } else {
-            inputNumber.insert("-", at: inputNumber.startIndex)
+            inputNumber.insert(contentsOf: Text.negativeSymbol, at: inputNumber.startIndex)
         }
     }
     
     @IBAction private func touchUpCEButton(_ sender: UIButton) {
-        inputNumber = noValue
+        inputNumber = Text.noValue
     }
     
     @IBAction private func touchUpACButton(_ sender: UIButton) {
         showingOperationsStackView.subviews.forEach { $0.removeFromSuperview() }
-        formula = noValue
-        inputNumber = noValue
-        operatorLabel.text = blank
+        formula = Text.noValue
+        inputNumber = Text.noValue
+        operatorLabel.text = Text.blank
     }
     
     @IBAction private func touchUpResultButton(_ sender: UIButton) {
@@ -91,8 +97,8 @@ class ViewController: UIViewController {
         addFormula()
         MakeOperationStackView()
         scrollTobottom()
-        inputNumber = noValue
-        operatorLabel.text = blank
+        inputNumber = Text.noValue
+        operatorLabel.text = Text.blank
        
         do {
             var formulaQueue = ExpressionParser.parse(from: formula)
@@ -111,8 +117,8 @@ class ViewController: UIViewController {
             return
         }
         
-        if `operator` == blank {
-            formula += ("+" + operand)
+        if `operator` == Text.blank {
+            formula += (String(Operator.add.rawValue) + operand)
         } else {
             formula += (`operator` + operand)
         }
@@ -166,7 +172,7 @@ class ViewController: UIViewController {
         numberFormatter.maximumSignificantDigits = 20
         numberFormatter.roundingMode = .up
         
-        let result = numberFormatter.string(from: operationResult as NSNumber) ?? zero
+        let result = numberFormatter.string(from: operationResult as NSNumber) ?? Text.zero
         
         return result
     }

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController {
     private var result: Double = 0.0
     private var inputNumber: String = "" {
         willSet {
-            guard newValue != noValue else {
+            guard newValue != noValue, newValue != "-" else {
                 operandLabel.text = zero
                 return
             }
@@ -58,6 +58,8 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpConvertingPositiveNegativeButton() {
+        guard inputNumber != zero else { return }
+    
         if inputNumber.prefix(1) == "-" {
             inputNumber.removeFirst()
         } else {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -7,10 +7,10 @@
 import UIKit
 
 class ViewController: UIViewController {
-    @IBOutlet weak var operandLabel: UILabel!
-    @IBOutlet weak var operatorLabel: UILabel!
-    @IBOutlet weak var showingOperationsStackView: UIStackView!    
-    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet private weak var operandLabel: UILabel!
+    @IBOutlet private weak var operatorLabel: UILabel!
+    @IBOutlet private weak var showingOperationsStackView: UIStackView!
+    @IBOutlet private weak var scrollView: UIScrollView!
     
     private let numberFormatter = NumberFormatter()
     private let zero = "0"
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpNumberButton(_ sender: UIButton) {
+    @IBAction private func touchUpNumberButton(_ sender: UIButton) {
         guard let number = sender.titleLabel?.text else { return }
         
         switch number {
@@ -44,7 +44,7 @@ class ViewController: UIViewController {
         inputNumber += number
     }
     
-    @IBAction func touchUpOperatorButton(_ sender: UIButton) {
+    @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
         guard inputNumber != noValue else {
             operatorLabel.text = sender.titleLabel?.text
             return
@@ -64,7 +64,7 @@ class ViewController: UIViewController {
         operatorLabel.text = sender.titleLabel?.text
     }
     
-    @IBAction func touchUpConvertingPositiveNegativeButton() {
+    @IBAction private func touchUpConvertingPositiveNegativeButton() {
         guard inputNumber != zero else { return }
     
         if inputNumber.prefix(1) == "-" {
@@ -74,18 +74,18 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpCEButton(_ sender: UIButton) {
+    @IBAction private func touchUpCEButton(_ sender: UIButton) {
         inputNumber = noValue
     }
     
-    @IBAction func touchUpACButton(_ sender: UIButton) {
+    @IBAction private func touchUpACButton(_ sender: UIButton) {
         showingOperationsStackView.subviews.forEach { $0.removeFromSuperview() }
         formula = noValue
         inputNumber = noValue
         operatorLabel.text = blank
     }
     
-    @IBAction func touchUpResultButton(_ sender: UIButton) {
+    @IBAction private func touchUpResultButton(_ sender: UIButton) {
         guard operandLabel.text != changeStyle(result) else { return }
 
         addFormula()

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -115,8 +115,6 @@ class ViewController: UIViewController {
         operationStackView.alignment = .fill
         operationStackView.spacing = 8
         
-        let operatorLabel = makeOperatorLabel()
-        
         operationStackView.addArrangedSubview(operatorLabel)
         operationStackView.addArrangedSubview(makeOperandLabel())
         

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -86,7 +86,7 @@ class ViewController: UIViewController {
     
     @IBAction private func touchUpACButton(_ sender: UIButton) {
         showingOperationsStackView.subviews.forEach { $0.removeFromSuperview() }
-        formula = Text.noValue
+        rawFormula = Text.noValue
         inputNumber = Text.noValue
         operatorLabel.text = Text.blank
     }
@@ -101,7 +101,7 @@ class ViewController: UIViewController {
         operatorLabel.text = Text.blank
        
         do {
-            var formulaQueue = ExpressionParser.parse(from: formula)
+            var formulaQueue = ExpressionParser.parse(from: rawFormula)
             result = try formulaQueue.result()
             operandLabel.text = String(result.changeToDemical)
         } catch CalculatorError.divideByZeroError {
@@ -118,9 +118,9 @@ class ViewController: UIViewController {
         }
         
         if `operator` == Text.blank {
-            formula += (String(Operator.add.rawValue) + operand)
+            rawFormula += (String(Operator.add.rawValue) + operand)
         } else {
-            formula += (`operator` + operand)
+            rawFormula += (`operator` + operand)
         }
     }
     

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
     var result: Double = 0.0
     var operand: String = "" {
         willSet {
-            guard newValue != "" && newValue != "-" else {
+            guard newValue != "" else {
                 modifiableOperandLabel.text = "0"
                 return
             }
@@ -56,8 +56,6 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpPositiveNegativeNumberButton() {
-        guard operand != "" else { return }
-        
         if operand.prefix(1) == "-" {
             operand.removeFirst()
         } else {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -92,7 +92,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction private func touchUpResultButton(_ sender: UIButton) {
-        guard operandLabel.text != changeStyle(result) else { return }
+        guard operandLabel.text != result.changeToDemical else { return }
 
         addFormula()
         MakeOperationStackView()
@@ -103,7 +103,7 @@ class ViewController: UIViewController {
         do {
             var formulaQueue = ExpressionParser.parse(from: formula)
             result = try formulaQueue.result()
-            operandLabel.text = String(changeStyle(result))
+            operandLabel.text = String(result.changeToDemical)
         } catch CalculatorError.divideByZeroError {
             operandLabel.text = numberFormatter.notANumberSymbol
         } catch {
@@ -165,15 +165,5 @@ class ViewController: UIViewController {
         scrollView.layoutIfNeeded()
         scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.height),
                                     animated: false)
-    }
-    
-    private func changeStyle(_ operationResult: Double) -> String {
-        numberFormatter.numberStyle = .decimal
-        numberFormatter.maximumSignificantDigits = 20
-        numberFormatter.roundingMode = .up
-        
-        let result = numberFormatter.string(from: operationResult as NSNumber) ?? Text.zero
-        
-        return result
     }
 }

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -9,8 +9,8 @@ import UIKit
 class ViewController: UIViewController {
     @IBOutlet weak var modifiableOperandLabel: UILabel!
     @IBOutlet weak var modifiableOperatorLabel: UILabel!
-    @IBOutlet weak var overallOperationLabelStackView: UIStackView!
-    
+    @IBOutlet weak var operationsStackView: UIStackView!    
+    @IBOutlet weak var operationsScrollView: UIScrollView!
     var overallOperation: String = ""
     var result: Double = 0.0
     var operand: String = "" {
@@ -51,6 +51,7 @@ class ViewController: UIViewController {
         }
         collecOperation()
         MakeOperationStackView()
+        scrollTobottom()
         operand = ""
         modifiableOperatorLabel.text = sender.titleLabel?.text
     }
@@ -68,7 +69,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
-        overallOperationLabelStackView.subviews.forEach { $0.removeFromSuperview() }
+        operationsStackView.subviews.forEach { $0.removeFromSuperview() }
         overallOperation = ""
         operand = ""
         modifiableOperatorLabel.text = " "
@@ -111,10 +112,17 @@ class ViewController: UIViewController {
         operationStackView.alignment = .fill
         operationStackView.spacing = 8
         
-        operationStackView.addArrangedSubview(makeOperatorLabel())
+        let operatorLabel = makeOperatorLabel()
+        
+        operationStackView.addArrangedSubview(operatorLabel)
         operationStackView.addArrangedSubview(makeOperandLabel())
         
-        overallOperationLabelStackView.insertArrangedSubview(operationStackView,at: overallOperationLabelStackView.arrangedSubviews.count)
+        operationsStackView.insertArrangedSubview(operationStackView,at: operationsStackView.arrangedSubviews.count)
+    }
+    
+    func scrollTobottom() {
+        operationsScrollView.layoutIfNeeded()
+        operationsScrollView.setContentOffset(CGPoint(x: 0, y: operationsScrollView.contentSize.height - operationsScrollView.bounds.height), animated: false)
     }
     
     func makeOperandLabel() -> UILabel {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -115,11 +115,21 @@ class ViewController: UIViewController {
         operationStackView.alignment = .fill
         operationStackView.spacing = 8
         
-        operationStackView.addArrangedSubview(operatorLabel)
+        operationStackView.addArrangedSubview(makeOperatorLabel())
         operationStackView.addArrangedSubview(makeOperandLabel())
         
         showingOperationsStackView.insertArrangedSubview(operationStackView,
                                                          at: showingOperationsStackView.arrangedSubviews.count)
+    }
+    
+    private func makeOperatorLabel() -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = operatorLabel.text
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        
+        return label
     }
     
     private func makeOperandLabel() -> UILabel {
@@ -130,16 +140,6 @@ class ViewController: UIViewController {
         label.font = UIFont.preferredFont(forTextStyle: .title3)
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         label.setContentCompressionResistancePriority(.defaultHigh , for: .horizontal)
-        
-        return label
-    }
-    
-    private func makeOperatorLabel() -> UILabel {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = operatorLabel.text
-        label.textColor = .white
-        label.font = UIFont.preferredFont(forTextStyle: .title3)
         
         return label
     }

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -36,9 +36,9 @@ class ViewController: UIViewController {
             if operandItem == "0" {
                 operandItem.removeFirst()
             }
-            
-            operandItem += number
         }
+        
+        operandItem += number
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
@@ -56,12 +56,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpCEButton(_ sender: UIButton) {
-        guard operandItem != "" else { return }
-        operandItem.removeLast()
+        operandItem = ""
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
-        operandItem = ""
+        // 이전 라벨 텍스트들까지 지우는 방식으로 변경
     }
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -84,6 +84,7 @@ class ViewController: UIViewController {
         addFormula()
         MakeOperationStackView()
         inputNumber = noValue
+        operatorLabel.text = blank
         
         do {
             var formulaQueue = ExpressionParser.parse(from: formula)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum ExpressionParser {
-    static func parse(from input: String) throws -> Formula {
+    static func parse(from input: String) -> Formula {
         var formula = Formula()
         let operands = componentsByOperators(from: input)
         let operators = input.compactMap { Operator.init(rawValue: $0) }

--- a/Calculator/Calculator/Model/Extension/Double+Extension.swift
+++ b/Calculator/Calculator/Model/Extension/Double+Extension.swift
@@ -5,6 +5,19 @@
 //  Created by 써니쿠키 on 2022/09/22.
 //
 
+import Foundation
+
 extension Double: CalculateItem {
+    var changeToDemical: String {
+        let numberFormatter = NumberFormatter()
+        let twenty: Int = 20
+        
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = twenty
+        numberFormatter.roundingMode = .up
     
+        let result = numberFormatter.string(from: self as NSNumber) ?? "0"
+        
+        return result
+    }
 }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -7,9 +7,9 @@
 
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
-    case subtract = "-"
-    case divide = "/"
-    case multiply = "*"
+    case subtract = "−"
+    case divide = "÷"
+    case multiply = "×"
     
     func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -18,22 +18,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="220.5" width="382" height="45"/>
+                                <rect key="frame" x="16" y="161.5" width="382" height="104"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="104"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Nd6-Zr-Y6e">
-                                                <rect key="frame" x="298" y="0.0" width="84" height="20.5"/>
+                                                <rect key="frame" x="256" y="0.0" width="126" height="50"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
-                                                        <rect key="frame" x="16" y="0.0" width="68" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
+                                                        <rect key="frame" x="58" y="0.0" width="68" height="50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -41,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="bottomRight" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="iC9-OM-dL7">
-                                                <rect key="frame" x="288" y="24.5" width="94" height="20.5"/>
+                                                <rect key="frame" x="246" y="54" width="136" height="50"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12345678" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
-                                                        <rect key="frame" x="16" y="0.0" width="78" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
+                                                        <rect key="frame" x="58" y="0.0" width="78" height="50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -108,7 +108,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchUpPositiveNegativeNumberButton" destination="BYZ-38-t0r" eventType="touchUpInside" id="4aR-mz-J8N"/>
+                                                    <action selector="touchUpConvertingPositiveNegativeButton" destination="BYZ-38-t0r" eventType="touchUpInside" id="4aR-mz-J8N"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
@@ -318,7 +318,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchUpEqualSignButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wQc-0x-kq9"/>
+                                                    <action selector="touchUpResultButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bO4-Wc-6jd"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -364,10 +364,10 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="modifiableOperandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
-                        <outlet property="modifiableOperatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
-                        <outlet property="operationsScrollView" destination="BOT-7g-vxv" id="Lp0-rO-aXO"/>
-                        <outlet property="operationsStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
+                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
+                        <outlet property="scrollView" destination="BOT-7g-vxv" id="Lp0-rO-aXO"/>
+                        <outlet property="showingOperationsStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -17,40 +17,40 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="181.5" width="382" height="104"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                                <rect key="frame" x="16" y="220.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="104"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Nd6-Zr-Y6e">
-                                                <rect key="frame" x="274" y="0.0" width="108" height="50"/>
+                                                <rect key="frame" x="298" y="0.0" width="84" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
-                                                        <rect key="frame" x="58" y="0.0" width="50" height="50"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
+                                                        <rect key="frame" x="16" y="0.0" width="68" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="iC9-OM-dL7">
-                                                <rect key="frame" x="225" y="54" width="157" height="50"/>
+                                            <stackView opaque="NO" contentMode="bottomRight" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="iC9-OM-dL7">
+                                                <rect key="frame" x="288" y="24.5" width="94" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
-                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
-                                                        <rect key="frame" x="58" y="0.0" width="99" height="50"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12345678" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
+                                                        <rect key="frame" x="16" y="0.0" width="78" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -63,14 +63,14 @@
                                 <constraints>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="BOT-7g-vxv" secondAttribute="height" priority="100" id="82c-Ko-nh3"/>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="width" secondItem="BOT-7g-vxv" secondAttribute="width" id="9hO-gT-uzB"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="gA2-7M-FxF" secondAttribute="height" priority="1" id="PfX-qG-S4s"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="leading" secondItem="K6N-nC-kaV" secondAttribute="leading" id="WTo-5t-Xde"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="trailing" secondItem="K6N-nC-kaV" secondAttribute="trailing" id="bYc-Yd-kw9"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="bottom" secondItem="K6N-nC-kaV" secondAttribute="bottom" id="dlN-3y-jhh"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="top" secondItem="K6N-nC-kaV" secondAttribute="top" id="hlo-zV-yFo"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="BOT-7g-vxv" secondAttribute="height" priority="1" id="PfX-qG-S4s"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="leading" secondItem="BOT-7g-vxv" secondAttribute="leading" id="WTo-5t-Xde"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="trailing" secondItem="BOT-7g-vxv" secondAttribute="trailing" id="bYc-Yd-kw9"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="bottom" secondItem="BOT-7g-vxv" secondAttribute="bottom" id="dlN-3y-jhh"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="top" secondItem="BOT-7g-vxv" secondAttribute="top" id="hlo-zV-yFo"/>
                                 </constraints>
-                                <viewLayoutGuide key="contentLayoutGuide" id="K6N-nC-kaV"/>
-                                <viewLayoutGuide key="frameLayoutGuide" id="gA2-7M-FxF"/>
+                                <viewLayoutGuide key="contentLayoutGuide" id="ChG-0T-tYC"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="dfP-9g-zEG"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YKH-82-hZC">
                                 <rect key="frame" x="16" y="362.5" width="382" height="479.5"/>
@@ -358,7 +358,7 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="BOT-7g-vxv" secondAttribute="trailing" constant="16" id="jGA-4U-1bz"/>
                             <constraint firstItem="YKH-82-hZC" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="jKU-BN-eas"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="YKH-82-hZC" secondAttribute="bottom" constant="20" id="lPP-CN-Q7m"/>
-                            <constraint firstItem="DC3-Ia-6L7" firstAttribute="top" secondItem="BOT-7g-vxv" secondAttribute="bottom" constant="20" id="mfk-MI-h75"/>
+                            <constraint firstItem="DC3-Ia-6L7" firstAttribute="top" secondItem="BOT-7g-vxv" secondAttribute="bottom" constant="40" id="mfk-MI-h75"/>
                             <constraint firstItem="BOT-7g-vxv" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="qyL-Qq-yAo"/>
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
@@ -366,7 +366,8 @@
                     <connections>
                         <outlet property="modifiableOperandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
                         <outlet property="modifiableOperatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
-                        <outlet property="overallOperationLabelStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
+                        <outlet property="operationsScrollView" destination="BOT-7g-vxv" id="Lp0-rO-aXO"/>
+                        <outlet property="operationsStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -361,8 +361,9 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
-                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
+                        <outlet property="modifiableOperandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
+                        <outlet property="modifiableOperatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
+                        <outlet property="overallOperationLabelStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -17,11 +17,47 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="227.5" width="382" height="45"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                                <rect key="frame" x="16" y="181.5" width="382" height="104"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="104"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Nd6-Zr-Y6e">
+                                                <rect key="frame" x="274" y="0.0" width="108" height="50"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
+                                                        <rect key="frame" x="58" y="0.0" width="50" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="iC9-OM-dL7">
+                                                <rect key="frame" x="225" y="54" width="157" height="50"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
+                                                        <rect key="frame" x="58" y="0.0" width="99" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
                                     </stackView>
                                 </subviews>
                                 <constraints>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -17,47 +17,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
                                 <rect key="frame" x="16" y="227.5" width="382" height="45"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -317,25 +281,28 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpEqualSignButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wQc-0x-kq9"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="292.5" width="382" height="50"/>
+                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text=" " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
+                                                <rect key="frame" x="0.0" y="0.0" width="7" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="58" y="0.0" width="324" height="50"/>
+                                                <rect key="frame" x="15" y="0.0" width="367" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,22 +18,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="227.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -40,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -108,6 +109,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QwN-tc-RvH"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -121,6 +125,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bIj-Xl-eRR"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -129,6 +136,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MrC-2l-gwz"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -137,6 +147,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="U1l-6v-ssL"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -145,6 +158,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fhO-5F-PYX"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -158,6 +174,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hUg-8p-itl"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -166,6 +185,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="baq-1t-qt3"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -174,6 +196,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zm5-jZ-a6j"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -182,6 +207,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AZP-5e-yWb"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -195,6 +223,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QFs-A4-yjB"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -203,6 +234,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mwc-dO-6Lc"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -211,6 +245,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2vz-u0-DSr"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -219,6 +256,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="y9S-46-2Ga"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -232,6 +272,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MYq-Ty-a5J"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -240,6 +283,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="GOX-AD-Zzx"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -248,6 +294,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pEU-hp-lEj"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -265,19 +314,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="292.5" width="382" height="50"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
+                                                <rect key="frame" x="58" y="0.0" width="324" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -302,6 +351,10 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpACButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8kI-ZX-y9m"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -93,6 +96,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCEButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MeW-hc-7io"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -101,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpPositiveNegativeNumberButton" destination="BYZ-38-t0r" eventType="touchUpInside" id="4aR-mz-J8N"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# README(4) 계산기
-
 # 계산기
 
 ## 1. ✏️ 프로젝트 소개
@@ -449,19 +447,20 @@ input.components(separatedBy: operators)
 <details>
  <summary> [해결과정 details] </summary>
         
-- 5-1 오토레이아웃의 문제인가?
+- 5-1 오토레이아웃의 문제인가? </br>
     처음엔 **오토레이아웃의 문제**인가 싶어 오토레이아웃도 뜯어살펴보았지만 문제를 찾지 못했습니다.
 
-- 5-2. 내려가지 않는 한 줄만큼 setContentOffsetd의 y축 값으로 추가
+- 5-2. 내려가지 않는 한 줄만큼 setContentOffsetd의 y축 값으로 추가 </br>
     setContentOffsetd의 y축 값을 더 내려가도록 해주면 될까 싶어서 **offSet변화량을 콘솔로 확인해서 변화량인 24큼 더 내리도록 해보았습니다** ( y = contentSize의 높이 - bounds의 높이 + **24** ) 
 
-    이렇게 할 때는 `컨텐츠높이`가 `bounds높이`보다 커질 때를 기준으로 첫번째 입력(아래GIF에서 +7때)에서 마지막줄이 안 보이고, 두번째 입력시(+8떄) 이전에 찍은 +7값과 같이 두개값이 동시에 나온 후에 세번째부터는 정상작동하는 문제가 있습니다.
-   <img width = 200, src ="https://i.imgur.com/PNj4xWk.gif">
+    이렇게 할 때는 `컨텐츠높이`가 `bounds높이`보다 커질 때를 기준으로 첫번째 입력(아래GIF에서 +7때)에서 마지막줄이 안 보이고, 두번째 입력시(+8떄) 이전에 찍은 +7값과 같이 두개값이 동시에 나온 후에 세번째부터는 정상작동하는 문제가 있습니다. </br>
+   
+    <img width = 200, src ="https://i.imgur.com/PNj4xWk.gif">
     
-- 5-3. 시간적인 duration 관련 문제인가?
+- 5-3. 시간적인 duration 관련 문제인가? </br>
     업데이트 후 스클롤링 함수를 호출하는 시간 사이에 delay가 생길까 싶어 **notification Center**사용으로 한박자 늦게 scroll을 내리는 함수를 호출해보기도 했지만 무용지물이었습니다..
     
-- 5-4. ✅ 드로잉 사이클 (drawing cycle)을 공부
+- 5-4. ✅ 드로잉 사이클 (drawing cycle)을 공부 </br>
     컨텐츠가 변하여도 다음 드로잉사이클까지 **대기 후**에 다시 view가 업데이트 되는것을 알았습니다.
     
     setNeedsDisplay 메서드를 사용하면 시스템에게 draw 메서드를 호출하도록 요청해서 다시 View를 그려주게되는데 이 과정이 바로 즉각 되는것이 아니라 다음 drawing cycle까지 기다렸다가 진행됩니다. 제 화면에서 생각해보면 내부에서 스크롤하는 함수가 호출되어 스크롤을 제일 아래로 내렸지만, 하단에 스택뷰가 추가된 완성된 레이아웃 재배치는 그 후에 이뤄지는 사이클이었기 때문에 마지막 줄이 안보이는 문제가 생겼던 것입니다.
@@ -472,8 +471,8 @@ input.components(separatedBy: operators)
     아래의 표는 스크롤뷰에 추가된 스택뷰의 갯수에 따른 컨텐츠높이, bound높이, content offset의 y축값 을 정리한 것입니다.
     표에서 확인이 가능한 것은 layoutIfNeeded를 호출하지 않고 계산기를 찍을때와 호출했을 때의 값이 한스텝씩 차이가 난다는 것입니다. 
 
-    <img width = 800, src ="https://i.imgur.com/oDgorTU.png">
-    (위 표에서 offSet을 빨간글씨는 스크롤 제일 아랫줄이 보이지 않을때를 표시한 것입니다..)
+    <img width = 800, src ="https://i.imgur.com/oDgorTU.png"> </br>
+    (위 표에서 offSet을 빨간글씨는 스크롤 제일 아랫줄이 보이지 않을때를 표시한 것입니다.)
 
     이 스텝의 차이는 위에서 설명했듯이 순서의 차이입니다. `스크롤내리기 -> 뷰 업데이트` 와 `뷰 업데이트 -> 스크롤내리기` 의 차이입니다.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+# README(4) 계산기
+
 # 계산기
+
 ## 1. ✏️ 프로젝트 소개
 계산기입니다.
 -  사칙연산 (+, -, ÷, X)이 가능합니다.
@@ -17,16 +20,40 @@
 
 ---
 
-## 3. 🔍 프로젝트 구성
+## 3. 🔍 프로젝트 구성과 실행예시
 - Class Diagram
-<img width = 1000, src = "https://i.imgur.com/6fpgIUM.png">
+<img width = 1000, src = "https://i.imgur.com/lnjKDxO.png">
+
+- 실행예시
+
+|정상작동 예시(1)|정상작동 예시(2)
+|------------|-----------|
+|  <img width = 250, src = "https://i.imgur.com/fS8rX2P.gif">  | <img width = 250, src = "https://i.imgur.com/KZMPWjJ.gif"> |
+
+|`CE`버튼 작동예시 | `AC`버튼 작동예시 |
+|-----------|-----------|
+|<img width = 250, src = "https://i.imgur.com/9eLFZ8e.gif">|<img width = 250, src = "https://i.imgur.com/cSKQSWe.gif">|
+
+|`+/-` 버튼 작동 예시 | 제일 하단으로 Auto Scrolling 예시 |
+|-----------|-----------|
+|<img width = 250, src = "https://i.imgur.com/kbu4ugR.gif">|<img width = 250, src = "https://i.imgur.com/eFms2BQ.gif">|
+
+| 나누기 0 시 오류처리 | 소수점 한개 이상 오류처리 |
+|-----------|-----------|
+|<img width = 250, src = "https://i.imgur.com/yRYaKTn.gif">|<img width = 250, src = "https://i.imgur.com/eSxvqkr.gif">|
+
+---
 
 ## 4. ⚒️ 구현 내용
+
+### [ 🚩 Model ]
+
 **1️⃣ 자료구조를 구현하기위한 Queue, LinkedList, Node**
 
 ☑️ CalculatorItemQueue 구조체  </br>
 ☑️ LinkedList 구조체  </br>
 ☑️ Node 클래스  </br>
+
 <details>
     <summary> [details - 타입별 프로퍼티와 메서드 설명] </summary>
 
@@ -37,7 +64,6 @@ LinkedList 이용한 FIFO형태의 Queue 자료구조입니다
 - `dequeue()`: Queue의 맨 앞의 데이터 (제일 먼저 추가되었던 데이터)를 반환하고 삭제합니다.
 - `clear()`: Queue의 데이터를 모두 삭제합니다.
 - `isEmpty()`: Queue가 비어있는지 Bool타입으로 반환합니다.
-
 ☑️ LinkedList 구조체
 Node를 이용한 단방향 연결리스트 자료구조입니다.
 - `head`: 연결리스의 첫번째 데이터입니다. 
@@ -46,7 +72,6 @@ Node를 이용한 단방향 연결리스트 자료구조입니다.
 - `removeLast()`: 리스트의 마지막 데이터 (제일 늦게 추가되었던 데이터)를 반환하고 삭제합니다.
 - `removeFirst()`: 리스트의 맨 앞의 데이터 (제일 먼저 추가되었던 데이터)를 반환하고 삭제합니다.
 - `isEmpty()`: 리스트가 비어있는지 Bool타입으로 반환합니다.
-
 ☑️ Node 클래스
 - `data`: 필요한 데이터를 저장합니다, 외부에서 읽기만 가능합니다
 - `next`: 메모리상에서 또 다른 Node의 주소를 참조합니다.
@@ -109,6 +134,97 @@ Node를 이용한 단방향 연결리스트 자료구조입니다.
 **4️⃣ unit test** </br>
 <img width=550, src = "https://i.imgur.com/gIbl5Qm.png">
 
+
+### [ 🚩 ViewController ]
+**1️⃣ property**
+
+☑️ formula, result, inputNumber </br>
+ 
+ <details>
+<summary> [details - 프로퍼티별 설명] </summary>
+    
+- `rawFormula`: `=` 버튼을 누를 시 계산해 줄 공식을 담습니다.
+- `result`: 계산 결과를 담습니다.
+- `inputNumber`: 실시간 input을 보여줍니다. willSet을 이용해 라벨에 표시해줍니다. 값이 비거나, 음수부호일 시에는 0을 표시합니다.(음수부호는 0으로 보여도 뒤에 숫자를 누를 시 음수로 표시됩니다)
+ </details>
+ 
+   </br>
+ 
+**2️⃣ IBAction 메서드**
+
+☑️ touchUpNumberButton </br>
+☑️ touchUpOperatorButton </br>
+☑️ touchUpConvertingPositiveNegativeButton </br>
+☑️ touchUpCEButton  </br>
+☑️ touchUpACButton </br>
+☑️ touchUpResultButton </br>
+
+  <details>
+<summary> [details - 메서드 별 기능 설명] </summary>
+    
+ - `touchUpNumberButton`: 
+     - 숫자패드에 반응해 라벨에 띄우기 위해 inputNumber에 담습니다. 
+     - `0`버튼과 `00`버튼은 현재값이 0일때 눌러도 여러번 입력되지 않도록 guard문 처리했습니다.
+     - `1~9` 버튼은 현재값이 0일때 0을 지우고 숫자가 입력되도록 합니다.
+ - `touchUpOperatorButton`:
+     - 연산자를 처음 누른다면 거라면 연산자라벨에 누른 연산자를 보여줍니다.
+     - 기존에 숫자를 눌렀었다면 이전에 누른 공식을 stackView에 label로 올려주고 
+        실시간 input을 보여주는 label은 초기화한 후 연산자라벨에 눌러진 연산자를 보여줍니다.
+     - 더불어 나중에 계산을 위해 formula프로퍼티에도 이전에 누른 공식을 추가합니다.
+ - `touchUpConvertingPositiveNegativeButton`:
+     - 첫번째 자릿수가 마이너스인지 구분하여 음수🔁양수 convert해줍니다.
+     - 0일 때는 양수, 음수 convert 되지 않습니다.
+ - `touchUpCEButton`:
+     - input내용을 지워줍니다.
+ - `touchUpACButton`:
+     - input내용과 기존 공식들 모두 지워줍니다
+ - `touchUpResultButton`:
+     - 기존에 `=`을 누른 후 다시 누르는 경우 작동하지 않도록 guard문 처리했습니다.
+     - 마지막 input들을 stackView에 label로 올려주고 input을 비워줍니다.
+     - 오류처리를 위해 do-catch문으로 결과를 계산해줍니다
+     - `divideByZeroError` 시 Nan처리를 위해 numberFormatter의 notANumberSymbol을 사용합니다.
+ 
+</details>
+
+</br>
+    
+**3️⃣ 메서드**
+
+☑️ addFormula </br>
+☑️ MakeOperationStackView </br>
+☑️ makeOperatorLabel </br>
+☑️ scrollTobottom </br>
+☑️ changeStyle </br>
+
+<details>
+<summary> [details - 메서드 별 기능 설명] </summary>
+
+- `addFormula`
+     - 계산을 위해 formula 프로퍼티에 값을 담습니다.
+     - (3-2) 를 (+3-2)로 담기위해 if문으로 라벨이 비어있을 때는 +를 담아줍니다.
+- `MakeOperationStackView`:
+    - UIStackView를 생성하고 특성을 정해줍니다.
+    - 연산자 라벨과 피연산 라벨을 horizontal axis로 담습니다.
+    - `showingOperationsStackView`의 맨 뒤에 추가해줍니다.
+- `makeOperatorLabel`, `makeOperandLabel`
+    - UILabel을 생성하고 특성을 정해줍니다.
+    - 각각 현재 입력된 연산자, 피연산자를 text로 갖습니다.
+- `scrollTobottom`
+    - scrollView를 자동으로 제일 하단에 위치하도록 합니다.
+    - setContentOffset만 사용할 시 제일 하단 한 줄이 나오지 않는 문제가 있어 layoutIfNeeded()를 이용해 보류 중인 레이아웃 업데이트가 될 떄까지 기다린 후 스크롤을 아래로 내려주도록 합니다.
+- `changeStyle`
+    - 계산결과값에 NumberFormatter를 이용해 필요 스타일을 잡아줍니다.
+    - 1000의 자리마다 쉼표를 추가하고 20자리까지만 표기합니다. 잘리는 숫자는 반올림 해줍니다.
+
+</details>
+
+</br>
+
+**4️⃣ Text 구조체** </br>
+☑️ 기본텍스트를 상수로 사용하기 위한 구조체
+
+</br>
+
 ---
 
 ## 5. ✅ 프로젝트 수행 중 경험하고 배운 것
@@ -124,6 +240,14 @@ Node를 이용한 단방향 연결리스트 자료구조입니다.
 - 고차함수 사용하기 </br>
     ☑️ map, compactMap 사용하기 </br>
     ☑️ 옵셔녈바인딩대신 compactMap을 사용할 수 있음 </br>
+- UIStackView 코드로 다뤄보기 </br>
+    ☑️ 코드로 stackView생성과 특성을 지정해주기 </br>
+- UIlabel 코드로 다루기 </br>
+    ☑️ 코드로 UILabel생성과 특성을 지정해주고 stackView에 add해주기 </br>
+- scrollView 다루기 </br>
+    ☑️ 실제 컨텐츠 사이즈에서 원하는 bound의 위치로 CGPoint를 이용해 스크롤 이동하기 </br>
+- NumberFormatter() 포매터 사용하기 </br>
+    ☑️ 1000의 자리마다 쉼표, 유효숫자, NaN사용, 소숫점 처리 파라미터 이용하기 </br>
 
 ---
 
@@ -314,12 +438,59 @@ input.components(separatedBy: operators)
 ```
 </details>
 
+### 5️⃣ ScrollView Scroll 기본값으로 제일 하단으로 지정해 놓는 방법
+
+`setContentOffset` 을 이용해 CGPoint의 y축을 (contentSize의 높이 - bounds의 높이)로 설정해 주어도 scrollView 제일 하단 한 줄 빼고 스크롤이 되는 문제가 있었습니다. 하단 영상처럼 +7 이후부터는 제일 스택뷰의 한 줄이 화면에 보이지 않는 문제였습니다. 스크롤을 내려주는 메서드를 호출해줘도 맨 마지막 줄 빼고 그 위까지만 스크롤 되는 문제였습니다.
+
+<img width = 200, src ="https://i.imgur.com/DE8huir.gif">
+
+결론적으론 View의 drawing cycle을 공부해 `layoutIfNeeded()` 메서드를 호출해 주는 방식으로 문제를 해결했습니다.
+
+<details>
+ <summary> [해결과정 details] </summary>
+        
+- 5-1 오토레이아웃의 문제인가?
+    처음엔 **오토레이아웃의 문제**인가 싶어 오토레이아웃도 뜯어살펴보았지만 문제를 찾지 못했습니다.
+
+- 5-2. 내려가지 않는 한 줄만큼 setContentOffsetd의 y축 값으로 추가
+    setContentOffsetd의 y축 값을 더 내려가도록 해주면 될까 싶어서 **offSet변화량을 콘솔로 확인해서 변화량인 24큼 더 내리도록 해보았습니다** ( y = contentSize의 높이 - bounds의 높이 + **24** ) 
+
+    이렇게 할 때는 `컨텐츠높이`가 `bounds높이`보다 커질 때를 기준으로 첫번째 입력(아래GIF에서 +7때)에서 마지막줄이 안 보이고, 두번째 입력시(+8떄) 이전에 찍은 +7값과 같이 두개값이 동시에 나온 후에 세번째부터는 정상작동하는 문제가 있습니다.
+   <img width = 200, src ="https://i.imgur.com/PNj4xWk.gif">
+    
+- 5-3. 시간적인 duration 관련 문제인가?
+    업데이트 후 스클롤링 함수를 호출하는 시간 사이에 delay가 생길까 싶어 **notification Center**사용으로 한박자 늦게 scroll을 내리는 함수를 호출해보기도 했지만 무용지물이었습니다..
+    
+- 5-4. ✅ 드로잉 사이클 (drawing cycle)을 공부
+    컨텐츠가 변하여도 다음 드로잉사이클까지 **대기 후**에 다시 view가 업데이트 되는것을 알았습니다.
+    
+    setNeedsDisplay 메서드를 사용하면 시스템에게 draw 메서드를 호출하도록 요청해서 다시 View를 그려주게되는데 이 과정이 바로 즉각 되는것이 아니라 다음 drawing cycle까지 기다렸다가 진행됩니다. 제 화면에서 생각해보면 내부에서 스크롤하는 함수가 호출되어 스크롤을 제일 아래로 내렸지만, 하단에 스택뷰가 추가된 완성된 레이아웃 재배치는 그 후에 이뤄지는 사이클이었기 때문에 마지막 줄이 안보이는 문제가 생겼던 것입니다.
+    
+    setNeedsDisplay와 같은 기능을 하지만 layoutIfNeeded메서드는 다음 드로잉 사이클까지 기다리지 않고 즉시 view layout을 업데이트 해줄 수 있는 메서드입니다. 때문에 layoutIfNeeded메서드를 호출한 후 스크롤을 내려주어 문제를 해결했습니다. 
+
+    setNeedsDisplay 메서드의 호출 여부에 따른 실제 offset 수치를 확인해 보았습니다. 
+    아래의 표는 스크롤뷰에 추가된 스택뷰의 갯수에 따른 컨텐츠높이, bound높이, content offset의 y축값 을 정리한 것입니다.
+    표에서 확인이 가능한 것은 layoutIfNeeded를 호출하지 않고 계산기를 찍을때와 호출했을 때의 값이 한스텝씩 차이가 난다는 것입니다. 
+
+    <img width = 800, src ="https://i.imgur.com/oDgorTU.png">
+    (위 표에서 offSet을 빨간글씨는 스크롤 제일 아랫줄이 보이지 않을때를 표시한 것입니다..)
+
+    이 스텝의 차이는 위에서 설명했듯이 순서의 차이입니다. `스크롤내리기 -> 뷰 업데이트` 와 `뷰 업데이트 -> 스크롤내리기` 의 차이입니다.
+
+    </details>   
+    
+    
+    ---
 
 ## 7. 🔗 참고 링크
-- [Swift Language Guide - Extentions
+- [[공식문서] Swift Language Guide - Extentions
 ](https://docs.swift.org/swift-book/LanguageGuide/Extensions.html)
-- [Swift Language Guide - Protocols
+- [[공식문서]Swift Language Guide - Protocols
 ](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html)
-- [Swift Language Guide - Inheritance](https://docs.swift.org/swift-book/LanguageGuide/Inheritance.html)
+- [[공식문서]Swift Language Guide - Inheritance](https://docs.swift.org/swift-book/LanguageGuide/Inheritance.html)
+- [[공식문서]ios developer - UIView](https://developer.apple.com/documentation/uikit/uiview) 
+- [[공식문서]ios developer - NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)     
+- [야곰닷넷 - 오토레이아웃 정복하기](https://yagom.net/courses/autolayout/)        
 - [개발자 소들이-Swift) 큐(Queue) 구현 해보기](https://babbab2.tistory.com/84)
 - [개발자 소들이-Swift) 단방향 연결 리스트(LinkedList) 구현 해보기](https://babbab2.tistory.com/86)
+- [iOS ) View/레이아웃 업데이트 관련 메소드](https://zeddios.tistory.com/359)


### PR DESCRIPTION
@lina0322 (@엘림)
안녕하세요 엘림!
Step3 PR드립니다

UI구현에 약해서 결국 PR도 목표PR보다 늦게 보내게 되었어요😂
머리를 쥐어뜯게 만드는 Step3였습니다....허허허
마지막 스텝도 잘 부탁드리겠습니다 🙇🏻‍♀️

---


## ✅ 프로젝트 수행 중 경험하고 배운 것
- UIStackView 코드로 다뤄보기
    ☑️ 코드로 stackView생성과 특성을 지정해주기
- UIlabel 코드로 다뤄보기
    ☑️ 코드로 UILabel생성과 특성을 지정해주고 stackView에 add해주기 
- scrollView 다뤄보기
    ☑️ 실제 컨텐츠 사이즈에서 원하는 bound의 위치로 CGPoint를 이용해 스크롤 이동하기
- NumberFormatter() 포매터 사용하기
    ☑️ 1000의 자리마다 쉼표, 유효숫자, NaN사용, 소숫점 처리 파라미터 이용하기
---

## ⚒️ 구현내용

viewController
 - ☑️ Parameter
    - `formula`: `=` 버튼을 누를 시 계산해 줄 공식을 담습니다.
    - `result`: 계산 결과를 담습니다.
    - `inputNumber`: 실시간 input을 보여줍니다. willSet을 이용해 라벨에 표시해줍니다. 값이 비거나, 음수부호일 시에는 0을 표시합니다.(음수부호는 0으로 보여도 뒤에 숫자를 누를 시 음수로 표시됩니다)
                                    
 
 - ☑️ IBAction 메서드
     - `touchUpNumberButton`: 
         - 숫자패드에 반응해 라벨에 띄우기 위해 inputNumber에 담습니다. 
         - `0`버튼과 `00`버튼은 현재값이 0일때 눌러도 여러번 입력되지 않도록 guard문 처리했습니다.
         - `1~9` 버튼은 현재값이 0일때 0을 지우고 숫자가 입력되도록 합니다.
     - `touchUpOperatorButton`:
         - 연산자를 처음 누른다면 거라면 연산자라벨에 누른 연산자를 보여줍니다.
         - 기존에 숫자를 눌렀었다면 이전에 누른 공식을 stackView에 label로 올려주고 
            실시간 input을 보여주는 label은 초기화한 후 연산자라벨에 눌러진 연산자를 보여줍니다.
         - 더불어 나중에 계산을 위해 formula프로퍼티에도 이전에 누른 공식을 추가합니다.
     - `touchUpConvertingPositiveNegativeButton`:
         - 첫번째 자릿수가 마이너스인지 구분하여 음수🔁양수 convert해줍니다.
         - 0일 때는 양수, 음수 convert 되지 않습니다.
     - `touchUpCEButton`:
         - input내용을 지워줍니다.
     - `touchUpACButton`:
         - input내용과 기존 공식들 모두 지워줍니다
     - `touchUpResultButton`:
         - 기존에 `=`을 누른 후 다시 누르는 경우 작동하지 않도록 guard문 처리했습니다.
         - 마지막 input들을 stackView에 label로 올려주고 input을 비워줍니다.
         - 오류처리를 위해 do-catch문으로 결과를 계산해줍니다
         - `divideByZeroError` 시 Nan처리를 위해 numberFormatter의 notANumberSymbol을 사용합니다.
 - ☑️ 메서드 
     - `addFormula`
         - 계산을 위해 formula 프로퍼티에 값을 담습니다.
         - (3-2) 를 (+3-2)로 담기위해 if문으로 라벨이 비어있을 때는 +를 담아줍니다.
    - `MakeOperationStackView`:
        - UIStackView를 생성하고 특성을 정해줍니다.
        - 연산자 라벨과 피연산 라벨을 horizontal axis로 담습니다.
        - `showingOperationsStackView`의 맨 뒤에 추가해줍니다.
    - `makeOperatorLabel`, `makeOperandLabel`
        - UILabel을 생성하고 특성을 정해줍니다.
        - 각각 현재 입력된 연산자, 피연산자를 text로 갖습니다.
    - `scrollTobottom`
        - scrollView를 자동으로 제일 하단에 위치하도록 합니다.
        - setContentOffset만 사용할 시 제일 하단 한 줄이 나오지 않는 문제가 있어 layoutIfNeeded()를 이용해 보류 중인 레이아웃 업데이트가 될 떄까지 기다린 후 스크롤을 아래로 내려주도록 합니다.
    - `changeStyle`
        - 계산결과값에 NumberFormatter를 이용해 필요 스타일을 잡아줍니다.
        - 1000의 자리마다 쉼표를 추가하고 20자리까지만 표기합니다. 잘리는 숫자는 반올림 해줍니다.

---

## 🤔 고민한 부분
처음부터 끝까지 고민덩어리인 Step3였지만.. 제가 UI공부가 덜 된 문제인 것 같아서 한 가지만 적겠습니다😂

### 1️⃣ input Number를 label로 보여주는 방식을 IBAction에서 직접 처리해줄지, 프로퍼티를 통해 변경해줄지에 대한 고민을 했습니다.
처음엔 IBAction 메서드에서 버튼들(숫자버튼, CE, AC, +/-)터시 시 **직접 operandLabel.text로 접근해서 라벨값을 변경**해줬었습니다.
코드를 작성하면서 label의 text값이 옵셔널이라 0이거나 값이 비어있는지 확인할 때마다 guard문으로 옵셔널로 풀어줘야함에 불편함을 느꼈습니다.
그래서 새로운 프로퍼티 inputNumber를 만들어 willSet을 이용해 값이 변할 때마다 operandLabel.text에 담길 수 있도록 수정했습니다.
 
---

## 🙇🏻‍♀️ 조언을 얻고싶은 부분
### 1️⃣ ScrollView 기본값으로 스크롤을 맨 아래로 내리는 방법🥲
`setContentOffset` 을 이용해 CGPoint의 y축을 (contentSize의 높이 - bounds의 높이)로 설정해 주어도 scrollView 제일 하단 한 줄 빼고 스크롤이 되는 문제가 있었습니다. 
<img width = 200, src ="https://i.imgur.com/DE8huir.gif">


1. 처음엔 오토레이아웃의 문제인가 싶어 오토레이아웃도 뜯어살펴보았지만 문제를 찾지 못했습니다.

2. 내려가지 않는 한 줄만큼 setContentOffsetd의 y축 값으로 추가해주면 될까 싶어서 offSet변화량을 콘솔로 확인해서 변화량인 24큼 더 내리도록 해보았습니다 ( y = contentSize의 높이 - bounds의 높이 + **24** ) 

    이렇게 할 때는 컨텐츠높이랑 bounds높이보다 커질 때를 기준으로 첫번째 입력에서 마지막줄이 안 보이고(아래GIF에서 +7때), 두번째 입력시(+8떄) 이전에 찍은 +7값과 같이 두개값이 동시에 나온 후에 세번째부터는 정상작동하는 문제가 있습니다.
   <img width = 200, src ="https://i.imgur.com/PNj4xWk.gif">

    
아래의 표는 스크롤뷰에 추가된 스택뷰의 갯수에 따른 컨텐츠높이, bound높이, content offset의 y축값 을 정리한 것입니다.
아래의 표에서 확인이 가능한 것은 layoutIfNeeded를 호출하지 않고 계산기를 찍을때 한스텝씩 차이가 난다는 것입니다. 이것을 미뤄보아 **'스택뷰가 추가되고, CGPoint의 Y축이 계산이 이전 컨텐츠사이즈로 계산되고 있는 것 같다'** 라고 의심 하고있습니다.

<img width = 800, src ="https://i.imgur.com/oDgorTU.png">

(위 표에서 offSet을 빨간글씨는 스크롤 제일 아랫줄이 보이지 않을때를 표시한 것입니다..)
    
3. 위의 표에서 세번째 표의 8번일때만 정상작동 할 수 있도록 if 문으로 contentSize.height == bounds.height 일때 offset을 더 아래로 내려보도록 해보았지만 무용지물 이었습니다.

4. 한스텝씩 차이나는게 시간적 duration문제인가 싶어 delay를 주기 위해 notification Center사용으로 한박자 늦게 scroll을 내리는 함수를 호출해보기도 했지만 무용지물이었습니다..


레이아웃을 즉시 업데이트할 수 있게 하는 layoutIfNeeded메서드를 사용해서 해결은 했지만, 정확한 원인을 알고 싶은데 찾지를 못하고 있습니다 😂 위에 의심대로 한박자씩 늦는거라면 2번처럼 Y축을 +24 해주면 정상작동이 되야한다고 예상되는데 왜 7번째에 한번 안되는지도 모르겠습니다..

🥲 엘림도 혹시 비슷한 문제를 겪으셨거나 이유를 알고 계시면 조언 부탁드리겠습니다 

