### PR TITLE
계산기 II [STEP1] 써니쿠키, 스톤 

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		41EF0CA628EACD25005EADF3 /* UIStackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EF0CA528EACD25005EADF3 /* UIStackView+Extension.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
-		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
+		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
@@ -94,7 +94,7 @@
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C713D9452570E5EB001C3AFC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ViewController.swift; sourceTree = "<group>"; wrapsLines = 1; };
+		C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CalculatorViewController.swift; sourceTree = "<group>"; wrapsLines = 1; };
 		C713D9482570E5EB001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -210,7 +210,7 @@
 			children = (
 				C713D9412570E5EB001C3AFC /* AppDelegate.swift */,
 				C713D9432570E5EB001C3AFC /* SceneDelegate.swift */,
-				C713D9452570E5EB001C3AFC /* ViewController.swift */,
+				C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */,
 			);
 			path = Conrtroller;
 			sourceTree = "<group>";
@@ -535,7 +535,7 @@
 				417BF91628DC60B6008CE4F5 /* Operator.swift in Sources */,
 				419E552E28D8962D00B21DE6 /* CalculateItem.swift in Sources */,
 				419E553028D8977000B21DE6 /* CalculatorItemQueue.swift in Sources */,
-				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				417BF91428DC5D0C008CE4F5 /* CalculatorError.swift in Sources */,
 				41AC2E7828D89DDA0026B631 /* LinkedList.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		419E553028D8977000B21DE6 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419E552F28D8977000B21DE6 /* CalculatorItemQueue.swift */; };
 		41AC2E7828D89DDA0026B631 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AC2E7728D89DDA0026B631 /* LinkedList.swift */; };
 		41AC2E8028D8A7B50026B631 /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AC2E7F28D8A7B50026B631 /* LinkedListTests.swift */; };
+		41EF0CA628EACD25005EADF3 /* UIStackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EF0CA528EACD25005EADF3 /* UIStackView+Extension.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -89,6 +90,7 @@
 		41AC2E7728D89DDA0026B631 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		41AC2E7D28D8A7B50026B631 /* LinkedListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		41AC2E7F28D8A7B50026B631 /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
+		41EF0CA528EACD25005EADF3 /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 			children = (
 				417BF90228DC5332008CE4F5 /* String+Extension.swift */,
 				417BF90428DC5359008CE4F5 /* Double+Extension.swift */,
+				41EF0CA528EACD25005EADF3 /* UIStackView+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -536,6 +539,7 @@
 				417BF91428DC5D0C008CE4F5 /* CalculatorError.swift in Sources */,
 				41AC2E7828D89DDA0026B631 /* LinkedList.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				41EF0CA628EACD25005EADF3 /* UIStackView+Extension.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				41083C6928D979A700B86025 /* Node.swift in Sources */,
 				417BF90328DC5332008CE4F5 /* String+Extension.swift in Sources */,

--- a/Calculator/Calculator/Conrtroller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Conrtroller/CalculatorViewController.swift
@@ -6,14 +6,15 @@
 
 import UIKit
 
-struct Text {
-    fileprivate static let zero: String = "0"
-    fileprivate static let noValue: String = ""
-    fileprivate static let negativeSymbol: String = "-"
-    fileprivate static let dot: Character = "."
-}
 
-class ViewController: UIViewController {
+class CalculatorViewController: UIViewController {
+    enum Text {
+        static let zero: String = "0"
+        static let noValue: String = ""
+        static let negativeSymbol: String = "-"
+        static let dot: Character = "."
+    }
+    
     @IBOutlet private weak var operandLabel: UILabel!
     @IBOutlet private weak var operatorLabel: UILabel!
     @IBOutlet private weak var showingOperationsStackView: UIStackView!
@@ -31,7 +32,7 @@ class ViewController: UIViewController {
                 return
             }
             
-        operandLabel.text = newValue
+            operandLabel.text = newValue
         }
     }
     
@@ -65,10 +66,10 @@ class ViewController: UIViewController {
         
         guard inputNumber.split(with: Text.dot).count <= 2,
               inputNumber != String(Text.dot) else {
-                  resetInputNumber()
-                  operandLabel.text = numberFormatter.notANumberSymbol
-                  return
-              }
+            resetInputNumber()
+            operandLabel.text = numberFormatter.notANumberSymbol
+            return
+        }
         
         addFormula()
         makeOperationStackView()
