### PR TITLE
계산기 [STEP 3] rhovin

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A64E0A128E2EF5300368B17 /* NumericKeypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A64E0A028E2EF5300368B17 /* NumericKeypad.swift */; };
 		1A86816C28D805CD00BE2837 /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A86816B28D805CD00BE2837 /* CalculatorViewController.swift */; };
 		1A8681B128D8747200BE2837 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8681B028D8747200BE2837 /* CalculatorItemQueue.swift */; };
 		1A8681B728D874F000BE2837 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8681B628D874F000BE2837 /* CalculateItem.swift */; };
@@ -51,6 +52,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1A64E0A028E2EF5300368B17 /* NumericKeypad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericKeypad.swift; sourceTree = "<group>"; };
 		1A86816B28D805CD00BE2837 /* CalculatorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorViewController.swift; sourceTree = "<group>"; };
 		1A8681B028D8747200BE2837 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		1A8681B628D874F000BE2837 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				1ABBF5D728DC7E9C00F26BC5 /* CalculatorError.swift */,
 				1ABBF5DD28DCACF300F26BC5 /* ExpressionParser.swift */,
 				1AFBACDE28DB11EA00D7E26D /* Operator+CalculateItem.swift */,
+				1A64E0A028E2EF5300368B17 /* NumericKeypad.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -418,6 +421,7 @@
 				1A8681B728D874F000BE2837 /* CalculateItem.swift in Sources */,
 				1A86816C28D805CD00BE2837 /* CalculatorViewController.swift in Sources */,
 				1ABBF5D828DC7E9C00F26BC5 /* CalculatorError.swift in Sources */,
+				1A64E0A128E2EF5300368B17 /* NumericKeypad.swift in Sources */,
 				1A8681BD28D88DB300BE2837 /* AppDelegate.swift in Sources */,
 				1AFBACE228DB123500D7E26D /* Double+CalculateItem.swift in Sources */,
 				1AFBACDF28DB11EA00D7E26D /* Operator+CalculateItem.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1A8681B128D8747200BE2837 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8681B028D8747200BE2837 /* CalculatorItemQueue.swift */; };
 		1A8681B728D874F000BE2837 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8681B628D874F000BE2837 /* CalculateItem.swift */; };
 		1A8681BD28D88DB300BE2837 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
+		1AAF487D28E4636800DD5781 /* UIStrollView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF487C28E4636800DD5781 /* UIStrollView+Extension.swift */; };
 		1ABBF5D828DC7E9C00F26BC5 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABBF5D728DC7E9C00F26BC5 /* CalculatorError.swift */; };
 		1ABBF5DA28DCABBF00F26BC5 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABBF5D928DCABBF00F26BC5 /* String+Extension.swift */; };
 		1ABBF5DE28DCACF300F26BC5 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABBF5DD28DCACF300F26BC5 /* ExpressionParser.swift */; };
@@ -56,6 +57,7 @@
 		1A86816B28D805CD00BE2837 /* CalculatorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorViewController.swift; sourceTree = "<group>"; };
 		1A8681B028D8747200BE2837 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		1A8681B628D874F000BE2837 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
+		1AAF487C28E4636800DD5781 /* UIStrollView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStrollView+Extension.swift"; sourceTree = "<group>"; };
 		1ABBF5D728DC7E9C00F26BC5 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
 		1ABBF5D928DCABBF00F26BC5 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		1ABBF5DD28DCACF300F26BC5 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 			children = (
 				1ABBF5D928DCABBF00F26BC5 /* String+Extension.swift */,
 				1AFBACE128DB123500D7E26D /* Double+CalculateItem.swift */,
+				1AAF487C28E4636800DD5781 /* UIStrollView+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -418,6 +421,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1AAF487D28E4636800DD5781 /* UIStrollView+Extension.swift in Sources */,
 				1A8681B728D874F000BE2837 /* CalculateItem.swift in Sources */,
 				1A86816C28D805CD00BE2837 /* CalculatorViewController.swift in Sources */,
 				1ABBF5D828DC7E9C00F26BC5 /* CalculatorError.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1A8681B728D874F000BE2837 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8681B628D874F000BE2837 /* CalculateItem.swift */; };
 		1A8681BD28D88DB300BE2837 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		1AAF487D28E4636800DD5781 /* UIStrollView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF487C28E4636800DD5781 /* UIStrollView+Extension.swift */; };
+		1AAF487F28E5760200DD5781 /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF487E28E5760200DD5781 /* Calculator.swift */; };
 		1ABBF5D828DC7E9C00F26BC5 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABBF5D728DC7E9C00F26BC5 /* CalculatorError.swift */; };
 		1ABBF5DA28DCABBF00F26BC5 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABBF5D928DCABBF00F26BC5 /* String+Extension.swift */; };
 		1ABBF5DE28DCACF300F26BC5 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABBF5DD28DCACF300F26BC5 /* ExpressionParser.swift */; };
