### PR TITLE
계산기 [STEP 1] Rhode

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 		D0680283297FF6FA0008F03B /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0680282297FF6FA0008F03B /* CalculatorTests.swift */; };
 		D068028A297FF7110008F03B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
-		D068028C297FF8350008F03B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D068028B297FF8350008F03B /* Calculator.swift */; };
+		D068028D29801D6D0008F03B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D068028B297FF8350008F03B /* Calculator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -202,7 +202,6 @@
 			files = (
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
-				D068028C297FF8350008F03B /* Calculator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -212,6 +211,7 @@
 			files = (
 				D068028A297FF7110008F03B /* ViewController.swift in Sources */,
 				D0680283297FF6FA0008F03B /* CalculatorTests.swift in Sources */,
+				D068028D29801D6D0008F03B /* Calculator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		D0680283297FF6FA0008F03B /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0680282297FF6FA0008F03B /* CalculatorTests.swift */; };
 		D068028A297FF7110008F03B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
 		D068028D29801D6D0008F03B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D068028B297FF8350008F03B /* Calculator.swift */; };
+		D068028E298108530008F03B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D068028B297FF8350008F03B /* Calculator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -202,6 +203,7 @@
 			files = (
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				D068028E298108530008F03B /* Calculator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -9,11 +9,23 @@
 /* Begin PBXBuildFile section */
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
-		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		D0680283297FF6FA0008F03B /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0680282297FF6FA0008F03B /* CalculatorTests.swift */; };
+		D068028A297FF7110008F03B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
+		D068028C297FF8350008F03B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D068028B297FF8350008F03B /* Calculator.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D0680284297FF6FA0008F03B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -24,10 +36,20 @@
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D0680280297FF6FA0008F03B /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D0680282297FF6FA0008F03B /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
+		D068028B297FF8350008F03B /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		C713D93B2570E5EB001C3AFC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D068027D297FF6FA0008F03B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -41,6 +63,7 @@
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
+				D0680281297FF6FA0008F03B /* CalculatorTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -49,6 +72,7 @@
 			isa = PBXGroup;
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
+				D0680280297FF6FA0008F03B /* CalculatorTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -63,8 +87,17 @@
 				C713D94A2570E5ED001C3AFC /* Assets.xcassets */,
 				C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */,
 				C713D94F2570E5ED001C3AFC /* Info.plist */,
+				D068028B297FF8350008F03B /* Calculator.swift */,
 			);
 			path = Calculator;
+			sourceTree = "<group>";
+		};
+		D0680281297FF6FA0008F03B /* CalculatorTests */ = {
+			isa = PBXGroup;
+			children = (
+				D0680282297FF6FA0008F03B /* CalculatorTests.swift */,
+			);
+			path = CalculatorTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -87,17 +120,39 @@
 			productReference = C713D93E2570E5EB001C3AFC /* Calculator.app */;
 			productType = "com.apple.product-type.application";
 		};
+		D068027F297FF6FA0008F03B /* CalculatorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D0680288297FF6FA0008F03B /* Build configuration list for PBXNativeTarget "CalculatorTests" */;
+			buildPhases = (
+				D068027C297FF6FA0008F03B /* Sources */,
+				D068027D297FF6FA0008F03B /* Frameworks */,
+				D068027E297FF6FA0008F03B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D0680285297FF6FA0008F03B /* PBXTargetDependency */,
+			);
+			name = CalculatorTests;
+			productName = CalculatorTests;
+			productReference = D0680280297FF6FA0008F03B /* CalculatorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C713D9362570E5EB001C3AFC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1420;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
+					};
+					D068027F297FF6FA0008F03B = {
+						CreatedOnToolsVersion = 14.2;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
 				};
 			};
@@ -115,6 +170,7 @@
 			projectRoot = "";
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
+				D068027F297FF6FA0008F03B /* CalculatorTests */,
 			);
 		};
 /* End PBXProject section */
@@ -130,6 +186,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D068027E297FF6FA0008F03B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -137,13 +200,30 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				D068028C297FF8350008F03B /* Calculator.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D068027C297FF6FA0008F03B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D068028A297FF7110008F03B /* ViewController.swift in Sources */,
+				D0680283297FF6FA0008F03B /* CalculatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D0680285297FF6FA0008F03B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = D0680284297FF6FA0008F03B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C713D9472570E5EB001C3AFC /* Main.storyboard */ = {
@@ -324,6 +404,53 @@
 			};
 			name = Release;
 		};