@@ -79,7 +80,7 @@ class ViewController: UIViewController {
     
     @IBAction private func touchUpConvertingPositiveNegativeButton() {
         guard inputNumber != Text.zero else { return }
-    
+        
         if inputNumber.prefix(1) == Text.negativeSymbol {
             inputNumber.removeFirst()
         } else {
@@ -93,14 +94,15 @@ class ViewController: UIViewController {
     
     @IBAction private func touchUpACButton(_ sender: UIButton) {
         showingOperationsStackView.removeSubViewAll()
+        isCalculated = false
         resetRawFormula()
         resetInputNumber()
         resetOperatorLabel()
     }
     
     @IBAction private func touchUpResultButton(_ sender: UIButton) {
-        guard operandLabel.text != result.changeToDemical else { return }
-
+        guard !isCalculated else { return }
+        
         addFormula()
         makeOperationStackView()
         scrollTobottom()
@@ -111,23 +113,14 @@ class ViewController: UIViewController {
             var formulaQueue = ExpressionParser.parse(from: rawFormula.joined(separator: " "))
             result = try formulaQueue.result()
             operandLabel.text = String(result.changeToDemical)
-            isCalculated = true
             resetRawFormula()
         } catch CalculatorError.divideByZeroError {
             operandLabel.text = numberFormatter.notANumberSymbol
         } catch {
             operandLabel.text = "Error: Please retry"
         }
-    }
-    
-    private func addFormula() {
-        guard let`operator` = operatorLabel.text,
-              let operand = operandLabel.text else {
-            return
-        }
         
-        rawFormula.append(`operator`)
-        rawFormula.append(operand)
+        isCalculated = true
     }
     
     private func makeOperationStackView() {
@@ -167,14 +160,9 @@ class ViewController: UIViewController {
         return label
     }
     
-    private func scrollTobottom() {
-        scrollView.layoutIfNeeded()
-        scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.height),
-                                    animated: false)
-    }
 }
 
-extension ViewController {
+private extension CalculatorViewController {
     private func resetInputNumber() {
         inputNumber = Text.noValue
     }
@@ -185,5 +173,21 @@ extension ViewController {
     
     private func resetRawFormula() {
         rawFormula = []
+    }
+    
+    private func addFormula() {
+        guard let`operator` = operatorLabel.text,
+              let operand = operandLabel.text else {
+            return
+        }
+        
+        rawFormula.append(`operator`)
+        rawFormula.append(operand)
+    }
+    
+    private func scrollTobottom() {
+        scrollView.layoutIfNeeded()
+        scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.height),
+                                    animated: false)
     }
 }

--- a/Calculator/Calculator/Conrtroller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Conrtroller/CalculatorViewController.swift
@@ -36,6 +36,39 @@ class CalculatorViewController: UIViewController {
         }
     }
     
+    private var makeStackView: UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.spacing = 8
+        
+        return stackView
+    }
+    
+    private var makeOperatorLabel: UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = operatorLabel.text
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        
+        return label
+    }
+    
+    private var makeOperandLabel: UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = operandLabel.text
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultHigh , for: .horizontal)
+        
+        return label
+    }
+    
     @IBAction private func touchUpNumberButton(_ sender: UIButton) {
         guard let number = sender.titleLabel?.text else { return }
         
@@ -53,7 +86,7 @@ class CalculatorViewController: UIViewController {
     
     @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
         if isCalculated {
-            makeOperationStackView()
+            addStackView()
             addFormula()
             resetInputNumber()
             isCalculated = false
@@ -72,7 +105,7 @@ class CalculatorViewController: UIViewController {
         }
         
         addFormula()
-        makeOperationStackView()
+        addStackView()
         scrollTobottom()
         resetInputNumber()
         operatorLabel.text = sender.titleLabel?.text
@@ -104,7 +137,7 @@ class CalculatorViewController: UIViewController {
         guard !isCalculated else { return }
         
         addFormula()
-        makeOperationStackView()
+        addStackView()
         scrollTobottom()
         resetInputNumber()
         resetOperatorLabel()
@@ -122,44 +155,6 @@ class CalculatorViewController: UIViewController {
         
         isCalculated = true
     }
-    
-    private func makeOperationStackView() {
-        let operationStackView = UIStackView()
-        operationStackView.axis = .horizontal
-        operationStackView.translatesAutoresizingMaskIntoConstraints = false
-        operationStackView.distribution = .fill
-        operationStackView.alignment = .fill
-        operationStackView.spacing = 8
-        
-        operationStackView.addArrangedSubview(makeOperatorLabel())
-        operationStackView.addArrangedSubview(makeOperandLabel())
-        
-        showingOperationsStackView.insertArrangedSubview(operationStackView,
-                                                         at: showingOperationsStackView.arrangedSubviews.count)
-    }
-    
-    private func makeOperatorLabel() -> UILabel {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = operatorLabel.text
-        label.textColor = .white
-        label.font = UIFont.preferredFont(forTextStyle: .title3)
-        
-        return label
-    }
-    
-    private func makeOperandLabel() -> UILabel {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = operandLabel.text
-        label.textColor = .white
-        label.font = UIFont.preferredFont(forTextStyle: .title3)
-        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        label.setContentCompressionResistancePriority(.defaultHigh , for: .horizontal)
-        
-        return label
-    }
-    
 }
 
 private extension CalculatorViewController {
@@ -183,6 +178,16 @@ private extension CalculatorViewController {
         
         rawFormula.append(`operator`)
         rawFormula.append(operand)
+    }
+    
+    private func addStackView() {
+        let stackView = makeStackView
+
+        stackView.addArrangedSubview(makeOperatorLabel)
+        stackView.addArrangedSubview(makeOperandLabel)
+        
+        showingOperationsStackView.insertArrangedSubview(stackView,
+                                                         at: showingOperationsStackView.arrangedSubviews.count)
     }
     
     private func scrollTobottom() {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -11,6 +11,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var modifiableOperatorLabel: UILabel!
     @IBOutlet weak var overallOperationLabelStackView: UIStackView!
     
+    var overallOperation: String = ""
+    var result: Double = 0.0
     var operand: String = "" {
         willSet {
             guard newValue != "" && newValue != "-" else {
@@ -47,7 +49,7 @@ class ViewController: UIViewController {
             modifiableOperatorLabel.text = sender.titleLabel?.text
             return
         }
-        
+        collecOperation()
         MakeOperationStackView()
         operand = ""
         modifiableOperatorLabel.text = sender.titleLabel?.text
@@ -69,6 +71,35 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
         // 이전 라벨 텍스트들까지 지우는 방식으로 변경
+    }
+    
+    @IBAction func touchUpEqualSignButton(_ sender: UIButton) {
+        guard modifiableOperandLabel.text != String(result) else { return }
+        collecOperation()
+        MakeOperationStackView()
+        operand = ""
+        
+        do {
+            var formula = ExpressionParser.parse(from: overallOperation)
+            result = try formula.result()
+            modifiableOperandLabel.text = String(result)
+        } catch CalculatorError.divideByZeroError {
+            modifiableOperandLabel.text = "NaN"
+        } catch {
+            modifiableOperandLabel.text = "Error: Please retry"
+        }
+    }
+    
+    func collecOperation() {
+        guard let`operator` = modifiableOperatorLabel.text,
+              let operand = modifiableOperandLabel.text else {
+            return
+        }
+        if `operator` == " " {
+            overallOperation += ("+" + operand)
+        } else {
+            overallOperation += (`operator` + operand)
+        }
     }
     
     func MakeOperationStackView() {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -11,6 +11,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var modifiableOperatorLabel: UILabel!
     @IBOutlet weak var operationsStackView: UIStackView!    
     @IBOutlet weak var operationsScrollView: UIScrollView!
+    
     var overallOperation: String = ""
     var result: Double = 0.0
     var operand: String = "" {
@@ -19,7 +20,7 @@ class ViewController: UIViewController {
                 modifiableOperandLabel.text = "0"
                 return
             }
-            
+        
             modifiableOperandLabel.text = newValue
         }
     }
@@ -77,6 +78,7 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpEqualSignButton(_ sender: UIButton) {
         guard modifiableOperandLabel.text != String(result) else { return }
+        
         collecOperation()
         MakeOperationStackView()
         operand = ""
@@ -84,7 +86,7 @@ class ViewController: UIViewController {
         do {
             var formula = ExpressionParser.parse(from: overallOperation)
             result = try formula.result()
-            modifiableOperandLabel.text = String(result)
+            modifiableOperandLabel.text = String(changeStyle(result))
         } catch CalculatorError.divideByZeroError {
             modifiableOperandLabel.text = "NaN"
         } catch {
@@ -147,5 +149,16 @@ class ViewController: UIViewController {
         return label
     }
     
+    func changeStyle(_ operationResult: Double) -> String {
+        let numberFormatter = NumberFormatter()
+        
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = 20
+        numberFormatter.roundingMode = .up
+        
+        let result = numberFormatter.string(from: operationResult as NSNumber) ?? "0"
+        
+        return result
+    }
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
     @IBOutlet private weak var scrollView: UIScrollView!
     
     private let numberFormatter = NumberFormatter()
-    private var formula: String = ""
+    private var rawFormula: String = ""
     private var result: Double = 0.0
     private var inputNumber: String = "" {
         willSet {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -58,7 +58,7 @@ class ViewController: UIViewController {
         
         guard inputNumber.split(with: Text.dot).count <= 2,
               inputNumber != String(Text.dot) else {
-                  inputNumber = Text.noValue
+                  resetInputNumber()
                   operandLabel.text = numberFormatter.notANumberSymbol
                   return
               }
@@ -66,7 +66,7 @@ class ViewController: UIViewController {
         addFormula()
         MakeOperationStackView()
         scrollTobottom()
-        inputNumber = Text.noValue
+        resetInputNumber()
         operatorLabel.text = sender.titleLabel?.text
     }
     
@@ -81,14 +81,15 @@ class ViewController: UIViewController {
     }
     
     @IBAction private func touchUpCEButton(_ sender: UIButton) {
-        inputNumber = Text.noValue
+        resetInputNumber()
+        resetOperatorLabel()
     }
     
     @IBAction private func touchUpACButton(_ sender: UIButton) {
-        showingOperationsStackView.subviews.forEach { $0.removeFromSuperview() }
-        rawFormula = Text.noValue
-        inputNumber = Text.noValue
-        operatorLabel.text = Text.blank
+        showingOperationsStackView.removeSubViewAll()
+        resetRawFormula()
+        resetInputNumber()
+        resetOperatorLabel()
     }
     
     @IBAction private func touchUpResultButton(_ sender: UIButton) {
@@ -97,8 +98,8 @@ class ViewController: UIViewController {
         addFormula()
         MakeOperationStackView()
         scrollTobottom()
-        inputNumber = Text.noValue
-        operatorLabel.text = Text.blank
+        resetInputNumber()
+        resetOperatorLabel()
        
         do {
             var formulaQueue = ExpressionParser.parse(from: rawFormula)
@@ -165,5 +166,19 @@ class ViewController: UIViewController {
         scrollView.layoutIfNeeded()
         scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.height),
                                     animated: false)
+    }
+}
+
+extension ViewController {
+    private func resetInputNumber() {
+        inputNumber = Text.noValue
+    }
+    
+    private func resetInputNumber() {
+        operatorLabel.text = Text.blank
+    }
+    
+    private func resetRawFormula() {
+        rawFormula = Text.noValue
     }
 }

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -70,7 +70,10 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
-        // 이전 라벨 텍스트들까지 지우는 방식으로 변경
+        overallOperationLabelStackView.subviews.forEach { $0.removeFromSuperview() }
+        overallOperation = ""
+        operand = ""
+        modifiableOperatorLabel.text = " "
     }
     
     @IBAction func touchUpEqualSignButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -50,6 +50,13 @@ class ViewController: UIViewController {
             return
         }
         
+        guard inputNumber.split(with: ".").count <= 2,
+              inputNumber != "." else {
+            inputNumber = noValue
+            operandLabel.text = numberFormatter.notANumberSymbol
+            return
+        }
+        
         addFormula()
         MakeOperationStackView()
         scrollTobottom()
@@ -80,12 +87,13 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpResultButton(_ sender: UIButton) {
         guard operandLabel.text != changeStyle(result) else { return }
-        
+
         addFormula()
         MakeOperationStackView()
+        scrollTobottom()
         inputNumber = noValue
         operatorLabel.text = blank
-        
+       
         do {
             var formulaQueue = ExpressionParser.parse(from: formula)
             result = try formulaQueue.result()

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -77,7 +77,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpResultButton(_ sender: UIButton) {
-        guard operandLabel.text != String(result) else { return }
+        guard operandLabel.text != changeStyle(result) else { return }
         
         addFormula()
         MakeOperationStackView()

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -104,22 +104,17 @@ class ViewController: UIViewController {
     }
     
     func MakeOperationStackView() {
-        let operationStackView = makeOperationStackVie()
+        let operationStackView = UIStackView()
+        operationStackView.axis = .horizontal
+        operationStackView.translatesAutoresizingMaskIntoConstraints = false
+        operationStackView.distribution = .fill
+        operationStackView.alignment = .fill
+        operationStackView.spacing = 8
+        
         operationStackView.addArrangedSubview(makeOperatorLabel())
         operationStackView.addArrangedSubview(makeOperandLabel())
-
-        overallOperationLabelStackView.insertArrangedSubview(operationStackView,at: overallOperationLabelStackView.arrangedSubviews.count)
-    }
-    
-    func makeOperationStackVie() -> UIStackView {
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.distribution = .fill
-        stackView.alignment = .fill
-        stackView.spacing = 8
         
-        return stackView
+        overallOperationLabelStackView.insertArrangedSubview(operationStackView,at: overallOperationLabelStackView.arrangedSubviews.count)
     }
     
     func makeOperandLabel() -> UILabel {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -7,17 +7,18 @@
 import UIKit
 
 class ViewController: UIViewController {
-    @IBOutlet weak var operandLabel: UILabel!
-    @IBOutlet weak var operatorLabel: UILabel!
+    @IBOutlet weak var modifiableOperandLabel: UILabel!
+    @IBOutlet weak var modifiableOperatorLabel: UILabel!
+    @IBOutlet weak var overallOperationLabelStackView: UIStackView!
     
-    var operandItem: String = "" {
+    var operand: String = "" {
         willSet {
             guard newValue != "" && newValue != "-" else {
-                operandLabel.text = "0"
+                modifiableOperandLabel.text = "0"
                 return
             }
             
-            operandLabel.text = newValue
+            modifiableOperandLabel.text = newValue
         }
     }
     
@@ -31,36 +32,85 @@ class ViewController: UIViewController {
         
         switch number {
         case "0", "00":
-            guard operandItem != "0" else { return }
+            guard operand != "0" else { return }
         default:
-            if operandItem == "0" {
-                operandItem.removeFirst()
+            if operand == "0" {
+                operand.removeFirst()
             }
         }
         
-        operandItem += number
+        operand += number
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
-        operatorLabel.text = sender.titleLabel?.text
+        guard operand != "" else {
+            modifiableOperatorLabel.text = sender.titleLabel?.text
+            return
+        }
+        
+        MakeOperationStackView()
+        operand = ""
+        modifiableOperatorLabel.text = sender.titleLabel?.text
     }
     
     @IBAction func touchUpPositiveNegativeNumberButton() {
-        guard operandItem != "" else { return }
+        guard operand != "" else { return }
         
-        if operandItem.prefix(1) == "-" {
-            operandItem.removeFirst()
+        if operand.prefix(1) == "-" {
+            operand.removeFirst()
         } else {
-            operandItem.insert("-", at: operandItem.startIndex)
+            operand.insert("-", at: operand.startIndex)
         }
     }
     
     @IBAction func touchUpCEButton(_ sender: UIButton) {
-        operandItem = ""
+        operand = ""
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
         // 이전 라벨 텍스트들까지 지우는 방식으로 변경
     }
+    
+    func MakeOperationStackView() {
+        let operationStackView = makeOperationStackVie()
+        operationStackView.addArrangedSubview(makeOperatorLabel())
+        operationStackView.addArrangedSubview(makeOperandLabel())
+
+        overallOperationLabelStackView.insertArrangedSubview(operationStackView,at: overallOperationLabelStackView.arrangedSubviews.count)
+    }
+    
+    func makeOperationStackVie() -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.spacing = 8
+        
+        return stackView
+    }
+    
+    func makeOperandLabel() -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = modifiableOperandLabel.text
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultHigh , for: .horizontal)
+        
+        return label
+    }
+    
+    func makeOperatorLabel() -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = modifiableOperatorLabel.text
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        
+        return label
+    }
+    
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -9,14 +9,14 @@ import UIKit
 class ViewController: UIViewController {
     @IBOutlet weak var operandLabel: UILabel!
     @IBOutlet weak var operatorLabel: UILabel!
-
+    
     var operandItem: String = "" {
         willSet {
-            guard newValue != "" else {
+            guard newValue != "" && newValue != "-" else {
                 operandLabel.text = "0"
                 return
             }
-
+            
             operandLabel.text = newValue
         }
     }
@@ -43,6 +43,25 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
         operatorLabel.text = sender.titleLabel?.text
+    }
+    
+    @IBAction func touchUpPositiveNegativeNumberButton() {
+        guard operandItem != "" else { return }
+        
+        if operandItem.prefix(1) == "-" {
+            operandItem.removeFirst()
+        } else {
+            operandItem.insert("-", at: operandItem.startIndex)
+        }
+    }
+    
+    @IBAction func touchUpCEButton(_ sender: UIButton) {
+        guard operandItem != "" else { return }
+        operandItem.removeLast()
+    }
+    
+    @IBAction func touchUpACButton(_ sender: UIButton) {
+        operandItem = ""
     }
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -7,10 +7,42 @@
 import UIKit
 
 class ViewController: UIViewController {
+    @IBOutlet weak var operandLabel: UILabel!
+    @IBOutlet weak var operatorLabel: UILabel!
 
+    var operandItem: String = "" {
+        willSet {
+            guard newValue != "" else {
+                operandLabel.text = "0"
+                return
+            }
+
+            operandLabel.text = newValue
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+    }
+    
+    @IBAction func touchUpNumberButton(_ sender: UIButton) {
+        guard let number = sender.titleLabel?.text else { return }
+        
+        switch number {
+        case "0", "00":
+            guard operandItem != "0" else { return }
+        default:
+            if operandItem == "0" {
+                operandItem.removeFirst()
+            }
+            
+            operandItem += number
+        }
+    }
+    
+    @IBAction func touchUpOperatorButton(_ sender: UIButton) {
+        operatorLabel.text = sender.titleLabel?.text
     }
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 struct Text {
     fileprivate static let zero: String = "0"
     fileprivate static let noValue: String = ""
-    fileprivate static let blank: String = " "
     fileprivate static let negativeSymbol: String = "-"
     fileprivate static let dot: Character = "."
 }
@@ -21,7 +20,7 @@ class ViewController: UIViewController {
     @IBOutlet private weak var scrollView: UIScrollView!
     
     private let numberFormatter = NumberFormatter()
-    private var rawFormula: String = ""
+    private var rawFormula: [String] = []
     private var result: Double = 0.0
     private var inputNumber: String = "" {
         willSet {
@@ -31,7 +30,7 @@ class ViewController: UIViewController {
                 return
             }
             
-            operandLabel.text = newValue
+        operandLabel.text = newValue
         }
     }
     
@@ -82,7 +81,6 @@ class ViewController: UIViewController {
     
     @IBAction private func touchUpCEButton(_ sender: UIButton) {
         resetInputNumber()
-        resetOperatorLabel()
     }
     
     @IBAction private func touchUpACButton(_ sender: UIButton) {
@@ -100,9 +98,9 @@ class ViewController: UIViewController {
         scrollTobottom()
         resetInputNumber()
         resetOperatorLabel()
-       
+        
         do {
-            var formulaQueue = ExpressionParser.parse(from: rawFormula)
+            var formulaQueue = ExpressionParser.parse(from: rawFormula.joined(separator: " "))
             result = try formulaQueue.result()
             operandLabel.text = String(result.changeToDemical)
         } catch CalculatorError.divideByZeroError {
@@ -117,12 +115,8 @@ class ViewController: UIViewController {
               let operand = operandLabel.text else {
             return
         }
-        
-        if `operator` == Text.blank {
-            rawFormula += (String(Operator.add.rawValue) + operand)
-        } else {
-            rawFormula += (`operator` + operand)
-        }
+        rawFormula.append(`operator`)
+        rawFormula.append(operand)
     }
     
     private func MakeOperationStackView() {
@@ -175,10 +169,10 @@ extension ViewController {
     }
     
     private func resetOperatorLabel() {
-        operatorLabel.text = Text.blank
+        operatorLabel.text = Text.noValue
     }
     
     private func resetRawFormula() {
-        rawFormula = Text.noValue
+        rawFormula = []
     }
 }

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -22,6 +22,7 @@ class ViewController: UIViewController {
     private let numberFormatter = NumberFormatter()
     private var rawFormula: [String] = []
     private var result: Double = 0.0
+    private var isCalculated: Bool = false
     private var inputNumber: String = "" {
         willSet {
             guard newValue != Text.noValue,
@@ -50,6 +51,13 @@ class ViewController: UIViewController {
     }
     
     @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
+        if isCalculated {
+            makeOperationStackView()
+            addFormula()
+            resetInputNumber()
+            isCalculated = false
+        }
+        
         guard inputNumber != Text.noValue else {
             operatorLabel.text = sender.titleLabel?.text
             return
@@ -63,7 +71,7 @@ class ViewController: UIViewController {
               }
         
         addFormula()
-        MakeOperationStackView()
+        makeOperationStackView()
         scrollTobottom()
         resetInputNumber()
         operatorLabel.text = sender.titleLabel?.text
@@ -94,7 +102,7 @@ class ViewController: UIViewController {
         guard operandLabel.text != result.changeToDemical else { return }
 
         addFormula()
-        MakeOperationStackView()
+        makeOperationStackView()
         scrollTobottom()
         resetInputNumber()
         resetOperatorLabel()
@@ -103,6 +111,8 @@ class ViewController: UIViewController {
             var formulaQueue = ExpressionParser.parse(from: rawFormula.joined(separator: " "))
             result = try formulaQueue.result()
             operandLabel.text = String(result.changeToDemical)
+            isCalculated = true
+            resetRawFormula()
         } catch CalculatorError.divideByZeroError {
             operandLabel.text = numberFormatter.notANumberSymbol
         } catch {
@@ -115,11 +125,12 @@ class ViewController: UIViewController {
               let operand = operandLabel.text else {
             return
         }
+        
         rawFormula.append(`operator`)
         rawFormula.append(operand)
     }
     
-    private func MakeOperationStackView() {
+    private func makeOperationStackView() {
         let operationStackView = UIStackView()
         operationStackView.axis = .horizontal
         operationStackView.translatesAutoresizingMaskIntoConstraints = false

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -6,6 +6,14 @@
 
 import UIKit
 
+struct Text {
+    fileprivate static let zero: String = "0"
+    fileprivate static let noValue: String = ""
+    fileprivate static let blank: String = " "
+    fileprivate static let negativeSymbol: String = "-"
+    fileprivate static let dot: Character = "."
+}
+
 class ViewController: UIViewController {
     @IBOutlet private weak var operandLabel: UILabel!
     @IBOutlet private weak var operatorLabel: UILabel!
@@ -13,15 +21,13 @@ class ViewController: UIViewController {
     @IBOutlet private weak var scrollView: UIScrollView!
     
     private let numberFormatter = NumberFormatter()
-    private let zero = "0"
-    private let noValue = ""
-    private let blank = " "
     private var formula: String = ""
     private var result: Double = 0.0
     private var inputNumber: String = "" {
         willSet {
-            guard newValue != noValue, newValue != "-" else {
-                operandLabel.text = zero
+            guard newValue != Text.noValue,
+                  newValue != Text.negativeSymbol else {
+                operandLabel.text = Text.zero
                 return
             }
             
@@ -34,9 +40,9 @@ class ViewController: UIViewController {
         
         switch number {
         case "0", "00":
-            guard inputNumber != zero else { return }
+            guard inputNumber != Text.zero else { return }
         default:
-            if inputNumber == zero {
+            if inputNumber == Text.zero {
                 inputNumber.removeFirst()
             }
         }
@@ -45,44 +51,44 @@ class ViewController: UIViewController {
     }
     
     @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
-        guard inputNumber != noValue else {
+        guard inputNumber != Text.noValue else {
             operatorLabel.text = sender.titleLabel?.text
             return
         }
         
-        guard inputNumber.split(with: ".").count <= 2,
-              inputNumber != "." else {
-            inputNumber = noValue
-            operandLabel.text = numberFormatter.notANumberSymbol
-            return
-        }
+        guard inputNumber.split(with: Text.dot).count <= 2,
+              inputNumber != String(Text.dot) else {
+                  inputNumber = Text.noValue
+                  operandLabel.text = numberFormatter.notANumberSymbol
+                  return
+              }
         
         addFormula()
         MakeOperationStackView()
         scrollTobottom()
-        inputNumber = noValue
+        inputNumber = Text.noValue
         operatorLabel.text = sender.titleLabel?.text
     }
     
     @IBAction private func touchUpConvertingPositiveNegativeButton() {
-        guard inputNumber != zero else { return }
+        guard inputNumber != Text.zero else { return }
     
-        if inputNumber.prefix(1) == "-" {
+        if inputNumber.prefix(1) == Text.negativeSymbol {
             inputNumber.removeFirst()
         } else {
-            inputNumber.insert("-", at: inputNumber.startIndex)
+            inputNumber.insert(contentsOf: Text.negativeSymbol, at: inputNumber.startIndex)
         }
     }
     
     @IBAction private func touchUpCEButton(_ sender: UIButton) {
-        inputNumber = noValue
+        inputNumber = Text.noValue
     }
     
     @IBAction private func touchUpACButton(_ sender: UIButton) {
         showingOperationsStackView.subviews.forEach { $0.removeFromSuperview() }
-        formula = noValue
-        inputNumber = noValue
-        operatorLabel.text = blank
+        formula = Text.noValue
+        inputNumber = Text.noValue
+        operatorLabel.text = Text.blank
     }
     
     @IBAction private func touchUpResultButton(_ sender: UIButton) {
@@ -91,8 +97,8 @@ class ViewController: UIViewController {
         addFormula()
         MakeOperationStackView()
         scrollTobottom()
-        inputNumber = noValue
-        operatorLabel.text = blank
+        inputNumber = Text.noValue
+        operatorLabel.text = Text.blank
        
         do {
             var formulaQueue = ExpressionParser.parse(from: formula)
@@ -111,8 +117,8 @@ class ViewController: UIViewController {
             return
         }
         
-        if `operator` == blank {
-            formula += ("+" + operand)
+        if `operator` == Text.blank {
+            formula += (String(Operator.add.rawValue) + operand)
         } else {
             formula += (`operator` + operand)
         }
@@ -166,7 +172,7 @@ class ViewController: UIViewController {
         numberFormatter.maximumSignificantDigits = 20
         numberFormatter.roundingMode = .up
         
-        let result = numberFormatter.string(from: operationResult as NSNumber) ?? zero
+        let result = numberFormatter.string(from: operationResult as NSNumber) ?? Text.zero
         
         return result
     }

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController {
     private var result: Double = 0.0
     private var inputNumber: String = "" {
         willSet {
-            guard newValue != noValue else {
+            guard newValue != noValue, newValue != "-" else {
                 operandLabel.text = zero
                 return
             }
@@ -58,6 +58,8 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpConvertingPositiveNegativeButton() {
+        guard inputNumber != zero else { return }
+    
         if inputNumber.prefix(1) == "-" {
             inputNumber.removeFirst()
         } else {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -7,10 +7,10 @@
 import UIKit
 
 class ViewController: UIViewController {
-    @IBOutlet weak var operandLabel: UILabel!
-    @IBOutlet weak var operatorLabel: UILabel!
-    @IBOutlet weak var showingOperationsStackView: UIStackView!    
-    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet private weak var operandLabel: UILabel!
+    @IBOutlet private weak var operatorLabel: UILabel!
+    @IBOutlet private weak var showingOperationsStackView: UIStackView!
+    @IBOutlet private weak var scrollView: UIScrollView!
     
     private let numberFormatter = NumberFormatter()
     private let zero = "0"
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpNumberButton(_ sender: UIButton) {
+    @IBAction private func touchUpNumberButton(_ sender: UIButton) {
         guard let number = sender.titleLabel?.text else { return }
         
         switch number {
@@ -44,7 +44,7 @@ class ViewController: UIViewController {
         inputNumber += number
     }
     
-    @IBAction func touchUpOperatorButton(_ sender: UIButton) {
+    @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
         guard inputNumber != noValue else {
             operatorLabel.text = sender.titleLabel?.text
             return
@@ -64,7 +64,7 @@ class ViewController: UIViewController {
         operatorLabel.text = sender.titleLabel?.text
     }
     
-    @IBAction func touchUpConvertingPositiveNegativeButton() {
+    @IBAction private func touchUpConvertingPositiveNegativeButton() {
         guard inputNumber != zero else { return }
     
         if inputNumber.prefix(1) == "-" {
@@ -74,18 +74,18 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpCEButton(_ sender: UIButton) {
+    @IBAction private func touchUpCEButton(_ sender: UIButton) {
         inputNumber = noValue
     }
     
-    @IBAction func touchUpACButton(_ sender: UIButton) {
+    @IBAction private func touchUpACButton(_ sender: UIButton) {
         showingOperationsStackView.subviews.forEach { $0.removeFromSuperview() }
         formula = noValue
         inputNumber = noValue
         operatorLabel.text = blank
     }
     
-    @IBAction func touchUpResultButton(_ sender: UIButton) {
+    @IBAction private func touchUpResultButton(_ sender: UIButton) {
         guard operandLabel.text != changeStyle(result) else { return }
 
         addFormula()

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -174,7 +174,7 @@ extension ViewController {
         inputNumber = Text.noValue
     }
     
-    private func resetInputNumber() {
+    private func resetOperatorLabel() {
         operatorLabel.text = Text.blank
     }
     

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -115,8 +115,6 @@ class ViewController: UIViewController {
         operationStackView.alignment = .fill
         operationStackView.spacing = 8
         
-        let operatorLabel = makeOperatorLabel()
-        
         operationStackView.addArrangedSubview(operatorLabel)
         operationStackView.addArrangedSubview(makeOperandLabel())
         

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -86,7 +86,7 @@ class ViewController: UIViewController {
     
     @IBAction private func touchUpACButton(_ sender: UIButton) {
         showingOperationsStackView.subviews.forEach { $0.removeFromSuperview() }
-        formula = Text.noValue
+        rawFormula = Text.noValue
         inputNumber = Text.noValue
         operatorLabel.text = Text.blank
     }
@@ -101,7 +101,7 @@ class ViewController: UIViewController {
         operatorLabel.text = Text.blank
        
         do {
-            var formulaQueue = ExpressionParser.parse(from: formula)
+            var formulaQueue = ExpressionParser.parse(from: rawFormula)
             result = try formulaQueue.result()
             operandLabel.text = String(result.changeToDemical)
         } catch CalculatorError.divideByZeroError {
@@ -118,9 +118,9 @@ class ViewController: UIViewController {
         }
         
         if `operator` == Text.blank {
-            formula += (String(Operator.add.rawValue) + operand)
+            rawFormula += (String(Operator.add.rawValue) + operand)
         } else {
-            formula += (`operator` + operand)
+            rawFormula += (`operator` + operand)
         }
     }
     

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
     var result: Double = 0.0
     var operand: String = "" {
         willSet {
-            guard newValue != "" && newValue != "-" else {
+            guard newValue != "" else {
                 modifiableOperandLabel.text = "0"
                 return
             }
@@ -56,8 +56,6 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpPositiveNegativeNumberButton() {
-        guard operand != "" else { return }
-        
         if operand.prefix(1) == "-" {
             operand.removeFirst()
         } else {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -92,7 +92,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction private func touchUpResultButton(_ sender: UIButton) {
-        guard operandLabel.text != changeStyle(result) else { return }
+        guard operandLabel.text != result.changeToDemical else { return }
 
         addFormula()
         MakeOperationStackView()
@@ -103,7 +103,7 @@ class ViewController: UIViewController {
         do {
             var formulaQueue = ExpressionParser.parse(from: formula)
             result = try formulaQueue.result()
-            operandLabel.text = String(changeStyle(result))
+            operandLabel.text = String(result.changeToDemical)
         } catch CalculatorError.divideByZeroError {
             operandLabel.text = numberFormatter.notANumberSymbol
         } catch {
@@ -165,15 +165,5 @@ class ViewController: UIViewController {
         scrollView.layoutIfNeeded()
         scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.height),
                                     animated: false)
-    }
-    
-    private func changeStyle(_ operationResult: Double) -> String {
-        numberFormatter.numberStyle = .decimal
-        numberFormatter.maximumSignificantDigits = 20
-        numberFormatter.roundingMode = .up
-        
-        let result = numberFormatter.string(from: operationResult as NSNumber) ?? Text.zero
-        
-        return result
     }
 }

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -9,8 +9,8 @@ import UIKit
 class ViewController: UIViewController {
     @IBOutlet weak var modifiableOperandLabel: UILabel!
     @IBOutlet weak var modifiableOperatorLabel: UILabel!
-    @IBOutlet weak var overallOperationLabelStackView: UIStackView!
-    
+    @IBOutlet weak var operationsStackView: UIStackView!    
+    @IBOutlet weak var operationsScrollView: UIScrollView!
     var overallOperation: String = ""
     var result: Double = 0.0
     var operand: String = "" {
@@ -51,6 +51,7 @@ class ViewController: UIViewController {
         }
         collecOperation()
         MakeOperationStackView()
+        scrollTobottom()
         operand = ""
         modifiableOperatorLabel.text = sender.titleLabel?.text
     }
@@ -68,7 +69,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
-        overallOperationLabelStackView.subviews.forEach { $0.removeFromSuperview() }
+        operationsStackView.subviews.forEach { $0.removeFromSuperview() }
         overallOperation = ""
         operand = ""
         modifiableOperatorLabel.text = " "
@@ -111,10 +112,17 @@ class ViewController: UIViewController {
         operationStackView.alignment = .fill
         operationStackView.spacing = 8
         
-        operationStackView.addArrangedSubview(makeOperatorLabel())
+        let operatorLabel = makeOperatorLabel()
+        
+        operationStackView.addArrangedSubview(operatorLabel)
         operationStackView.addArrangedSubview(makeOperandLabel())
         
-        overallOperationLabelStackView.insertArrangedSubview(operationStackView,at: overallOperationLabelStackView.arrangedSubviews.count)
+        operationsStackView.insertArrangedSubview(operationStackView,at: operationsStackView.arrangedSubviews.count)
+    }
+    
+    func scrollTobottom() {
+        operationsScrollView.layoutIfNeeded()
+        operationsScrollView.setContentOffset(CGPoint(x: 0, y: operationsScrollView.contentSize.height - operationsScrollView.bounds.height), animated: false)
     }
     
     func makeOperandLabel() -> UILabel {

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -115,11 +115,21 @@ class ViewController: UIViewController {
         operationStackView.alignment = .fill
         operationStackView.spacing = 8
         
-        operationStackView.addArrangedSubview(operatorLabel)
+        operationStackView.addArrangedSubview(makeOperatorLabel())
         operationStackView.addArrangedSubview(makeOperandLabel())
         
         showingOperationsStackView.insertArrangedSubview(operationStackView,
                                                          at: showingOperationsStackView.arrangedSubviews.count)
+    }
+    
+    private func makeOperatorLabel() -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = operatorLabel.text
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        
+        return label
     }
     
     private func makeOperandLabel() -> UILabel {
@@ -130,16 +140,6 @@ class ViewController: UIViewController {
         label.font = UIFont.preferredFont(forTextStyle: .title3)
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         label.setContentCompressionResistancePriority(.defaultHigh , for: .horizontal)
-        
-        return label
-    }
-    
-    private func makeOperatorLabel() -> UILabel {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = operatorLabel.text
-        label.textColor = .white
-        label.font = UIFont.preferredFont(forTextStyle: .title3)
         
         return label
     }

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -36,9 +36,9 @@ class ViewController: UIViewController {
             if operandItem == "0" {
                 operandItem.removeFirst()
             }
-            
-            operandItem += number
         }
+        
+        operandItem += number
     }
     
     @IBAction func touchUpOperatorButton(_ sender: UIButton) {
@@ -56,12 +56,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpCEButton(_ sender: UIButton) {
-        guard operandItem != "" else { return }
-        operandItem.removeLast()
+        operandItem = ""
     }
     
     @IBAction func touchUpACButton(_ sender: UIButton) {
-        operandItem = ""
+        // 이전 라벨 텍스트들까지 지우는 방식으로 변경
     }
 }
 

--- a/Calculator/Calculator/Conrtroller/ViewController.swift
+++ b/Calculator/Calculator/Conrtroller/ViewController.swift
@@ -84,6 +84,7 @@ class ViewController: UIViewController {
         addFormula()
         MakeOperationStackView()
         inputNumber = noValue
+        operatorLabel.text = blank
         
         do {
             var formulaQueue = ExpressionParser.parse(from: formula)

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum ExpressionParser {
-    static func parse(from input: String) throws -> Formula {
+    static func parse(from input: String) -> Formula {
         var formula = Formula()
         let operands = componentsByOperators(from: input)
         let operators = input.compactMap { Operator.init(rawValue: $0) }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -10,28 +10,20 @@ import Foundation
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
         var formula = Formula()
-        let operands = componentsByOperators(from: input)
-        let operators = input.compactMap { Operator.init(rawValue: $0) }
-        
-        operands.compactMap { Double($0) }.forEach { formula.operands.enqueue($0) }
-        operators.forEach { formula.operators.enqueue($0) }
     
-        return formula
-    }
-
-    private static func componentsByOperators(from input: String) -> [String] {
-        var input = [input]
-        var result: [String] = []
-        
-        Operator.allCases.forEach {
-            result = []
-            while !input.isEmpty {
-                result.append(contentsOf: input.removeFirst().split(with: $0.rawValue))
-            }
-            
-            input = result
+        componentsByOperator(from: input).compactMap{ Double($0) }.forEach {
+            formula.operands.enqueue($0)
         }
         
-        return result
+        input.split(with: " ").filter { !$0.isDouble }.forEach {
+            guard let `operator` = Operator(rawValue: Character($0)) else { return }
+            formula.operators.enqueue(`operator`)
+        }
+        
+        return formula
+    }
+    
+    static private func componentsByOperator(from input: String) -> [String] {
+        return input.split(with: " ").compactMap { $0.isDouble ? $0 : nil }
     }
 }

--- a/Calculator/Calculator/Model/Extension/Double+Extension.swift
+++ b/Calculator/Calculator/Model/Extension/Double+Extension.swift
@@ -5,6 +5,19 @@
 //  Created by 써니쿠키 on 2022/09/22.
 //
 
+import Foundation
+
 extension Double: CalculateItem {
+    var changeToDemical: String {
+        let numberFormatter = NumberFormatter()
+        let twenty: Int = 20
+        
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = twenty
+        numberFormatter.roundingMode = .up
     
+        let result = numberFormatter.string(from: self as NSNumber) ?? "0"
+        
+        return result
+    }
 }

--- a/Calculator/Calculator/Model/Extension/String+Extension.swift
+++ b/Calculator/Calculator/Model/Extension/String+Extension.swift
@@ -11,6 +11,6 @@ extension String {
     }
     
     func split(with target: Character) -> [String] {
-        return self.components(separatedBy: String(target))
+        return split(separator: target).map { String($0) }
     }
 }

--- a/Calculator/Calculator/Model/Extension/String+Extension.swift
+++ b/Calculator/Calculator/Model/Extension/String+Extension.swift
@@ -6,6 +6,10 @@
 //
 
 extension String {
+    var isDouble: Bool {
+        return Double(self) != nil ? true : false
+    }
+    
     func split(with target: Character) -> [String] {
         return self.components(separatedBy: String(target))
     }

--- a/Calculator/Calculator/Model/Extension/UIStackView+Extension.swift
+++ b/Calculator/Calculator/Model/Extension/UIStackView+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  UIStackView.swift
+//  Calculator
+//
+//  Created by 맹선아 on 2022/10/03.
+//
+
+import UIKit
+
+extension UIStackView {
+    func removeSubViewAll() {
+        self.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    }
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -10,8 +10,8 @@ struct Formula {
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue()
     
     mutating func result() throws -> Double {
-        var result: Double = 0.0
-        
+        guard var result: Double = self.operands.dequeue()?.data else { throw CalculatorError.unknown }
+
         while operands.isEmpty == false {
             guard let operatorCase: Operator = self.operators.dequeue()?.data,
                   let operand: Double = self.operands.dequeue()?.data else {

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -7,9 +7,9 @@
 
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
-    case subtract = "-"
-    case divide = "/"
-    case multiply = "*"
+    case subtract = "−"
+    case divide = "÷"
+    case multiply = "×"
     
     func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Calculator View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="CalculatorViewController" customModule="Calculator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -18,22 +18,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="220.5" width="382" height="45"/>
+                                <rect key="frame" x="16" y="161.5" width="382" height="104"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="104"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Nd6-Zr-Y6e">
-                                                <rect key="frame" x="298" y="0.0" width="84" height="20.5"/>
+                                                <rect key="frame" x="256" y="0.0" width="126" height="50"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
-                                                        <rect key="frame" x="16" y="0.0" width="68" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
+                                                        <rect key="frame" x="58" y="0.0" width="68" height="50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -41,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="bottomRight" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="iC9-OM-dL7">
-                                                <rect key="frame" x="288" y="24.5" width="94" height="20.5"/>
+                                                <rect key="frame" x="246" y="54" width="136" height="50"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12345678" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
-                                                        <rect key="frame" x="16" y="0.0" width="78" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
+                                                        <rect key="frame" x="58" y="0.0" width="78" height="50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -108,7 +108,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchUpPositiveNegativeNumberButton" destination="BYZ-38-t0r" eventType="touchUpInside" id="4aR-mz-J8N"/>
+                                                    <action selector="touchUpConvertingPositiveNegativeButton" destination="BYZ-38-t0r" eventType="touchUpInside" id="4aR-mz-J8N"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
@@ -318,7 +318,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchUpEqualSignButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wQc-0x-kq9"/>
+                                                    <action selector="touchUpResultButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bO4-Wc-6jd"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -364,10 +364,10 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="modifiableOperandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
-                        <outlet property="modifiableOperatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
-                        <outlet property="operationsScrollView" destination="BOT-7g-vxv" id="Lp0-rO-aXO"/>
-                        <outlet property="operationsStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
+                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
+                        <outlet property="scrollView" destination="BOT-7g-vxv" id="Lp0-rO-aXO"/>
+                        <outlet property="showingOperationsStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -17,40 +17,40 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="181.5" width="382" height="104"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                                <rect key="frame" x="16" y="220.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="104"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Nd6-Zr-Y6e">
-                                                <rect key="frame" x="274" y="0.0" width="108" height="50"/>
+                                                <rect key="frame" x="298" y="0.0" width="84" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
-                                                        <rect key="frame" x="58" y="0.0" width="50" height="50"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
+                                                        <rect key="frame" x="16" y="0.0" width="68" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="iC9-OM-dL7">
-                                                <rect key="frame" x="225" y="54" width="157" height="50"/>
+                                            <stackView opaque="NO" contentMode="bottomRight" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="iC9-OM-dL7">
+                                                <rect key="frame" x="288" y="24.5" width="94" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
-                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
-                                                        <rect key="frame" x="58" y="0.0" width="99" height="50"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12345678" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
+                                                        <rect key="frame" x="16" y="0.0" width="78" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -63,14 +63,14 @@
                                 <constraints>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="BOT-7g-vxv" secondAttribute="height" priority="100" id="82c-Ko-nh3"/>
                                     <constraint firstItem="XRe-QE-UJf" firstAttribute="width" secondItem="BOT-7g-vxv" secondAttribute="width" id="9hO-gT-uzB"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="gA2-7M-FxF" secondAttribute="height" priority="1" id="PfX-qG-S4s"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="leading" secondItem="K6N-nC-kaV" secondAttribute="leading" id="WTo-5t-Xde"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="trailing" secondItem="K6N-nC-kaV" secondAttribute="trailing" id="bYc-Yd-kw9"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="bottom" secondItem="K6N-nC-kaV" secondAttribute="bottom" id="dlN-3y-jhh"/>
-                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="top" secondItem="K6N-nC-kaV" secondAttribute="top" id="hlo-zV-yFo"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="height" secondItem="BOT-7g-vxv" secondAttribute="height" priority="1" id="PfX-qG-S4s"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="leading" secondItem="BOT-7g-vxv" secondAttribute="leading" id="WTo-5t-Xde"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="trailing" secondItem="BOT-7g-vxv" secondAttribute="trailing" id="bYc-Yd-kw9"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="bottom" secondItem="BOT-7g-vxv" secondAttribute="bottom" id="dlN-3y-jhh"/>
+                                    <constraint firstItem="XRe-QE-UJf" firstAttribute="top" secondItem="BOT-7g-vxv" secondAttribute="top" id="hlo-zV-yFo"/>
                                 </constraints>
-                                <viewLayoutGuide key="contentLayoutGuide" id="K6N-nC-kaV"/>
-                                <viewLayoutGuide key="frameLayoutGuide" id="gA2-7M-FxF"/>
+                                <viewLayoutGuide key="contentLayoutGuide" id="ChG-0T-tYC"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="dfP-9g-zEG"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YKH-82-hZC">
                                 <rect key="frame" x="16" y="362.5" width="382" height="479.5"/>
@@ -358,7 +358,7 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="BOT-7g-vxv" secondAttribute="trailing" constant="16" id="jGA-4U-1bz"/>
                             <constraint firstItem="YKH-82-hZC" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="jKU-BN-eas"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="YKH-82-hZC" secondAttribute="bottom" constant="20" id="lPP-CN-Q7m"/>
-                            <constraint firstItem="DC3-Ia-6L7" firstAttribute="top" secondItem="BOT-7g-vxv" secondAttribute="bottom" constant="20" id="mfk-MI-h75"/>
+                            <constraint firstItem="DC3-Ia-6L7" firstAttribute="top" secondItem="BOT-7g-vxv" secondAttribute="bottom" constant="40" id="mfk-MI-h75"/>
                             <constraint firstItem="BOT-7g-vxv" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="qyL-Qq-yAo"/>
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
@@ -366,7 +366,8 @@
                     <connections>
                         <outlet property="modifiableOperandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
                         <outlet property="modifiableOperatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
-                        <outlet property="overallOperationLabelStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
+                        <outlet property="operationsScrollView" destination="BOT-7g-vxv" id="Lp0-rO-aXO"/>
+                        <outlet property="operationsStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -361,8 +361,9 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
-                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
+                        <outlet property="modifiableOperandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
+                        <outlet property="modifiableOperatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
+                        <outlet property="overallOperationLabelStackView" destination="XRe-QE-UJf" id="NJN-Q8-Ioi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -17,11 +17,47 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="227.5" width="382" height="45"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                                <rect key="frame" x="16" y="181.5" width="382" height="104"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="104"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Nd6-Zr-Y6e">
+                                                <rect key="frame" x="274" y="0.0" width="108" height="50"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vs2-Cn-oDq">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlG-ma-uLP">
+                                                        <rect key="frame" x="58" y="0.0" width="50" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="iC9-OM-dL7">
+                                                <rect key="frame" x="225" y="54" width="157" height="50"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="beM-R2-Wwe">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a6a-gR-hWj">
+                                                        <rect key="frame" x="58" y="0.0" width="99" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
                                     </stackView>
                                 </subviews>
                                 <constraints>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="161.5" width="382" height="104"/>
+                                <rect key="frame" x="16" y="148.5" width="382" height="104"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="104"/>
@@ -326,19 +326,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
+                                <rect key="frame" x="16" y="292.5" width="382" height="50"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text=" " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="7" height="37"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="15" y="0.0" width="367" height="37"/>
+                                                <rect key="frame" x="58" y="0.0" width="324" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -17,47 +17,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
                                 <rect key="frame" x="16" y="227.5" width="382" height="45"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -317,25 +281,28 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpEqualSignButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wQc-0x-kq9"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="292.5" width="382" height="50"/>
+                                <rect key="frame" x="16" y="305.5" width="382" height="37"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="37"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text=" " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
+                                                <rect key="frame" x="0.0" y="0.0" width="7" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="58" y="0.0" width="324" height="50"/>
+                                                <rect key="frame" x="15" y="0.0" width="367" height="37"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,22 +18,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="227.5" width="382" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="0.0" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -40,16 +41,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                                <rect key="frame" x="267" y="24.5" width="115" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="8" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -108,6 +109,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QwN-tc-RvH"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -121,6 +125,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bIj-Xl-eRR"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -129,6 +136,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MrC-2l-gwz"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -137,6 +147,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="U1l-6v-ssL"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -145,6 +158,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fhO-5F-PYX"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -158,6 +174,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hUg-8p-itl"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -166,6 +185,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="baq-1t-qt3"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -174,6 +196,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zm5-jZ-a6j"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -182,6 +207,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AZP-5e-yWb"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -195,6 +223,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QFs-A4-yjB"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -203,6 +234,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mwc-dO-6Lc"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -211,6 +245,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2vz-u0-DSr"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -219,6 +256,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOperatorButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="y9S-46-2Ga"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -232,6 +272,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MYq-Ty-a5J"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -240,6 +283,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="GOX-AD-Zzx"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -248,6 +294,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpNumberButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pEU-hp-lEj"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -265,19 +314,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="292.5" width="382" height="50"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
+                                                <rect key="frame" x="58" y="0.0" width="324" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -302,6 +351,10 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="Mgv-KS-xUJ"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="lXY-4E-0s5"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpACButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8kI-ZX-y9m"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -93,6 +96,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpCEButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MeW-hc-7io"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -101,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpPositiveNegativeNumberButton" destination="BYZ-38-t0r" eventType="touchUpInside" id="4aR-mz-J8N"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -9,40 +9,49 @@ import XCTest
 @testable import Calculator
 
 class ExpressionParserTests: XCTestCase {
-    var result1: [String]!
-    var result2: Formula!
-    
-    override func setUpWithError() throws {
-        result1 = [String]()
-        result2 = Formula()
-    }
-    
-    override func tearDownWithError() throws {
-        try super.setUpWithError()
-        result1 = nil
-        result2 = nil
-    }
-    
-    func test_parse_문자열을_연산자기호와숫자로나누어_Formula로반환확인() throws {
-        //given 연산자기호가 섞인 문자열을
-        let a = "1+23*456"
-        
-        //when 연산자기호와 숫자로나누어 큐에담은 formula를생성할시
-        result2 = try ExpressionParser.parse(from: a)
-    
-        //then formula의 숫자는 operands, 기호는 operators의 큐에담긴다.
-        let expectedOperand: [Double] = [1,23,456]
-        let expectedOperator: [Character] = ["+", "*"]
-        
-        XCTAssertEqual(expectedOperand[0], result2.operands.dequeue()?.data)
-        XCTAssertEqual(expectedOperand[1], result2.operands.dequeue()?.data)
-        XCTAssertEqual(expectedOperand[2], result2.operands.dequeue()?.data)
 
-        XCTAssertEqual(expectedOperator[0], result2.operators.dequeue()?.data?.rawValue)
-        XCTAssertEqual(expectedOperator[1], result2.operators.dequeue()?.data?.rawValue)
-        
-        //의도한 fail test
-        XCTAssertNotEqual(expectedOperand[0], result2.operands.dequeue()?.data)
-        XCTAssertNotEqual(expectedOperator[0], result2.operators.dequeue()?.data?.rawValue)
+    override func setUpWithError() throws { }
+    
+    override func tearDownWithError() throws { }
+    
+    func test_string값의_식의_결과값이_356일때_string내부의값을_parse하여_연산한_결과값이_356와일치하는지() {
+        let result: Double = 356
+        var parse = ExpressionParser.parse(from: "123 + 233")
+
+        XCTAssertEqual(result, try parse.result())
     }
+    
+    func test_양수234과_음수111_을_연산했을때_결과값으로_123이_나오는지(){
+        let result: Double = 123
+        var parse = ExpressionParser.parse(from: "234 + -111")
+        
+        XCTAssertEqual(result, try parse.result())
+    }
+    
+    func test_양수233과_음수111을_곱하고_음수2로나누었을때_정상적인_값이_출력되는지() {
+        let result: Double = (233 * -111) / -2
+        var parse = ExpressionParser.parse(from: "233 × -111 ÷ -2")
+        
+        XCTAssertEqual(result, try parse.result())
+        
+    }
+    
+    func test_양수123을_0으로_나누었을때_에러를_던지는지(){
+        var parse = ExpressionParser.parse(from: "123 ÷ 0")
+        
+        XCTAssertThrowsError(try parse.result())
+    }
+    
+    func test_양수123과_양수122를_더했을때_플러스가아닌_연산자가아닌_문자가_들어갔을때_에러를_던지는지(){
+        var parse = ExpressionParser.parse(from: "123 a 122")
+        
+        XCTAssertThrowsError(try parse.result())
+    }
+    
+    func test_양수200과_양수100를_더했을때_플러스가아닌_연산자가아닌_다른특수문자가_들어갔을때_에러를_던지는지(){
+        var parse = ExpressionParser.parse(from: "200 # 100")
+        
+        XCTAssertThrowsError(try parse.result())
+    }
+    
 }

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -23,22 +23,24 @@ class FormulaTests: XCTestCase {
     }
 
     func test_result() throws {
-        //give (0 + 111 - 110.99) / 10.0 * 3000  일 때
+        //give (111 - 110.99) / 10.0 * 3000  일 때
         sut.operands.enqueue(111)
-        sut.operands.enqueue(110.99)
-        sut.operands.enqueue(10.0)
-        sut.operands.enqueue(3000)
-    
-        sut.operators.enqueue(.add)
         sut.operators.enqueue(.subtract)
+        sut.operands.enqueue(110.99)
+        
         sut.operators.enqueue(.divide)
+        
+        sut.operands.enqueue(10.0)
         sut.operators.enqueue(.multiply)
+        sut.operands.enqueue(3000)
+        
+
         
         //when result 메서드 작동 시
         let result = try sut.result()
         
-        //then 값은 (0 + 111 - 110.99) / 10.0 * 3000 = 3
-        XCTAssertEqual((0 + 111 - 110.99) / 10.0 * 3000, result)
+        //then 값은 (111 - 110.99) / 10.0 * 3000 = 3
+        XCTAssertEqual((111 - 110.99) / 10.0 * 3000, result)
         
         //의도한 fail test
         XCTAssertNotEqual(4, result)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# README(4) 계산기
-
 # 계산기
 
 ## 1. ✏️ 프로젝트 소개
@@ -449,19 +447,20 @@ input.components(separatedBy: operators)
 <details>
  <summary> [해결과정 details] </summary>
         
-- 5-1 오토레이아웃의 문제인가?
+- 5-1 오토레이아웃의 문제인가? </br>
     처음엔 **오토레이아웃의 문제**인가 싶어 오토레이아웃도 뜯어살펴보았지만 문제를 찾지 못했습니다.
 
-- 5-2. 내려가지 않는 한 줄만큼 setContentOffsetd의 y축 값으로 추가
+- 5-2. 내려가지 않는 한 줄만큼 setContentOffsetd의 y축 값으로 추가 </br>
     setContentOffsetd의 y축 값을 더 내려가도록 해주면 될까 싶어서 **offSet변화량을 콘솔로 확인해서 변화량인 24큼 더 내리도록 해보았습니다** ( y = contentSize의 높이 - bounds의 높이 + **24** ) 
 
-    이렇게 할 때는 `컨텐츠높이`가 `bounds높이`보다 커질 때를 기준으로 첫번째 입력(아래GIF에서 +7때)에서 마지막줄이 안 보이고, 두번째 입력시(+8떄) 이전에 찍은 +7값과 같이 두개값이 동시에 나온 후에 세번째부터는 정상작동하는 문제가 있습니다.
-   <img width = 200, src ="https://i.imgur.com/PNj4xWk.gif">
+    이렇게 할 때는 `컨텐츠높이`가 `bounds높이`보다 커질 때를 기준으로 첫번째 입력(아래GIF에서 +7때)에서 마지막줄이 안 보이고, 두번째 입력시(+8떄) 이전에 찍은 +7값과 같이 두개값이 동시에 나온 후에 세번째부터는 정상작동하는 문제가 있습니다. </br>
+   
+    <img width = 200, src ="https://i.imgur.com/PNj4xWk.gif">
     
-- 5-3. 시간적인 duration 관련 문제인가?
+- 5-3. 시간적인 duration 관련 문제인가? </br>
     업데이트 후 스클롤링 함수를 호출하는 시간 사이에 delay가 생길까 싶어 **notification Center**사용으로 한박자 늦게 scroll을 내리는 함수를 호출해보기도 했지만 무용지물이었습니다..
     
-- 5-4. ✅ 드로잉 사이클 (drawing cycle)을 공부
+- 5-4. ✅ 드로잉 사이클 (drawing cycle)을 공부 </br>
     컨텐츠가 변하여도 다음 드로잉사이클까지 **대기 후**에 다시 view가 업데이트 되는것을 알았습니다.
     
     setNeedsDisplay 메서드를 사용하면 시스템에게 draw 메서드를 호출하도록 요청해서 다시 View를 그려주게되는데 이 과정이 바로 즉각 되는것이 아니라 다음 drawing cycle까지 기다렸다가 진행됩니다. 제 화면에서 생각해보면 내부에서 스크롤하는 함수가 호출되어 스크롤을 제일 아래로 내렸지만, 하단에 스택뷰가 추가된 완성된 레이아웃 재배치는 그 후에 이뤄지는 사이클이었기 때문에 마지막 줄이 안보이는 문제가 생겼던 것입니다.
@@ -472,8 +471,8 @@ input.components(separatedBy: operators)
     아래의 표는 스크롤뷰에 추가된 스택뷰의 갯수에 따른 컨텐츠높이, bound높이, content offset의 y축값 을 정리한 것입니다.
     표에서 확인이 가능한 것은 layoutIfNeeded를 호출하지 않고 계산기를 찍을때와 호출했을 때의 값이 한스텝씩 차이가 난다는 것입니다. 
 
-    <img width = 800, src ="https://i.imgur.com/oDgorTU.png">
-    (위 표에서 offSet을 빨간글씨는 스크롤 제일 아랫줄이 보이지 않을때를 표시한 것입니다..)
+    <img width = 800, src ="https://i.imgur.com/oDgorTU.png"> </br>
+    (위 표에서 offSet을 빨간글씨는 스크롤 제일 아랫줄이 보이지 않을때를 표시한 것입니다.)
 
     이 스텝의 차이는 위에서 설명했듯이 순서의 차이입니다. `스크롤내리기 -> 뷰 업데이트` 와 `뷰 업데이트 -> 스크롤내리기` 의 차이입니다.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+# README(4) 계산기
+
 # 계산기
+
 ## 1. ✏️ 프로젝트 소개
 계산기입니다.
 -  사칙연산 (+, -, ÷, X)이 가능합니다.
@@ -17,16 +20,40 @@
 
 ---
 
-## 3. 🔍 프로젝트 구성
+## 3. 🔍 프로젝트 구성과 실행예시
 - Class Diagram
-<img width = 1000, src = "https://i.imgur.com/6fpgIUM.png">
+<img width = 1000, src = "https://i.imgur.com/lnjKDxO.png">
+
+- 실행예시
+
+|정상작동 예시(1)|정상작동 예시(2)
+|------------|-----------|
+|  <img width = 250, src = "https://i.imgur.com/fS8rX2P.gif">  | <img width = 250, src = "https://i.imgur.com/KZMPWjJ.gif"> |
+
+|`CE`버튼 작동예시 | `AC`버튼 작동예시 |
+|-----------|-----------|
+|<img width = 250, src = "https://i.imgur.com/9eLFZ8e.gif">|<img width = 250, src = "https://i.imgur.com/cSKQSWe.gif">|
+
+|`+/-` 버튼 작동 예시 | 제일 하단으로 Auto Scrolling 예시 |
+|-----------|-----------|
+|<img width = 250, src = "https://i.imgur.com/kbu4ugR.gif">|<img width = 250, src = "https://i.imgur.com/eFms2BQ.gif">|
+
+| 나누기 0 시 오류처리 | 소수점 한개 이상 오류처리 |
+|-----------|-----------|
+|<img width = 250, src = "https://i.imgur.com/yRYaKTn.gif">|<img width = 250, src = "https://i.imgur.com/eSxvqkr.gif">|
+
+---
 
 ## 4. ⚒️ 구현 내용
+
+### [ 🚩 Model ]
+
 **1️⃣ 자료구조를 구현하기위한 Queue, LinkedList, Node**
 
 ☑️ CalculatorItemQueue 구조체  </br>
 ☑️ LinkedList 구조체  </br>
 ☑️ Node 클래스  </br>
+
 <details>
     <summary> [details - 타입별 프로퍼티와 메서드 설명] </summary>
 
@@ -37,7 +64,6 @@ LinkedList 이용한 FIFO형태의 Queue 자료구조입니다
 - `dequeue()`: Queue의 맨 앞의 데이터 (제일 먼저 추가되었던 데이터)를 반환하고 삭제합니다.
 - `clear()`: Queue의 데이터를 모두 삭제합니다.
 - `isEmpty()`: Queue가 비어있는지 Bool타입으로 반환합니다.
-
 ☑️ LinkedList 구조체
 Node를 이용한 단방향 연결리스트 자료구조입니다.
 - `head`: 연결리스의 첫번째 데이터입니다. 
@@ -46,7 +72,6 @@ Node를 이용한 단방향 연결리스트 자료구조입니다.
 - `removeLast()`: 리스트의 마지막 데이터 (제일 늦게 추가되었던 데이터)를 반환하고 삭제합니다.
 - `removeFirst()`: 리스트의 맨 앞의 데이터 (제일 먼저 추가되었던 데이터)를 반환하고 삭제합니다.
 - `isEmpty()`: 리스트가 비어있는지 Bool타입으로 반환합니다.
-
 ☑️ Node 클래스
 - `data`: 필요한 데이터를 저장합니다, 외부에서 읽기만 가능합니다
 - `next`: 메모리상에서 또 다른 Node의 주소를 참조합니다.
@@ -109,6 +134,97 @@ Node를 이용한 단방향 연결리스트 자료구조입니다.
 **4️⃣ unit test** </br>
 <img width=550, src = "https://i.imgur.com/gIbl5Qm.png">
 
+
+### [ 🚩 ViewController ]
+**1️⃣ property**
+
+☑️ formula, result, inputNumber </br>
+ 
+ <details>
+<summary> [details - 프로퍼티별 설명] </summary>
+    
+- `rawFormula`: `=` 버튼을 누를 시 계산해 줄 공식을 담습니다.
+- `result`: 계산 결과를 담습니다.
+- `inputNumber`: 실시간 input을 보여줍니다. willSet을 이용해 라벨에 표시해줍니다. 값이 비거나, 음수부호일 시에는 0을 표시합니다.(음수부호는 0으로 보여도 뒤에 숫자를 누를 시 음수로 표시됩니다)
+ </details>
+ 
+   </br>
+ 
+**2️⃣ IBAction 메서드**
+
+☑️ touchUpNumberButton </br>
+☑️ touchUpOperatorButton </br>
+☑️ touchUpConvertingPositiveNegativeButton </br>
+☑️ touchUpCEButton  </br>
+☑️ touchUpACButton </br>
+☑️ touchUpResultButton </br>
+
+  <details>
+<summary> [details - 메서드 별 기능 설명] </summary>
+    
+ - `touchUpNumberButton`: 
+     - 숫자패드에 반응해 라벨에 띄우기 위해 inputNumber에 담습니다. 
+     - `0`버튼과 `00`버튼은 현재값이 0일때 눌러도 여러번 입력되지 않도록 guard문 처리했습니다.
+     - `1~9` 버튼은 현재값이 0일때 0을 지우고 숫자가 입력되도록 합니다.
+ - `touchUpOperatorButton`:
+     - 연산자를 처음 누른다면 거라면 연산자라벨에 누른 연산자를 보여줍니다.
+     - 기존에 숫자를 눌렀었다면 이전에 누른 공식을 stackView에 label로 올려주고 
+        실시간 input을 보여주는 label은 초기화한 후 연산자라벨에 눌러진 연산자를 보여줍니다.
+     - 더불어 나중에 계산을 위해 formula프로퍼티에도 이전에 누른 공식을 추가합니다.
+ - `touchUpConvertingPositiveNegativeButton`:
+     - 첫번째 자릿수가 마이너스인지 구분하여 음수🔁양수 convert해줍니다.
+     - 0일 때는 양수, 음수 convert 되지 않습니다.
+ - `touchUpCEButton`:
+     - input내용을 지워줍니다.
+ - `touchUpACButton`:
+     - input내용과 기존 공식들 모두 지워줍니다
+ - `touchUpResultButton`:
+     - 기존에 `=`을 누른 후 다시 누르는 경우 작동하지 않도록 guard문 처리했습니다.
+     - 마지막 input들을 stackView에 label로 올려주고 input을 비워줍니다.
+     - 오류처리를 위해 do-catch문으로 결과를 계산해줍니다
+     - `divideByZeroError` 시 Nan처리를 위해 numberFormatter의 notANumberSymbol을 사용합니다.
+ 
+</details>
+
+</br>
+    
+**3️⃣ 메서드**
+
+☑️ addFormula </br>
+☑️ MakeOperationStackView </br>
+☑️ makeOperatorLabel </br>
+☑️ scrollTobottom </br>
+☑️ changeStyle </br>
+
+<details>
+<summary> [details - 메서드 별 기능 설명] </summary>
+
+- `addFormula`
+     - 계산을 위해 formula 프로퍼티에 값을 담습니다.
+     - (3-2) 를 (+3-2)로 담기위해 if문으로 라벨이 비어있을 때는 +를 담아줍니다.
+- `MakeOperationStackView`:
+    - UIStackView를 생성하고 특성을 정해줍니다.
+    - 연산자 라벨과 피연산 라벨을 horizontal axis로 담습니다.
+    - `showingOperationsStackView`의 맨 뒤에 추가해줍니다.
+- `makeOperatorLabel`, `makeOperandLabel`
+    - UILabel을 생성하고 특성을 정해줍니다.
+    - 각각 현재 입력된 연산자, 피연산자를 text로 갖습니다.
+- `scrollTobottom`
+    - scrollView를 자동으로 제일 하단에 위치하도록 합니다.
+    - setContentOffset만 사용할 시 제일 하단 한 줄이 나오지 않는 문제가 있어 layoutIfNeeded()를 이용해 보류 중인 레이아웃 업데이트가 될 떄까지 기다린 후 스크롤을 아래로 내려주도록 합니다.
+- `changeStyle`
+    - 계산결과값에 NumberFormatter를 이용해 필요 스타일을 잡아줍니다.
+    - 1000의 자리마다 쉼표를 추가하고 20자리까지만 표기합니다. 잘리는 숫자는 반올림 해줍니다.
+
+</details>
+
+</br>
+
+**4️⃣ Text 구조체** </br>
+☑️ 기본텍스트를 상수로 사용하기 위한 구조체
+
+</br>
+
 ---
 
 ## 5. ✅ 프로젝트 수행 중 경험하고 배운 것
@@ -124,6 +240,14 @@ Node를 이용한 단방향 연결리스트 자료구조입니다.
 - 고차함수 사용하기 </br>
     ☑️ map, compactMap 사용하기 </br>
     ☑️ 옵셔녈바인딩대신 compactMap을 사용할 수 있음 </br>
+- UIStackView 코드로 다뤄보기 </br>
+    ☑️ 코드로 stackView생성과 특성을 지정해주기 </br>
+- UIlabel 코드로 다루기 </br>
+    ☑️ 코드로 UILabel생성과 특성을 지정해주고 stackView에 add해주기 </br>
+- scrollView 다루기 </br>
+    ☑️ 실제 컨텐츠 사이즈에서 원하는 bound의 위치로 CGPoint를 이용해 스크롤 이동하기 </br>
+- NumberFormatter() 포매터 사용하기 </br>
+    ☑️ 1000의 자리마다 쉼표, 유효숫자, NaN사용, 소숫점 처리 파라미터 이용하기 </br>
 
 ---
 
@@ -314,12 +438,59 @@ input.components(separatedBy: operators)
 ```
 </details>
 
+### 5️⃣ ScrollView Scroll 기본값으로 제일 하단으로 지정해 놓는 방법
+
+`setContentOffset` 을 이용해 CGPoint의 y축을 (contentSize의 높이 - bounds의 높이)로 설정해 주어도 scrollView 제일 하단 한 줄 빼고 스크롤이 되는 문제가 있었습니다. 하단 영상처럼 +7 이후부터는 제일 스택뷰의 한 줄이 화면에 보이지 않는 문제였습니다. 스크롤을 내려주는 메서드를 호출해줘도 맨 마지막 줄 빼고 그 위까지만 스크롤 되는 문제였습니다.
+
+<img width = 200, src ="https://i.imgur.com/DE8huir.gif">
+
+결론적으론 View의 drawing cycle을 공부해 `layoutIfNeeded()` 메서드를 호출해 주는 방식으로 문제를 해결했습니다.
+
+<details>
+ <summary> [해결과정 details] </summary>
+        
+- 5-1 오토레이아웃의 문제인가?
+    처음엔 **오토레이아웃의 문제**인가 싶어 오토레이아웃도 뜯어살펴보았지만 문제를 찾지 못했습니다.
+
+- 5-2. 내려가지 않는 한 줄만큼 setContentOffsetd의 y축 값으로 추가
+    setContentOffsetd의 y축 값을 더 내려가도록 해주면 될까 싶어서 **offSet변화량을 콘솔로 확인해서 변화량인 24큼 더 내리도록 해보았습니다** ( y = contentSize의 높이 - bounds의 높이 + **24** ) 
+
+    이렇게 할 때는 `컨텐츠높이`가 `bounds높이`보다 커질 때를 기준으로 첫번째 입력(아래GIF에서 +7때)에서 마지막줄이 안 보이고, 두번째 입력시(+8떄) 이전에 찍은 +7값과 같이 두개값이 동시에 나온 후에 세번째부터는 정상작동하는 문제가 있습니다.
+   <img width = 200, src ="https://i.imgur.com/PNj4xWk.gif">
+    
+- 5-3. 시간적인 duration 관련 문제인가?
+    업데이트 후 스클롤링 함수를 호출하는 시간 사이에 delay가 생길까 싶어 **notification Center**사용으로 한박자 늦게 scroll을 내리는 함수를 호출해보기도 했지만 무용지물이었습니다..
+    
+- 5-4. ✅ 드로잉 사이클 (drawing cycle)을 공부
+    컨텐츠가 변하여도 다음 드로잉사이클까지 **대기 후**에 다시 view가 업데이트 되는것을 알았습니다.
+    
+    setNeedsDisplay 메서드를 사용하면 시스템에게 draw 메서드를 호출하도록 요청해서 다시 View를 그려주게되는데 이 과정이 바로 즉각 되는것이 아니라 다음 drawing cycle까지 기다렸다가 진행됩니다. 제 화면에서 생각해보면 내부에서 스크롤하는 함수가 호출되어 스크롤을 제일 아래로 내렸지만, 하단에 스택뷰가 추가된 완성된 레이아웃 재배치는 그 후에 이뤄지는 사이클이었기 때문에 마지막 줄이 안보이는 문제가 생겼던 것입니다.
+    
+    setNeedsDisplay와 같은 기능을 하지만 layoutIfNeeded메서드는 다음 드로잉 사이클까지 기다리지 않고 즉시 view layout을 업데이트 해줄 수 있는 메서드입니다. 때문에 layoutIfNeeded메서드를 호출한 후 스크롤을 내려주어 문제를 해결했습니다. 
+
+    setNeedsDisplay 메서드의 호출 여부에 따른 실제 offset 수치를 확인해 보았습니다. 
+    아래의 표는 스크롤뷰에 추가된 스택뷰의 갯수에 따른 컨텐츠높이, bound높이, content offset의 y축값 을 정리한 것입니다.
+    표에서 확인이 가능한 것은 layoutIfNeeded를 호출하지 않고 계산기를 찍을때와 호출했을 때의 값이 한스텝씩 차이가 난다는 것입니다. 
+
+    <img width = 800, src ="https://i.imgur.com/oDgorTU.png">
+    (위 표에서 offSet을 빨간글씨는 스크롤 제일 아랫줄이 보이지 않을때를 표시한 것입니다..)
+
+    이 스텝의 차이는 위에서 설명했듯이 순서의 차이입니다. `스크롤내리기 -> 뷰 업데이트` 와 `뷰 업데이트 -> 스크롤내리기` 의 차이입니다.
+
+    </details>   
+    
+    
+    ---
 
 ## 7. 🔗 참고 링크
-- [Swift Language Guide - Extentions
+- [[공식문서] Swift Language Guide - Extentions
 ](https://docs.swift.org/swift-book/LanguageGuide/Extensions.html)
-- [Swift Language Guide - Protocols
+- [[공식문서]Swift Language Guide - Protocols
 ](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html)
-- [Swift Language Guide - Inheritance](https://docs.swift.org/swift-book/LanguageGuide/Inheritance.html)
+- [[공식문서]Swift Language Guide - Inheritance](https://docs.swift.org/swift-book/LanguageGuide/Inheritance.html)
+- [[공식문서]ios developer - UIView](https://developer.apple.com/documentation/uikit/uiview) 
+- [[공식문서]ios developer - NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)     
+- [야곰닷넷 - 오토레이아웃 정복하기](https://yagom.net/courses/autolayout/)        
 - [개발자 소들이-Swift) 큐(Queue) 구현 해보기](https://babbab2.tistory.com/84)
 - [개발자 소들이-Swift) 단방향 연결 리스트(LinkedList) 구현 해보기](https://babbab2.tistory.com/86)
+- [iOS ) View/레이아웃 업데이트 관련 메소드](https://zeddios.tistory.com/359)


### PR DESCRIPTION

안녕하세요 엘림!(@lina0322)
계산기 2 Step1 PR드립니다!
컨셉이 다른 두 명의 코드를 합쳐보는 프로젝트를 진행해보았습니다
저희 둘 다 서로의 코드를 수용하려는 자세였어서
생각보다 수월하게 풀어나갈 수 있었습니다.😄

스톤의 Array컨셉과, 써니쿠키의 linkedList 컨셉 중 LinkedList를 채택하게되어 써니쿠키 레포지토리를 fork하여 새로운 branch로 코드로 합쳐 보았습니다🤝

## ⚒️ 코드 구현내용 

### 써니쿠키의 브랜치를 이어받았기 때문에 스톤의 로직이 채택되어 수정한 부분을 위주로 설명했습니다

☑️ **Queue에 이용되는 자료구조 선택 (Array 와 LinkedList)**
 - 스톤이 구현한 array는 Head를 옮겨주는 방식으로 array의 오버헤드의 단점을 보완했었기 때문에 LinkedList와 사이에서 어떤 방식을 채택할까 고민했습니다.
 - Step2에서 핵심경험으로 '제네릭을 활용하여 범용적인 타입 구현'이 선택사항으로 있어서 제네릭타입인 Node와 Linked List를 채택했습니다

☑️ **`componentsByOperator()` 를 이용한 String을 쪼갠 return값**
 - 써니쿠키는 이 메서드를 이용해 계산식이 숫자만 걸러서 나오도록, 예를들어 "1+245x67" -> ["1", "245", "67"] 이 나오도도록 구현했고,
    스톤은 띄어쓰기를 기준으로 split하여 숫자와 연산자를 모두 구분해주는, 예를들어 "1 + 245 x 67" -> ["1", "+", "245", "X", "67"] 이 나오도록 구현한 컨셉이 둘이 달랐고, 스톤의 컨셉을 채택했습니다.
 - 이유는 extension String에서 구현한 `split()` 의 사용이 더 깔끔했고, `componentsByOperator()`메서드가 사용되는 `parse()`와 연관지어 생각했을때 숫자와 연산자를 모두 구분지어주는 것이 `componentsByOperator()`메서드의 역할에 더 알맞다고 생각했습니다.

☑️ **Formula구조체의 `result()` 계산 방법**
 - 써니쿠키는 '1+245x67' 을 계산 할 때, ViewController에서 제일 앞에 +를 추가해주도록 처리해 +1+245x67으로 계산되게 했었고, 스톤은 '1+245x67'식을 그대로 받아 계산할 수 있었습니다. ViewController에서 추가적인 처리해주지 않을 수 있는 스톤 방식을 채택했습니다.

☑️ **ViewController에서 함수 기능분리 여부**
 - 스톤은 메서드의 여러곳에서 반복 사용하는 부분을 하나의 메서드로 만들어 반복사용했었습니다. 재사용하는 부분은 함수로 구현해놓는게 맞다고 판단되어 `resetInputNumber()`,`resetOperatorLabel()`,`resetRawFormula()`를 메서드로 만들어 함수 기능을 분리한 스톤의 방식을 채택했습니다. 
 - 그리고, 스톤은 IBAction 외의 메서드들을 extension ViewController로 분리했었습니다. 구분이 가독성에 도움이 된다 생각하여 채택했습니다.

☑️ **rawFormula의 타입 (Array와 String)**
- 위에 작성한 `componentsByOperator()`메서드의 컨셉이 바뀌면서 split()을 띄어쓰기를 기준으로 String을 쪼개줘야 하는데, array상태에서 joined()메서드를 이용해 사이사이 띄어쓰기를 한번에 넣어주는 방법이 있었고, rawFormula를 String타입으로 유지하려면 연산자(+,-,/,x) 를 추가할 때 앞 뒤로 띄어쓰기를 추가하는 방법이 있었습니다. 둘 중 한번에 추가해 주는 방법이 깔끔하다 생각해 rawFormula를 array로 사용한 스톤의 방식을 채택했습니다.

☑️ **stackView 연산프로퍼티와 addStackView 함수 분리**
- 써니쿠키는 각각의 label을 만드는 함수 두개와 stackView를 만들어 scrollView의 하위 스택뷰에 스택뷰를 추가해주는 함수 한개로 총 세가지의 함수를 사용하여 피연산자와 연산자를 scrollView에 추가해주는 로직이였고
- 스톤은 각각의 label과 stackView에 연산프로퍼티로 속성에 접근할 때 마다 label과 stackView를 반환해주는 로직과, scrollView의 하위 스택뷰에 스택뷰를 추가해주는 함수 한개로 구현하였습니다.
- 연산프로퍼티를 사용하는 것이 가독성이 좋고 직관적이여서 채택했습니다.

☑️ **isClaculated 프로퍼티의 Bool타입으로 코드진행 여부 결정** 
- 기존의 코드에서 label의 값으로 연산이 됐는지, 안됐는지를 판별하는 조건식을 가지고 있었는데, 조금 더 명확하게 플래그 변수를 사용하여 조건식을 판별할 수 있도록 선언하였습니다.

☑️ **operatorLabel, inputNumber 초기화 함수 분리**
- `CalculatorViewController` 내부에서 피연산자 값과, 연산자의 값을 초기화하는 부분이 반복되어 함수를 분리했습니다.

☑️ **UIStackView extension 구현**
- stackView의 하위 요소들을 제거하는 로직을 extension을 활용하여 removeSubViewAll메서드로 구현했습니다.

☑️ **String extension 구현**
- `ExpressionParser` enum타입의 parse메서드 내부에서 `String` 값이 `Double`형으로 형변환이 되는 값인지 확인하기 위해 `isDouble`을 구현했습니다.

---

## 🤔 고민한 부분
### 1️⃣ Step1과 Step2의 경계에 대한 부분
`Step1`에서의 요구사항은 짝궁과의 코드를 합치는 것이 `Step1`의 목표인데 합치는 과정에서의 리팩토링과 `Step2`에서의 리팩토링에 대한 경계가 모호하다는 생각이 들었습니다
그래서 step1에서는 둘의 코드를 합치는데 중점을 두고 (시뮬레이션은 돌아가도록 조금의 리팩토링은 포함), 네이밍이나 계산기에서 새로발견한 오류들에 대한 처리는 Step2에서 진행하기로 했습니다.