@@ -58,6 +59,7 @@
 		1A8681B028D8747200BE2837 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		1A8681B628D874F000BE2837 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		1AAF487C28E4636800DD5781 /* UIStrollView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStrollView+Extension.swift"; sourceTree = "<group>"; };
+		1AAF487E28E5760200DD5781 /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		1ABBF5D728DC7E9C00F26BC5 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
 		1ABBF5D928DCABBF00F26BC5 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		1ABBF5DD28DCACF300F26BC5 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 			children = (
 				1A8681B028D8747200BE2837 /* CalculatorItemQueue.swift */,
 				1AFBACFF28DBFB0500D7E26D /* Formula.swift */,
+				1AAF487E28E5760200DD5781 /* Calculator.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				1AFBACE228DB123500D7E26D /* Double+CalculateItem.swift in Sources */,
 				1AFBACDF28DB11EA00D7E26D /* Operator+CalculateItem.swift in Sources */,
 				1A8681B128D8747200BE2837 /* CalculatorItemQueue.swift in Sources */,
+				1AAF487F28E5760200DD5781 /* Calculator.swift in Sources */,
 				1AFBAD0028DBFB0500D7E26D /* Formula.swift in Sources */,
 				1ABBF5DA28DCABBF00F26BC5 /* String+Extension.swift in Sources */,
 				1ABBF5DE28DCACF300F26BC5 /* ExpressionParser.swift in Sources */,

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -31,16 +31,22 @@ class CalculatorViewController: UIViewController {
         setOperandLabel(to: "0")
     }
     