+		D0680286297FF6FA0008F03B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U7WG3SYKJM;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jinahpark.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Debug;
+		};
+		D0680287297FF6FA0008F03B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U7WG3SYKJM;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jinahpark.CalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -341,6 +468,15 @@
 			buildConfigurations = (
 				C713D9532570E5ED001C3AFC /* Debug */,
 				C713D9542570E5ED001C3AFC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D0680288297FF6FA0008F03B /* Build configuration list for PBXNativeTarget "CalculatorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D0680286297FF6FA0008F03B /* Debug */,
+				D0680287297FF6FA0008F03B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+               BuildableName = "Calculator.app"
+               BlueprintName = "Calculator"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D068027F297FF6FA0008F03B"
+               BuildableName = "CalculatorTests.xctest"
+               BlueprintName = "CalculatorTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -11,30 +11,39 @@ protocol CalculateItem {
     
 }
 
-struct CalculatorItemQueue<T> {
+extension String: CalculateItem {
+    
+}
+
+struct CalculatorItemQueue<T: CalculateItem> {
     var data = [T]()
     init() {}
     
     mutating func dequeue() -> T? {
-        return nil
+        guard data.count > 0 else {
+            return nil
+        }
+        return data.removeFirst()
     }
     
     func peek() -> T? {
-        return nil
+        return data.first
     }
     
     mutating func enqueue(_ element: T) {
+        data.append(element)
     }
     
     mutating func clear() {
+        data.removeAll()
     }
     
     func isEmpty() -> Bool {
-        return true
+        return data.isEmpty
     }
     
     var count: Int {
-        return 0
+        return data.count
     }
     
 }

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -1,0 +1,40 @@
+//
+//  Calculator.swift
+//  Calculator
+//
+//  Created by Jinah Park on 2023/01/24.
+//
+
+import Foundation
+
+protocol CalculateItem {
+    
+}
+
+struct CalculatorItemQueue<T> {
+    var data = [T]()
+    init() {}
+    
+    mutating func dequeue() -> T? {
+        return nil
+    }
+    
+    func peek() -> T? {
+        return nil
+    }
+    
+    mutating func enqueue(_ element: T) {
+    }
+    
+    mutating func clear() {
+    }
+    
+    func isEmpty() -> Bool {
+        return true
+    }
+    
+    var count: Int {
+        return 0
+    }
+    
+}

--- a/Calculator/Calculator/Calculator.swift
+++ b/Calculator/Calculator/Calculator.swift
@@ -7,17 +7,22 @@
 
 import Foundation
 
-protocol CalculateItem {
-    
-}
+protocol CalculateItem {}
 
-extension String: CalculateItem {
-    
-}
+extension String: CalculateItem {}
 
 struct CalculatorItemQueue<T: CalculateItem> {
-    var data = [T]()
-    init() {}
+    private(set) var data: [T]
+    var isEmpty: Bool {
+        return data.isEmpty
+    }
+    var count: Int {
+        return data.count
+    }
+    
+    init(_ data: [T] = []) {
+        self.data = data
+    }
     
     mutating func dequeue() -> T? {
         guard data.count > 0 else {
@@ -37,13 +42,4 @@ struct CalculatorItemQueue<T: CalculateItem> {
     mutating func clear() {
         data.removeAll()
     }
-    
-    func isEmpty() -> Bool {
-        return data.isEmpty
-    }
-    
-    var count: Int {
-        return data.count
-    }
-    
 }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -23,7 +23,7 @@ final class CalculatorTests: XCTestCase {
 
     func test_dequeue호출시_큐가빈상태일경우_nil을반환한다() {
         //given
-        sut.data = []
+        sut = .init()
         //when
         let result = sut.dequeue()
         //then
@@ -32,33 +32,33 @@ final class CalculatorTests: XCTestCase {
     
     func test_dequeue호출시_큐가비지않았을경우_첫번째요소를빼서반환한다() {
         //given
-        sut.data = ["1", "2", "3"]
-        let expectation = "1"
+        sut = .init(["1", "2", "3"])
+        let expectedResult = "1"
         let expectedData = ["2", "3"]
         //when
         let result = sut.dequeue()
         //then
-        XCTAssertEqual(expectation, result)
+        XCTAssertEqual(expectedResult, result)
         XCTAssertEqual(expectedData, sut.data)
         
     }
     
     func test_dequeue호출시_큐에하나의요소가있을경우_첫번째요소를빼서반환하고빈배열이남는다() {
         //given
-        sut.data = ["1"]
-        let expectation = "1"
+        sut = .init(["1"])
+        let expectedResult = "1"
         let expectedData:[String] = []
         //when
         let result = sut.dequeue()
         //then
-        XCTAssertEqual(expectation, result)
+        XCTAssertEqual(expectedResult, result)
         XCTAssertEqual(expectedData, sut.data)
         
     }
     
     func test_peek호출시_큐가빈상태일경우_nil을반환한다() {
         //given
-        sut.data = []
+        sut = .init()
         //when
         let result = sut.peek()
         //then
@@ -67,20 +67,20 @@ final class CalculatorTests: XCTestCase {
     
     func test_peek호출시_큐가비지않았을경우_첫번째요소를빼지않고반환한다() {
         //given
-        sut.data = ["1", "2", "3"]
-        let expectation = "1"
+        sut = .init(["1", "2", "3"])
+        let expectedResult = "1"
         let expectedData = ["1", "2", "3"]
         //when
         let result = sut.peek()
         //then
-        XCTAssertEqual(expectation, result)
+        XCTAssertEqual(expectedResult, result)
         XCTAssertEqual(expectedData, sut.data)
         
     }
     
     func test_enqueue호출시_맨뒤에요소가추가된다() {
         //given
-        sut.data = ["1", "2", "3"]
+        sut = .init(["1", "2", "3"])
         let expectedData = ["1", "2", "3", "4"]
         //when
         sut.enqueue("4")
@@ -90,7 +90,7 @@ final class CalculatorTests: XCTestCase {
     
     func test_enqueue호출시_큐가비었을경우_요소가추가된다() {
         //given
-        sut.data = []
+        sut = .init()
         let expectedData = ["4"]
         //when
         sut.enqueue("4")
@@ -100,7 +100,7 @@ final class CalculatorTests: XCTestCase {
     
     func test_clear호출시_모든요소가삭제된다() {
         //given
-        sut.data = ["1", "2", "3"]
+        sut = .init(["1", "2", "3"])
         let expectedData: [String] = []
         //when
         sut.clear()
@@ -110,51 +110,35 @@ final class CalculatorTests: XCTestCase {
     
     func test_isEmpty호출시_비어있을때_True를반환한다() {
         //given
-        sut.data = []
+        sut = .init()
         //when
-        let result = sut.isEmpty()
+        let result = sut.isEmpty
         //then
         XCTAssertTrue(result)
     }
     
     func test_isEmpty호출시_요소가하나라도있을때_False를반환한다() {
         //given
-        sut.data = ["1"]
+        sut = .init(["1"])
         //when
-        let result = sut.isEmpty()
+        let result = sut.isEmpty
         //then
         XCTAssertFalse(result)
     }
     
     func test_비어있을때_count가_0이다() {
         //given
-        sut.data = []
-        let expectation = 0
+        sut = .init()
+        let expectedCount = 0
         //then
-        XCTAssertEqual(expectation, sut.count)
+        XCTAssertEqual(expectedCount, sut.count)
     }
     
     func test_1개의요소가있을때_count가_1이다() {
         //given
-        sut.data = ["1"]
-        let expectation = 1
+        sut = .init(["1"])
+        let expectedCount = 1
         //then
-        XCTAssertEqual(expectation, sut.count)
+        XCTAssertEqual(expectedCount, sut.count)
     }
-    
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -1,0 +1,135 @@
+//
+//  CalculatorTests.swift
+//  CalculatorTests
+//
+//  Created by Jinah Park on 2023/01/24.
+//
+
+import XCTest
+@testable import Calculator
+
+final class CalculatorTests: XCTestCase {
+    var sut: CalculatorItemQueue<String>!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = CalculatorItemQueue<String>()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+
+    func test_dequeue호출시_큐가빈상태일경우_nil을반환한다() {
+        //given
+        sut.data = []
+        //when
+        let result = sut.dequeue()
+        //then
+        XCTAssertNil(result)
+    }
+    
+    func test_dequeue호출시_큐가비지않았을경우_첫번째요소를빼서반환한다() {
+        //given
+        sut.data = ["1", "2", "3"]
+        let expectation = "1"
+        //when
+        let result = sut.dequeue()
+        //then
+        XCTAssertEqual(expectation, result)
+        XCTAssertEqual(["2", "3"], sut.data)
+        
+    }
+    
+    func test_peek호출시_큐가빈상태일경우_nil을반환한다() {
+        //given
+        sut.data = []
+        //when
+        let result = sut.peek()
+        //then
+        XCTAssertNil(result)
+    }
+    
+    func test_peek호출시_큐가비지않았을경우_첫번째요소를빼지않고반환한다() {
+        //given
+        sut.data = ["1", "2", "3"]
+        let expectation = "1"
+        //when
+        let result = sut.peek()
+        //then
+        XCTAssertEqual(expectation, result)
+        XCTAssertEqual(["1", "2", "3"], sut.data)
+        
+    }
+    
+    func test_enqueue호출시_맨뒤에요소가추가된다() {
+        //given
+        sut.data = ["1", "2", "3"]
+        let expectation = ["1", "2", "3", "4"]
+        //when
+        sut.enqueue("4")
+        //then
+        XCTAssertEqual(expectation, sut.data)
+    }
+    
+    func test_clear호출시_모든요소가삭제된다() {
+        //given
+        sut.data = ["1", "2", "3"]
+        let expectation: [String] = []
+        //when
+        sut.clear()
+        //then
+        XCTAssertEqual(expectation, sut.data)
+    }
+    
+    func test_isEmpty호출시_비어있을때_True를반환한다() {
+        //given
+        sut.data = []
+        //when
+        let result = sut.isEmpty()
+        //then
+        XCTAssertTrue(result)
+    }
+    
+    func test_isEmpty호출시_요소가하나라도있을때_False를반환한다() {
+        //given
+        sut.data = ["1"]
+        //when
+        let result = sut.isEmpty()
+        //then
+        XCTAssertFalse(result)
+    }
+    
+    func test_비어있을때_count가_0이다() {
+        //given
+        sut.data = []
+        let expectation = 0
+        //then
+        XCTAssertEqual(expectation, sut.count)
+    }
+    
+    func test_1개의요소가있을때_count가_1이다() {
+        //given
+        sut.data = ["1"]
+        let expectation = 1
+        //then
+        XCTAssertEqual(expectation, sut.count)
+    }
+    
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -34,11 +34,25 @@ final class CalculatorTests: XCTestCase {
         //given
         sut.data = ["1", "2", "3"]
         let expectation = "1"
+        let expectedData = ["2", "3"]
         //when
         let result = sut.dequeue()
         //then
         XCTAssertEqual(expectation, result)
-        XCTAssertEqual(["2", "3"], sut.data)
+        XCTAssertEqual(expectedData, sut.data)
+        
+    }
+    
+    func test_dequeue호출시_큐에하나의요소가있을경우_첫번째요소를빼서반환하고빈배열이남는다() {
+        //given
+        sut.data = ["1"]
+        let expectation = "1"
+        let expectedData:[String] = []
+        //when
+        let result = sut.dequeue()
+        //then
+        XCTAssertEqual(expectation, result)
+        XCTAssertEqual(expectedData, sut.data)
         
     }
     
@@ -55,32 +69,43 @@ final class CalculatorTests: XCTestCase {
         //given
         sut.data = ["1", "2", "3"]
         let expectation = "1"
+        let expectedData = ["1", "2", "3"]
         //when
         let result = sut.peek()
         //then
         XCTAssertEqual(expectation, result)
-        XCTAssertEqual(["1", "2", "3"], sut.data)
+        XCTAssertEqual(expectedData, sut.data)
         
     }
     
     func test_enqueue호출시_맨뒤에요소가추가된다() {
         //given
         sut.data = ["1", "2", "3"]
-        let expectation = ["1", "2", "3", "4"]
+        let expectedData = ["1", "2", "3", "4"]
         //when
         sut.enqueue("4")
         //then
-        XCTAssertEqual(expectation, sut.data)
+        XCTAssertEqual(expectedData, sut.data)
+    }
+    
+    func test_enqueue호출시_큐가비었을경우_요소가추가된다() {
+        //given
+        sut.data = []
+        let expectedData = ["4"]
+        //when
+        sut.enqueue("4")
+        //then
+        XCTAssertEqual(expectedData, sut.data)
     }
     
     func test_clear호출시_모든요소가삭제된다() {
         //given
         sut.data = ["1", "2", "3"]
-        let expectation: [String] = []
+        let expectedData: [String] = []
         //when
         sut.clear()
         //then
-        XCTAssertEqual(expectation, sut.data)
+        XCTAssertEqual(expectedData, sut.data)
     }
     
     func test_isEmpty호출시_비어있을때_True를반환한다() {

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@
 
 - 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
 
+## Step01 UML
+![](https://i.imgur.com/v4ctxZG.png)
+


### PR DESCRIPTION
@llingo 안녕하세요 링고! Rhode PR보냅니다! 이번 스텝에 대한 이해도가 낮아서 조금 시간이 걸린 것 같습니다.



## 조언을 얻고 싶은 부분
### 1. Struct로 구현하는 것이 맞는가
다음과 같은 이유로 `CalculatorItemQueue`을 struct로 구현했습니다.

 - 값을 참조해야하는 경우 class로 구현하는 것을 권장한다.
 - 상속을해야하는 경우 class로 구현하는 것을 권장한다.
 - 타입캐스팅을 사용해야하는 경우 class로 구현하는 것을 권장한다.
 - 위 세가지의 이유가 아니라면 일반적으로 struct로 구현하는 것을 애플의 guideline에서는 권장한다.

참조, 상속, 타입캐스팅 모두 사용할 일이 없어서 struct로 구현하는 것이 맞다고 판단했습니다. 제 선택이 맞는지 알고 싶습니다.

### 2. generic으로 테스트를 진행할 수 있는 방법은 없는가
구현은 generic T를 사용해서 구현했습니다.
```swift
struct CalculatorItemQueue<T: CalculateItem> {
    var data = [T]()
    
    ...
    
    mutating func dequeue() -> T? {
        ...
    }
    
    func peek() -> T? {
        ...
    }
    
    mutating func enqueue(_ element: T) {
        ...
    }
    
    ...
    
}
```

그러나 유닛 테스트를 진행할 때 generic T를 사용한 상태로 테스트를 진행할 수 없었습니다. T가 equatable하지 않다고 했습니다. Equatable 프로토콜을 채택해도 해결되지 않았습니다. 그래서 테스트를 진행할 때 플레이스홀더에 String을 넣어주고 스트링에 대한 케이스들로 테스트를 진행하였습니다.

```swift
import XCTest
@testable import Calculator

final class CalculatorTests: XCTestCase {
    var sut: CalculatorItemQueue<String>!

    override func setUpWithError() throws {
        try super.setUpWithError()
        sut = CalculatorItemQueue<String>()
    }
    
    ...
    
    func test_dequeue호출시_큐가비지않았을경우_첫번째요소를빼서반환한다() {
        //given
        sut.data = ["1", "2", "3"]
        let expectation = "1"
        let expectedData = ["2", "3"]
        //when
        let result = sut.dequeue()
        //then
        XCTAssertEqual(expectation, result)
        XCTAssertEqual(expectedData, sut.data)
        
    }
    
    ...

}
```

generic T 자체로 테스트를 진행할 방법이 없는지 궁금합니다. 

### T가 아닌 Any를 사용하는게 더 적절하지 않았는가
T와 Any에 대해서 이렇게 이해하고 있습니다.

 - T: 어느 타입이든 될 수 있지만, 여러개의 타입을 받을 수 없다.
 - Any: 어느 타입이든 될 수 있고, 여러개의 타입을 받을 수 있다.

일반적으로 T로 많이 구현하는 것 같아서 저도 T로 구현했습니다만..
큐 안에 `숫자-연산자-숫자-연산자` 순서로 쌓일 것을 생각하면, Any를 사용하는게 맞는게 아닌가 싶기도 합니다. 이 부분에 대해서 조언을 듣고 싶습니다. 