+    private func isOperandZero() -> Bool {
+        if operandLabel.text == "0" { return true }
+        
+        return false
+    }
+    
     private func inputNumber(by key: NumericKeypad) {
         guard var operand = operandLabel.text else { return }
         
         if (operand.last == "." || operand.contains(".")),
            key.rawValue == "." { return }
 
-        if operand == "0",
+        if isOperandZero(),
            (key.rawValue == "0" || key.rawValue == "00") { return }
         
-        if operand == "0" {
+        if isOperandZero() {
             operand = key.rawValue
         } else {
             operand += key.rawValue
@@ -56,7 +62,7 @@ class CalculatorViewController: UIViewController {
         let currentOperator = key.rawValue
         setOperatorLabel(to: currentOperator)
 
-        if operand == "0" {
+        if isOperandZero() {
             return
         }
         
@@ -67,7 +73,7 @@ class CalculatorViewController: UIViewController {
     private func changeOperandSign() {
         guard var operand = operandLabel.text else { return }
         
-        if operand == "0" { return }
+        if isOperandZero() { return }
         
         if operand.first != "−" {
             operand = "−" + operand

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -4,8 +4,16 @@ class CalculatorViewController: UIViewController {
     @IBOutlet private weak var operatorLabel: UILabel!
     @IBOutlet private weak var operandLabel: UILabel!
     
+    private var numberFormatter: NumberFormatter {
+        var numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        
+        return numberFormatter
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         resetOperatorAndOperandLabel()
     }
     

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -25,13 +25,18 @@ class CalculatorViewController: UIViewController {
     private func setOperandLabel(_ key: NumericKeypad) {
         guard var operand = operandLabel.text else { return }
         
+        if (operand.last == "." || operand.contains(".")),
+           key.rawValue == "." { return }
+
         if operand == "0",
            (key.rawValue == "0" || key.rawValue == "00") { return }
         
-        if (operand.last == "." || operand.contains(".")),
-           key.rawValue == "." { return }
+        if operand == "0" {
+            operand = key.rawValue
+        } else {
+            operand += key.rawValue
+        }
         
-        operand += key.rawValue
         operandLabel.text = operand
     }
     

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 class CalculatorViewController: UIViewController {
     @IBOutlet private weak var operatorLabel: UILabel!
     @IBOutlet private weak var operandLabel: UILabel!
+    @IBOutlet private weak var historyStackView: UIStackView!
     
     private var formula = ""
     private var numberFormatter: NumberFormatter {
@@ -15,7 +16,7 @@ class CalculatorViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        initOperatorAndOperandLabel()
+        clearAll()
     }
     
     private func setOperandLabel(to string: String?) {
@@ -87,6 +88,11 @@ class CalculatorViewController: UIViewController {
         setOperandLabel(to: "0")
     }
     
+    private func clearAll() {
+        historyStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        initOperatorAndOperandLabel()
+    }
+    
     @IBAction private func touchUpCalculatorButton(_ sender: UIButton) {
         guard let buttonTitle = sender.currentTitle,
               let key = NumericKeypad(rawValue: buttonTitle) else { return }
@@ -99,7 +105,7 @@ class CalculatorViewController: UIViewController {
         case .equal:
             return
         case .ac:
-            return
+            clearAll()
         case .ce:
             clearEntry()
         case .plusMinus:

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -21,6 +21,20 @@ class CalculatorViewController: UIViewController {
         operatorLabel.text = nil
         operandLabel.text = "0"
     }
+    
+    private func setOperandLabel(_ key: NumericKeypad) {
+        guard var operand = operandLabel.text else { return }
+        
+        if operand == "0",
+           (key.rawValue == "0" || key.rawValue == "00") { return }
+        
+        if (operand.last == "." || operand.contains(".")),
+           key.rawValue == "." { return }
+        
+        operand += key.rawValue
+        operandLabel.text = operand
+    }
+    
     @IBAction private func touchUpCalculatorButton(_ sender: UIButton) {
         guard let buttonTitle = sender.currentTitle,
               let key = NumericKeypad(rawValue: buttonTitle) else { return }

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -4,6 +4,7 @@ class CalculatorViewController: UIViewController {
     @IBOutlet private weak var operatorLabel: UILabel!
     @IBOutlet private weak var operandLabel: UILabel!
     @IBOutlet private weak var historyStackView: UIStackView!
+    @IBOutlet private weak var historyScrollView: UIScrollView!
     
     private var formula = ""
     private let numberFormatter: NumberFormatter = {
@@ -62,7 +63,7 @@ class CalculatorViewController: UIViewController {
         return label
     }
     
-    private func addHistory() {
+    private func addHistoryStackView() {
         let historyLabels: [UIView] = [
             makeHistoryLabel(text: operatorLabel.text),
             makeHistoryLabel(text: operandLabel.text)
@@ -80,6 +81,7 @@ class CalculatorViewController: UIViewController {
         }
         
         historyStackView.addArrangedSubview(stackView)
+        historyScrollView.moveToBottom()
     }
     
     private func inputOperator(by key: NumericKeypad) {
@@ -93,8 +95,8 @@ class CalculatorViewController: UIViewController {
             return
         }
         
+        addHistoryStackView()
         formula += operand + currentOperator
-        addHistory()
         setOperandLabel()
     }
     

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -19,7 +19,7 @@ class CalculatorViewController: UIViewController {
         clearAll()
     }
     
-    private func setOperandLabel(to string: String?) {
+    private func setOperandLabel(to string: String? = "0") {
         operandLabel.text = string
     }
     
@@ -29,7 +29,7 @@ class CalculatorViewController: UIViewController {
     
     private func initOperatorAndOperandLabel() {
         setOperatorLabel(to: nil)
-        setOperandLabel(to: "0")
+        setOperandLabel()
     }
     
     private func isOperandZero() -> Bool {
@@ -65,7 +65,7 @@ class CalculatorViewController: UIViewController {
         }
         
         formula += operand + currentOperator
-        setOperandLabel(to: "0")
+        setOperandLabel()
     }
     
     private func changeOperandSign() {
@@ -85,7 +85,7 @@ class CalculatorViewController: UIViewController {
     private func clearEntry() {
         if isOperandZero() { return }
         
-        setOperandLabel(to: "0")
+        setOperandLabel()
     }
     
     private func clearAll() {

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -6,6 +6,11 @@ class CalculatorViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        resetOperatorAndOperandLabel()
+    }
+    
+    private func resetOperatorAndOperandLabel() {
+        operatorLabel.text = nil
+        operandLabel.text = "0"
     }
 }

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -40,13 +40,10 @@ class CalculatorViewController: UIViewController {
     private func inputNumber(by key: NumericKeypad) {
         guard var operand = operandLabel.text else { return }
         
-        if (operand.last == "." || operand.contains(".")),
-           key.rawValue == "." { return }
-
-        if isOperandZero(),
-           (key.rawValue == "0" || key.rawValue == "00") { return }
+        if (operand.last == "." || operand.contains(".")) && (key.rawValue == ".") ||
+            isOperandZero() && (key.rawValue == "0" || key.rawValue == "00") { return }
         
-        if isOperandZero() {
+        if isOperandZero(), key.rawValue != "." {
             operand = key.rawValue
         } else {
             operand += key.rawValue

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -6,12 +6,12 @@ class CalculatorViewController: UIViewController {
     @IBOutlet private weak var historyStackView: UIStackView!
     
     private var formula = ""
-    private var numberFormatter: NumberFormatter {
+    private let numberFormatter: NumberFormatter = {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         
         return numberFormatter
-    }
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -53,6 +53,35 @@ class CalculatorViewController: UIViewController {
         setOperandLabel(to: operand)
     }
     
+    private func makeHistoryLabel(text: String?) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        
+        return label
+    }
+    
+    private func addHistory() {
+        let historyLabels: [UIView] = [
+            makeHistoryLabel(text: operatorLabel.text),
+            makeHistoryLabel(text: operandLabel.text)
+        ]
+        
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        
+        historyLabels.forEach {
+            stackView.addArrangedSubview($0)
+        }
+        
+        historyStackView.addArrangedSubview(stackView)
+    }
+    
     private func inputOperator(by key: NumericKeypad) {
         guard let operand = operandLabel.text,
                   operand.last != "." else { return }
@@ -65,6 +94,7 @@ class CalculatorViewController: UIViewController {
         }
         
         formula += operand + currentOperator
+        addHistory()
         setOperandLabel()
     }
     

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -14,19 +14,22 @@ class CalculatorViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        resetOperatorAndOperandLabel()
+        initOperatorAndOperandLabel()
     }
     
-    private func resetOperandLabel() {
-        operandLabel.text = "0"
+    private func setOperandLabel(to string: String?) {
+        operandLabel.text = string
     }
     
-    private func resetOperatorAndOperandLabel() {
-        operatorLabel.text = nil
-        resetOperandLabel()
+    private func setOperatorLabel(to string: String?) {
+        operatorLabel.text = string
     }
     
-    private func setOperandLabel(_ key: NumericKeypad) {
+    private func initOperatorAndOperandLabel() {
+        setOperatorLabel(to: nil)
+        setOperandLabel(to: "0")
+    }
+    
         guard var operand = operandLabel.text else { return }
         
         if (operand.last == "." || operand.contains(".")),

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -30,6 +30,7 @@ class CalculatorViewController: UIViewController {
         setOperandLabel(to: "0")
     }
     
+    private func inputNumber(by key: NumericKeypad) {
         guard var operand = operandLabel.text else { return }
         
         if (operand.last == "." || operand.contains(".")),
@@ -44,7 +45,9 @@ class CalculatorViewController: UIViewController {
             operand += key.rawValue
         }
         
-        operandLabel.text = operand
+        setOperandLabel(to: operand)
+    }
+    
     }
     
     @IBAction private func touchUpCalculatorButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -91,6 +91,7 @@ class CalculatorViewController: UIViewController {
     private func clearAll() {
         historyStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         initOperatorAndOperandLabel()
+        formula = ""
     }
     
     @IBAction private func touchUpCalculatorButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -11,6 +11,7 @@ class CalculatorViewController: UIViewController {
         let numberFormatter = NumberFormatter()
         numberFormatter.usesSignificantDigits = true
         numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = 20
         
         return numberFormatter
     }()
@@ -74,9 +75,12 @@ class CalculatorViewController: UIViewController {
     }
     
     private func addHistoryStackView(operatorText: String?, operandText: String?) {
+        guard let operand = operandText,
+              let convertedOperand = Double(operand) else { return }
+        
         let historyLabels: [UIView] = [
             makeHistoryLabel(text: operatorText),
-            makeHistoryLabel(text: operandText)
+            makeHistoryLabel(text: numberFormatter.string(from: convertedOperand as NSNumber))
         ]
         
         let stackView = UIStackView()
@@ -146,7 +150,7 @@ class CalculatorViewController: UIViewController {
     private func showCalculationResult() {
         do {
             let result = try calculator.calculate()
-            setOperandLabel(to: String(result))
+            setOperandLabel(to: numberFormatter.string(from: result as NSNumber))
         } catch CalculatorError.divisionByZero {
             setOperandLabel(to: numberFormatter.notANumberSymbol)
         } catch {

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -1,7 +1,9 @@
 import UIKit
 
 class CalculatorViewController: UIViewController {
-
+    @IBOutlet private weak var operatorLabel: UILabel!
+    @IBOutlet private weak var operandLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -47,7 +47,7 @@ class CalculatorViewController: UIViewController {
         guard var operand = operandLabel.text else { return }
         let keyNumber = key.rawValue
         
-        if (operand.last == "." || operand.contains(".")) && (keyNumber == ".") ||
+        if (operand.last == "." || operand.contains(".") || formula == "") && (keyNumber == ".") ||
             isOperandLabelZero() && (keyNumber == "0" || keyNumber == "00") { return }
         
         if (isOperandLabelZero() && keyNumber != ".") || formula == "" {

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -7,8 +7,10 @@ class CalculatorViewController: UIViewController {
     @IBOutlet private weak var historyScrollView: UIScrollView!
     
     private var formula = ""
+    private var isCalculateSucceeded = false
     private let numberFormatter: NumberFormatter = {
         let numberFormatter = NumberFormatter()
+        numberFormatter.usesSignificantDigits = true
         numberFormatter.numberStyle = .decimal
         
         return numberFormatter
@@ -47,11 +49,19 @@ class CalculatorViewController: UIViewController {
         guard var operand = operandLabel.text else { return }
         let keyNumber = key.rawValue
         
-        if (operand.last == "." || operand.contains(".") || formula == "") && (keyNumber == ".") ||
-            isOperandLabelZero() && (keyNumber == "0" || keyNumber == "00") { return }
+        if keyNumber == ".", operand.contains(".") {
+            return
+        }
         
-        if (isOperandLabelZero() && keyNumber != ".") || formula == "" {
+        if keyNumber == "0" || keyNumber == "00",
+           isOperandLabelZero() {
+            return
+        }
+        
+        if (isOperandLabelZero() && keyNumber != ".") ||
+            isCalculateSucceeded == true {
             operand = keyNumber
+            isCalculateSucceeded = false
         } else {
             operand += keyNumber
         }
@@ -165,6 +175,7 @@ class CalculatorViewController: UIViewController {
         
         setOperatorLabel(to: nil)
         initFormula()
+        isCalculateSucceeded = true
     }
     
     @IBAction private func touchUpCalculatorButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -81,6 +81,12 @@ class CalculatorViewController: UIViewController {
         setOperandLabel(to: operand)
     }
     
+    private func clearEntry() {
+        if isOperandZero() { return }
+        
+        setOperandLabel(to: "0")
+    }
+    
     @IBAction private func touchUpCalculatorButton(_ sender: UIButton) {
         guard let buttonTitle = sender.currentTitle,
               let key = NumericKeypad(rawValue: buttonTitle) else { return }
@@ -95,7 +101,7 @@ class CalculatorViewController: UIViewController {
         case .ac:
             return
         case .ce:
-            return
+            clearEntry()
         case .plusMinus:
             changeOperandSign()
         default:

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -32,7 +32,7 @@ class CalculatorViewController: UIViewController {
         setOperandLabel()
     }
     
-    private func isOperandZero() -> Bool {
+    private func isOperandLabelZero() -> Bool {
         if operandLabel.text == "0" { return true }
         
         return false
@@ -42,9 +42,9 @@ class CalculatorViewController: UIViewController {
         guard var operand = operandLabel.text else { return }
         
         if (operand.last == "." || operand.contains(".")) && (key.rawValue == ".") ||
-            isOperandZero() && (key.rawValue == "0" || key.rawValue == "00") { return }
+            isOperandLabelZero() && (key.rawValue == "0" || key.rawValue == "00") { return }
         
-        if isOperandZero(), key.rawValue != "." {
+        if isOperandLabelZero(), key.rawValue != "." {
             operand = key.rawValue
         } else {
             operand += key.rawValue
@@ -89,7 +89,7 @@ class CalculatorViewController: UIViewController {
         let currentOperator = key.rawValue
         setOperatorLabel(to: currentOperator)
 
-        if isOperandZero() {
+        if isOperandLabelZero() {
             return
         }
         
@@ -101,7 +101,7 @@ class CalculatorViewController: UIViewController {
     private func changeOperandSign() {
         guard var operand = operandLabel.text else { return }
         
-        if isOperandZero() { return }
+        if isOperandLabelZero() { return }
         
         if operand.first != "−" {
             operand = "−" + operand
@@ -113,7 +113,7 @@ class CalculatorViewController: UIViewController {
     }
     
     private func clearEntry() {
-        if isOperandZero() { return }
+        if isOperandLabelZero() { return }
         
         setOperandLabel()
     }

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -21,4 +21,25 @@ class CalculatorViewController: UIViewController {
         operatorLabel.text = nil
         operandLabel.text = "0"
     }
+    @IBAction private func touchUpCalculatorButton(_ sender: UIButton) {
+        guard let buttonTitle = sender.currentTitle,
+              let key = NumericKeypad(rawValue: buttonTitle) else { return }
+        
+        switch key {
+        case _ where NumericKeypad.numKeys.contains(key):
+            return
+        case _ where NumericKeypad.operatorKeys.contains(key):
+            return
+        case .equal:
+            return
+        case .ac:
+            return
+        case .ce:
+            return
+        case .plusMinus:
+            return
+        default:
+            return
+        }
+    }
 }

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -4,8 +4,9 @@ class CalculatorViewController: UIViewController {
     @IBOutlet private weak var operatorLabel: UILabel!
     @IBOutlet private weak var operandLabel: UILabel!
     
+    private var formula = ""
     private var numberFormatter: NumberFormatter {
-        var numberFormatter = NumberFormatter()
+        let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         
         return numberFormatter
@@ -48,6 +49,19 @@ class CalculatorViewController: UIViewController {
         setOperandLabel(to: operand)
     }
     
+    private func inputOperator(by key: NumericKeypad) {
+        guard let operand = operandLabel.text,
+                  operand.last != "." else { return }
+        
+        let currentOperator = key.rawValue
+        setOperatorLabel(to: currentOperator)
+
+        if operand == "0" {
+            return
+        }
+        
+        formula += operand + currentOperator
+        setOperandLabel(to: "0")
     }
     
     @IBAction private func touchUpCalculatorButton(_ sender: UIButton) {
@@ -56,9 +70,9 @@ class CalculatorViewController: UIViewController {
         
         switch key {
         case _ where NumericKeypad.numKeys.contains(key):
-            return
+            inputNumber(by: key)
         case _ where NumericKeypad.operatorKeys.contains(key):
-            return
+            inputOperator(by: key)
         case .equal:
             return
         case .ac:

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -76,7 +76,7 @@ class CalculatorViewController: UIViewController {
     
     private func addHistoryStackView(operatorText: String?, operandText: String?) {
         guard let operand = operandText,
-              let convertedOperand = Double(operand) else { return }
+              let convertedOperand = Double(operand.replacingOccurrences(of: "−", with: "-")) else { return }
         
         let historyLabels: [UIView] = [
             makeHistoryLabel(text: operatorText),

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -64,6 +64,20 @@ class CalculatorViewController: UIViewController {
         setOperandLabel(to: "0")
     }
     
+    private func changeOperandSign() {
+        guard var operand = operandLabel.text else { return }
+        
+        if operand == "0" { return }
+        
+        if operand.first != "−" {
+            operand = "−" + operand
+        } else {
+            operand = String(operand.dropFirst())
+        }
+        
+        setOperandLabel(to: operand)
+    }
+    
     @IBAction private func touchUpCalculatorButton(_ sender: UIButton) {
         guard let buttonTitle = sender.currentTitle,
               let key = NumericKeypad(rawValue: buttonTitle) else { return }
@@ -80,7 +94,7 @@ class CalculatorViewController: UIViewController {
         case .ce:
             return
         case .plusMinus:
-            return
+            changeOperandSign()
         default:
             return
         }

--- a/Calculator/Calculator/Controllers/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controllers/CalculatorViewController.swift
@@ -17,9 +17,13 @@ class CalculatorViewController: UIViewController {
         resetOperatorAndOperandLabel()
     }
     
+    private func resetOperandLabel() {
+        operandLabel.text = "0"
+    }
+    
     private func resetOperatorAndOperandLabel() {
         operatorLabel.text = nil
-        operandLabel.text = "0"
+        resetOperandLabel()
     }
     
     private func setOperandLabel(_ key: NumericKeypad) {

--- a/Calculator/Calculator/Enums/CalculatorError.swift
+++ b/Calculator/Calculator/Enums/CalculatorError.swift
@@ -8,6 +8,7 @@
 enum CalculatorError: Error {
     case queueIsEmpty
     case divisionByZero
+    case wrongFormula
 }
 
 extension CalculatorError: CustomDebugStringConvertible {
@@ -17,6 +18,8 @@ extension CalculatorError: CustomDebugStringConvertible {
             return "큐가 비어있습니다."
         case .divisionByZero:
             return "0으로 나눌 수 없습니다."
+        case .wrongFormula:
+            return "잘못된 수식입니다."
         }
     }
 }

--- a/Calculator/Calculator/Enums/ExpressionParser.swift
+++ b/Calculator/Calculator/Enums/ExpressionParser.swift
@@ -26,6 +26,6 @@ enum ExpressionParser {
             operators.insert(charactersIn: String($0.rawValue))
         }
 
-        return input.components(separatedBy: operators)
+        return input.components(separatedBy: operators).map { $0.replacingOccurrences(of: "−", with: "-") }
     }
 }

--- a/Calculator/Calculator/Enums/NumericKeypad.swift
+++ b/Calculator/Calculator/Enums/NumericKeypad.swift
@@ -20,7 +20,7 @@ enum NumericKeypad: String {
     case decimalPoint = "."
     
     case plus = "+"
-    case minus = "−"
+    case minus = "-"
     case division = "÷"
     case multiplication = "×"
     

--- a/Calculator/Calculator/Enums/NumericKeypad.swift
+++ b/Calculator/Calculator/Enums/NumericKeypad.swift
@@ -1,0 +1,31 @@
+//
+//  NumericKeypad.swift
+//  Calculator
+//
+//  Created by 노유빈 on 2022/09/27.
+//
+
+enum NumericKeypad: String {
+    case num1 = "1"
+    case num2 = "2"
+    case num3 = "3"
+    case num4 = "4"
+    case num5 = "5"
+    case num6 = "6"
+    case num7 = "7"
+    case num8 = "8"
+    case num9 = "9"
+    case num0 = "0"
+    case num00 = "00"
+    case decimalPoint = "."
+    
+    case plus = "+"
+    case minus = "-"
+    case division = "÷"
+    case multiplication = "×"
+    
+    case equal = "="
+    case ac = "AC"
+    case ce = "CE"
+    case plusMinus = "⁺⁄₋"
+}

--- a/Calculator/Calculator/Enums/NumericKeypad.swift
+++ b/Calculator/Calculator/Enums/NumericKeypad.swift
@@ -28,4 +28,7 @@ enum NumericKeypad: String {
     case ac = "AC"
     case ce = "CE"
     case plusMinus = "⁺⁄₋"
+    
+    static let numKeys = [num1, num2, num3, num4, num5, num6, num7, num8, num9, num0, num00, decimalPoint]
+    static let operatorKeys = [plus, minus, division, multiplication]
 }

--- a/Calculator/Calculator/Enums/NumericKeypad.swift
+++ b/Calculator/Calculator/Enums/NumericKeypad.swift
@@ -20,7 +20,7 @@ enum NumericKeypad: String {
     case decimalPoint = "."
     
     case plus = "+"
-    case minus = "-"
+    case minus = "−"
     case division = "÷"
     case multiplication = "×"
     

--- a/Calculator/Calculator/Extensions/UIStrollView+Extension.swift
+++ b/Calculator/Calculator/Extensions/UIStrollView+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  UIStrollView+Extension.swift
+//  Calculator
+//
+//  Created by 노유빈 on 2022/09/28.
+//
+
+import UIKit
+
+extension UIScrollView {
+    func moveToBottom() {
+        let bottomOffset = CGPoint(x: 0, y: contentSize.height - bounds.size.height)
+        setContentOffset(bottomOffset, animated: false)
+    }
+}

--- a/Calculator/Calculator/Models/Calculator.swift
+++ b/Calculator/Calculator/Models/Calculator.swift
@@ -28,7 +28,7 @@ class Calculator {
     }
     
     func addFormula(_ formula: String) {
-        self.formula += formula
+        self.formula += formula.replacingOccurrences(of: ",", with: "")
     }
     
     func calculate() throws -> Double {

--- a/Calculator/Calculator/Models/Calculator.swift
+++ b/Calculator/Calculator/Models/Calculator.swift
@@ -1,0 +1,43 @@
+//
+//  Calculator.swift
+//  Calculator
+//
+//  Created by 노유빈 on 2022/09/29.
+//
+
+class Calculator {
+    private(set) var formula = ""
+    private var calculationState = false
+    var isCalculateCompleted: Bool {
+        get {
+            return calculationState
+        }
+        
+        set(state) {
+            self.calculationState = state
+        }
+    }
+    
+    init(formula: String = "", calculationState: Bool = false) {
+        self.formula = formula
+        self.calculationState = calculationState
+    }
+    
+    func initFormula() {
+        formula = ""
+    }
+    
+    func addFormula(_ formula: String) {
+        self.formula += formula
+    }
+    
+    func calculate() throws -> Double {
+        var convertedFormula = ExpressionParser.parser(from: formula)
+        let result = try convertedFormula.result()
+        
+        initFormula()
+        isCalculateCompleted = true
+        
+        return result
+    }
+}

--- a/Calculator/Calculator/Views/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Views/Base.lproj/Main.storyboard
@@ -213,7 +213,7 @@
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                                <state key="normal" title="−">
+                                                <state key="normal" title="-">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>

--- a/Calculator/Calculator/Views/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Views/Base.lproj/Main.storyboard
@@ -364,6 +364,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="historyStackView" destination="XRe-QE-UJf" id="f8X-8h-xhr"/>
                         <outlet property="operandLabel" destination="Lwz-OF-XHD" id="yOx-hh-8j4"/>
                         <outlet property="operatorLabel" destination="HPC-iy-qdm" id="Xs0-JW-tHz"/>
                     </connections>

--- a/Calculator/Calculator/Views/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Views/Base.lproj/Main.storyboard
@@ -303,6 +303,10 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="yOx-hh-8j4"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="Xs0-JW-tHz"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/Views/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Views/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
@@ -14,17 +14,17 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="CalculatorViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                                <rect key="frame" x="16" y="242.33333333333337" width="396" height="52"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="396" height="52"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
+                                                <rect key="frame" x="263.66666666666669" y="0.0" width="132.33333333333331" height="24"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
                                                         <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
@@ -33,7 +33,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16.999999999999993" y="0.0" width="115.33333333333331" height="24"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -41,7 +41,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                                <rect key="frame" x="263.66666666666669" y="27.999999999999972" width="132.33333333333331" height="24"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
                                                         <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
@@ -50,7 +50,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16.999999999999993" y="0.0" width="115.33333333333331" height="24"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -73,13 +73,13 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="gA2-7M-FxF"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YKH-82-hZC">
-                                <rect key="frame" x="16" y="362.5" width="382" height="479.5"/>
+                                <rect key="frame" x="16" y="375" width="396" height="497"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="AP2-25-h5E">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="396" height="93"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ped-N8-JbY">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="AC">
@@ -90,7 +90,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="101" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="CE">
@@ -101,7 +101,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="202" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="⁺⁄₋">
@@ -112,7 +112,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="303" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="÷">
@@ -125,10 +125,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="35B-Om-mGh">
-                                        <rect key="frame" x="0.0" y="97.5" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="101" width="396" height="93"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L6z-2G-Gar">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="7">
@@ -139,7 +139,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="101" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="8">
@@ -150,7 +150,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="202" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="9">
@@ -161,7 +161,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="303" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="×">
@@ -174,10 +174,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="e7N-N0-vb2">
-                                        <rect key="frame" x="0.0" y="195" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="202" width="396" height="93"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-yz-XvG">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="4">
@@ -188,7 +188,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="101" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="5">
@@ -199,7 +199,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="202" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="6">
@@ -210,7 +210,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="303" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="-">
@@ -223,10 +223,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="NpY-aR-Nd4">
-                                        <rect key="frame" x="0.0" y="292.5" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="303" width="396" height="93"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nCE-qB-NiN">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="1">
@@ -237,7 +237,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="101" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="2">
@@ -248,7 +248,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="202" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="3">
@@ -259,7 +259,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="303" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="+">
@@ -272,10 +272,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="R7j-41-DOy">
-                                        <rect key="frame" x="0.0" y="390" width="382" height="89.5"/>
+                                        <rect key="frame" x="0.0" y="404" width="396" height="93"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mSz-Y3-r5Z">
-                                                <rect key="frame" x="0.0" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="0">
@@ -286,7 +286,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
-                                                <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="101" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title="00">
@@ -297,7 +297,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
-                                                <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="202" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <state key="normal" title=".">
@@ -308,7 +308,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
-                                                <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
+                                                <rect key="frame" x="303" y="0.0" width="93" height="93"/>
                                                 <color key="backgroundColor" red="0.89715212580000003" green="0.57001358270000002" blue="0.2305330038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Daw-iX-Owl" secondAttribute="height" multiplier="1:1" id="t9i-OQ-WFF"/>
@@ -326,19 +326,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="314.33333333333331" width="396" height="40.666666666666686"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="396" height="40.666666666666664"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="21" height="40.666666666666664"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                                <rect key="frame" x="29" y="0.0" width="367" height="40.666666666666664"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -364,6 +364,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="historyScrollView" destination="BOT-7g-vxv" id="g9A-PZ-bB5"/>
                         <outlet property="historyStackView" destination="XRe-QE-UJf" id="f8X-8h-xhr"/>
                         <outlet property="operandLabel" destination="Lwz-OF-XHD" id="yOx-hh-8j4"/>
                         <outlet property="operatorLabel" destination="HPC-iy-qdm" id="Xs0-JW-tHz"/>

--- a/Calculator/Calculator/Views/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Views/Base.lproj/Main.storyboard
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tRW-U7-eHL"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -93,6 +96,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="NBp-sf-vXP"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -101,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aPb-cl-U4O"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -109,6 +118,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Msh-vc-vNJ"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -122,6 +134,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uzN-OB-t42"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -130,6 +145,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gmD-da-2uV"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -138,6 +156,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bPO-81-RWt"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -146,6 +167,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hBp-Tm-ScE"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -159,6 +183,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Sge-PZ-dxG"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -167,6 +194,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="NAh-bb-fhc"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -175,6 +205,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qZ4-UH-RBZ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -183,6 +216,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UWP-KJ-Ncf"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -196,6 +232,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qvR-BM-rSO"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -204,6 +243,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ME1-ep-zzz"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -212,6 +254,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7t4-cP-bcA"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -220,6 +265,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="B6S-PR-je7"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -233,6 +281,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="EiN-Zr-hQw"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -241,6 +292,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="IhM-AR-fuM"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -249,6 +303,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Nr2-UD-Rwf"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -260,6 +317,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCalculatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="NMP-A9-4Ot"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -36,8 +36,6 @@ final class ExpressionParserTests: XCTestCase {
         XCTAssertEqual(result, 60)
     }
     
-    
-    
     func test_곱하기_string타입_식이_주어지면_파싱하여_결과가_나오는지_확인() {
         let stringFormula = "12×25×78×4"
         


### PR DESCRIPTION
@wonhee009 

안녕하세요 라자냐~ 로빈입니다.
생각보다 오래걸리고 신경쓸 부분이 많았던 힘든 스텝이었습니다😂
진행할수록 코드가 점점 더러워지는게 정상인가요?ㅠㅠ
코드를 이쁘게 작성하려고 노력했는데.... 한계에 부딪혔습니다... 아낌없는 조언 부탁드립니다!🙇‍♀️

# Step 3

## Calculator 클래스 정의
- 모델로 사용하기 위해 클래스를 정의하였습니다.
- 계산기 수식 및 계산완료 상태 프로퍼티와, 수식변경 및 계산하는 메소드를 갖고 있습니다.

## NumericKeypad 열거형 정의
- 계산기 버튼이 눌릴때 어떤 버튼인지 구별하기 위해서 열거형을 정의하였습니다.

## extension UIScrollView
- `func moveToBottom()` : 계산히스토리가 스크롤뷰 범위를 벗어난 경우, 자동으로 맨밑으로 스크롤되도록합니다. 

## CalculatorViewController
- `touchUpCalculatorButton()` : 계산기 버튼 이벤트가 들어오면 각 버튼에 맞는 메소드를 실행합니다.
- `addHistoryStackView()` : 새로운 연산자가 입력되면 기존에 입력된 피연산자와 연산자를 계산기 히스토리스택뷰에 추가합니다.

## NumberFormmater
- 계산기 숫자 포맷을 표현하기 위해 아래와 같이 넘버포맷을 선언하였습니다.
- 계산기 히스토리에서는 숫자가 3자리 마다 ,가 찍혀나오는데 연산자 입력받을 때에 3자리마다 ,나오는 것은 아직 구현하지 못했습니다.😂
```
private let numberFormatter: NumberFormatter = {
        let numberFormatter = NumberFormatter()
        numberFormatter.usesSignificantDigits = true
        numberFormatter.numberStyle = .decimal
        numberFormatter.maximumSignificantDigits = 20
        
        return numberFormatter
    }()
```


# 트러블 슈팅
### 1. 계산기 피연산자가 음수일 경우 계산결과가 재대로 안나오는 문제
- string 형태 수식을 연산자와 피연산자로 파싱할 때, 음수인 피연산자의 -기호가 사라지는 문제가 있었습니다.
- 음수기호 - 와, 연산기호 -를 구분하였습니다.(보이는 모양은 같지만 다른 문자가 있었습니다.)
- 음수기호 -는 Double로 타입변환이 불가능하여 아래와 같이 다시 연산기호 -로 치환하였습니다.
```
input.components(separatedBy: operators).map { $0.replacingOccurrences(of: "−", with: "-")
```

# 해결되지 못한 문제
### 1. 계산히스토리가 스크롤뷰 범위를 벗어난 경우, 계산히스토리가 추가될 때, 맨밑으로 스크롤이 내려가지 않은 문제
- 아래 영상과 같이 스크롤이 한줄 덜되는 문제가 있는데, 아직 원인을 명확히 찾지 못했습니다ㅠㅠ

https://user-images.githubusercontent.com/49301866/192996826-ab5b26b5-d2d9-4a2a-9cb0-9ba403b18ad4.mov

### 2. 계산기 숫자 20자리까지 제한
- 레이블의 자릿수를 어떻게 제한할지 고민중입니다.
- 피연산자 입력받을 때 3자리씩 ,로 구분해주는 기능을 완성하지 못했습니다.




