### PR TITLE
계산기 [STEP 2] 혜모리

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF5E81BB29837F10009A839B /* String+CalculatorItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5E81BA29837F10009A839B /* String+CalculatorItem.swift */; };
+		BF5E81BB29837F10009A839B /* extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5E81BA29837F10009A839B /* extensions.swift */; };
+		BF994A372983DC98000FAD1A /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF994A362983DC98000FAD1A /* Operator.swift */; };
 		BFC6FF9E2980DFF400629399 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FF9D2980DFF400629399 /* CalculateItem.swift */; };
 		BFC6FFA02980E03000629399 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FF9F2980E03000629399 /* LinkedList.swift */; };
 		BFC6FFA22980E04800629399 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FFA12980E04800629399 /* Node.swift */; };
@@ -40,7 +41,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		BF5E81BA29837F10009A839B /* String+CalculatorItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+CalculatorItem.swift"; sourceTree = "<group>"; };
+		BF5E81BA29837F10009A839B /* extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = extensions.swift; sourceTree = "<group>"; };
+		BF994A362983DC98000FAD1A /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		BFC6FF9D2980DFF400629399 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		BFC6FF9F2980E03000629399 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		BFC6FFA12980E04800629399 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -117,7 +119,8 @@
 				BFC6FF9D2980DFF400629399 /* CalculateItem.swift */,
 				BFC6FF9F2980E03000629399 /* LinkedList.swift */,
 				BFC6FFA12980E04800629399 /* Node.swift */,
-				BF5E81BA29837F10009A839B /* String+CalculatorItem.swift */,
+				BF5E81BA29837F10009A839B /* extensions.swift */,
+				BF994A362983DC98000FAD1A /* Operator.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -310,12 +313,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				BFC6FFA02980E03000629399 /* LinkedList.swift in Sources */,
-				BF5E81BB29837F10009A839B /* String+CalculatorItem.swift in Sources */,
+				BF5E81BB29837F10009A839B /* extensions.swift in Sources */,
 				BFC6FF9E2980DFF400629399 /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				BFE7748B297FAC240045AB91 /* CalculatorItemQueue.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				BF994A372983DC98000FAD1A /* Operator.swift in Sources */,
 				BFC6FFA22980E04800629399 /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		BF5E81BB29837F10009A839B /* extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5E81BA29837F10009A839B /* extensions.swift */; };
 		BF994A372983DC98000FAD1A /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF994A362983DC98000FAD1A /* Operator.swift */; };
 		BF994A392983F221000FAD1A /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF994A382983F221000FAD1A /* ExpressionParser.swift */; };
+		BF994A3B29842C9B000FAD1A /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF994A3A29842C9B000FAD1A /* Formula.swift */; };
+		BFABE1EC298569940089F381 /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFABE1EB298569930089F381 /* ExpressionParserTests.swift */; };
 		BFC6FF9E2980DFF400629399 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FF9D2980DFF400629399 /* CalculateItem.swift */; };
 		BFC6FFA02980E03000629399 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FF9F2980E03000629399 /* LinkedList.swift */; };
 		BFC6FFA22980E04800629399 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FFA12980E04800629399 /* Node.swift */; };
@@ -25,6 +27,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		BFABE1ED298569940089F381 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 		BFC6FFAB2980E12000629399 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
@@ -45,6 +54,9 @@
 		BF5E81BA29837F10009A839B /* extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = extensions.swift; sourceTree = "<group>"; };
 		BF994A362983DC98000FAD1A /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		BF994A382983F221000FAD1A /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		BF994A3A29842C9B000FAD1A /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		BFABE1E9298569930089F381 /* ExpressionParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BFABE1EB298569930089F381 /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		BFC6FF9D2980DFF400629399 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		BFC6FF9F2980E03000629399 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		BFC6FFA12980E04800629399 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -64,6 +76,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		BFABE1E6298569930089F381 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BFC6FFA42980E12000629399 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -88,6 +107,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BFABE1EA298569930089F381 /* ExpressionParserTests */ = {
+			isa = PBXGroup;
+			children = (
+				BFABE1EB298569930089F381 /* ExpressionParserTests.swift */,
+			);
+			path = ExpressionParserTests;
+			sourceTree = "<group>";
+		};
 		BFC6FFA82980E12000629399 /* CalculatorItemQueueTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -124,6 +151,7 @@
 				BF5E81BA29837F10009A839B /* extensions.swift */,
 				BF994A362983DC98000FAD1A /* Operator.swift */,
 				BF994A382983F221000FAD1A /* ExpressionParser.swift */,
+				BF994A3A29842C9B000FAD1A /* Formula.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -144,6 +172,7 @@
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				BFC6FFA82980E12000629399 /* CalculatorItemQueueTests */,
 				BFC6FFB62980E15200629399 /* LinkedListTests */,
+				BFABE1EA298569930089F381 /* ExpressionParserTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -154,6 +183,7 @@
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				BFC6FFA72980E12000629399 /* CalculatorItemQueueTests.xctest */,
 				BFC6FFB52980E15200629399 /* LinkedListTests.xctest */,
+				BFABE1E9298569930089F381 /* ExpressionParserTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -172,6 +202,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		BFABE1E8298569930089F381 /* ExpressionParserTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BFABE1F1298569940089F381 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */;
+			buildPhases = (
+				BFABE1E5298569930089F381 /* Sources */,
+				BFABE1E6298569930089F381 /* Frameworks */,
+				BFABE1E7298569930089F381 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BFABE1EE298569940089F381 /* PBXTargetDependency */,
+			);
+			name = ExpressionParserTests;
+			productName = ExpressionParserTests;
+			productReference = BFABE1E9298569930089F381 /* ExpressionParserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		BFC6FFA62980E12000629399 /* CalculatorItemQueueTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BFC6FFAF2980E12000629399 /* Build configuration list for PBXNativeTarget "CalculatorItemQueueTests" */;
@@ -234,6 +282,10 @@
 				LastSwiftUpdateCheck = 1410;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					BFABE1E8298569930089F381 = {
+						CreatedOnToolsVersion = 14.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					BFC6FFA62980E12000629399 = {
 						CreatedOnToolsVersion = 14.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
@@ -263,11 +315,19 @@
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				BFC6FFA62980E12000629399 /* CalculatorItemQueueTests */,
 				BFC6FFB42980E15200629399 /* LinkedListTests */,
+				BFABE1E8298569930089F381 /* ExpressionParserTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		BFABE1E7298569930089F381 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BFC6FFA52980E12000629399 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -295,6 +355,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		BFABE1E5298569930089F381 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BFABE1EC298569940089F381 /* ExpressionParserTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BFC6FFA32980E12000629399 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -322,6 +390,7 @@
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				BFE7748B297FAC240045AB91 /* CalculatorItemQueue.swift in Sources */,
+				BF994A3B29842C9B000FAD1A /* Formula.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 				BF994A372983DC98000FAD1A /* Operator.swift in Sources */,
 				BFC6FFA22980E04800629399 /* Node.swift in Sources */,
@@ -331,6 +400,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		BFABE1EE298569940089F381 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = BFABE1ED298569940089F381 /* PBXContainerItemProxy */;
+		};
 		BFC6FFAC2980E12000629399 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
@@ -363,6 +437,51 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		BFABE1EF298569940089F381 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = net.hyemory.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Debug;
+		};
+		BFABE1F0298569940089F381 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.hyemory.ExpressionParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Release;
+		};
 		BFC6FFAD2980E12000629399 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -615,6 +734,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		BFABE1F1298569940089F381 /* Build configuration list for PBXNativeTarget "ExpressionParserTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BFABE1EF298569940089F381 /* Debug */,
+				BFABE1F0298569940089F381 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		BFC6FFAF2980E12000629399 /* Build configuration list for PBXNativeTarget "CalculatorItemQueueTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		BFC6FFAA2980E12000629399 /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FFA92980E12000629399 /* CalculatorItemQueueTests.swift */; };
 		BFC6FFB82980E15200629399 /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FFB72980E15200629399 /* LinkedListTests.swift */; };
 		BFE7748B297FAC240045AB91 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7748A297FAC240045AB91 /* CalculatorItemQueue.swift */; };
+		BFFC494C2986830C001AC392 /* FormularTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFC494B2986830C001AC392 /* FormularTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -48,6 +49,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		BFFC494D2986830C001AC392 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -65,6 +73,8 @@
 		BFC6FFB52980E15200629399 /* LinkedListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFC6FFB72980E15200629399 /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
 		BFE7748A297FAC240045AB91 /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
+		BFFC49492986830C001AC392 /* FormularTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormularTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BFFC494B2986830C001AC392 /* FormularTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormularTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -91,6 +101,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BFC6FFB22980E15200629399 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BFFC49462986830C001AC392 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -166,6 +183,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		BFFC494A2986830C001AC392 /* FormularTests */ = {
+			isa = PBXGroup;
+			children = (
+				BFFC494B2986830C001AC392 /* FormularTests.swift */,
+			);
+			path = FormularTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
@@ -173,6 +198,7 @@
 				BFC6FFA82980E12000629399 /* CalculatorItemQueueTests */,
 				BFC6FFB62980E15200629399 /* LinkedListTests */,
 				BFABE1EA298569930089F381 /* ExpressionParserTests */,
+				BFFC494A2986830C001AC392 /* FormularTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -184,6 +210,7 @@
 				BFC6FFA72980E12000629399 /* CalculatorItemQueueTests.xctest */,
 				BFC6FFB52980E15200629399 /* LinkedListTests.xctest */,
 				BFABE1E9298569930089F381 /* ExpressionParserTests.xctest */,
+				BFFC49492986830C001AC392 /* FormularTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -256,6 +283,24 @@
 			productReference = BFC6FFB52980E15200629399 /* LinkedListTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		BFFC49482986830C001AC392 /* FormularTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BFFC49512986830C001AC392 /* Build configuration list for PBXNativeTarget "FormularTests" */;
+			buildPhases = (
+				BFFC49452986830C001AC392 /* Sources */,
+				BFFC49462986830C001AC392 /* Frameworks */,
+				BFFC49472986830C001AC392 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BFFC494E2986830C001AC392 /* PBXTargetDependency */,
+			);
+			name = FormularTests;
+			productName = FormularTests;
+			productReference = BFFC49492986830C001AC392 /* FormularTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -294,6 +339,10 @@
 						CreatedOnToolsVersion = 14.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					BFFC49482986830C001AC392 = {
+						CreatedOnToolsVersion = 14.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -316,6 +365,7 @@
 				BFC6FFA62980E12000629399 /* CalculatorItemQueueTests */,
 				BFC6FFB42980E15200629399 /* LinkedListTests */,
 				BFABE1E8298569930089F381 /* ExpressionParserTests */,
+				BFFC49482986830C001AC392 /* FormularTests */,
 			);
 		};
 /* End PBXProject section */
@@ -336,6 +386,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BFC6FFB32980E15200629399 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BFFC49472986830C001AC392 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -379,6 +436,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BFFC49452986830C001AC392 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BFFC494C2986830C001AC392 /* FormularTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -414,6 +479,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = BFC6FFB92980E15200629399 /* PBXContainerItemProxy */;
+		};
+		BFFC494E2986830C001AC392 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = BFFC494D2986830C001AC392 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -562,6 +632,51 @@
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.hyemory.LinkedListTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Release;
+		};
+		BFFC494F2986830C001AC392 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = net.hyemory.FormularTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Debug;
+		};
+		BFFC49502986830C001AC392 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.hyemory.FormularTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -757,6 +872,15 @@
 			buildConfigurations = (
 				BFC6FFBC2980E15200629399 /* Debug */,
 				BFC6FFBD2980E15200629399 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BFFC49512986830C001AC392 /* Build configuration list for PBXNativeTarget "FormularTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BFFC494F2986830C001AC392 /* Debug */,
+				BFFC49502986830C001AC392 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		BF5E81BB29837F10009A839B /* extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5E81BA29837F10009A839B /* extensions.swift */; };
 		BF994A372983DC98000FAD1A /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF994A362983DC98000FAD1A /* Operator.swift */; };
+		BF994A392983F221000FAD1A /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF994A382983F221000FAD1A /* ExpressionParser.swift */; };
 		BFC6FF9E2980DFF400629399 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FF9D2980DFF400629399 /* CalculateItem.swift */; };
 		BFC6FFA02980E03000629399 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FF9F2980E03000629399 /* LinkedList.swift */; };
 		BFC6FFA22980E04800629399 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC6FFA12980E04800629399 /* Node.swift */; };
@@ -43,6 +44,7 @@
 /* Begin PBXFileReference section */
 		BF5E81BA29837F10009A839B /* extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = extensions.swift; sourceTree = "<group>"; };
 		BF994A362983DC98000FAD1A /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		BF994A382983F221000FAD1A /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		BFC6FF9D2980DFF400629399 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		BFC6FF9F2980E03000629399 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		BFC6FFA12980E04800629399 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				BFC6FFA12980E04800629399 /* Node.swift */,
 				BF5E81BA29837F10009A839B /* extensions.swift */,
 				BF994A362983DC98000FAD1A /* Operator.swift */,
+				BF994A382983F221000FAD1A /* ExpressionParser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -312,6 +315,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF994A392983F221000FAD1A /* ExpressionParser.swift in Sources */,
 				BFC6FFA02980E03000629399 /* LinkedList.swift in Sources */,
 				BF5E81BB29837F10009A839B /* extensions.swift in Sources */,
 				BFC6FF9E2980DFF400629399 /* CalculateItem.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -61,6 +61,17 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFFC49482986830C001AC392"
+               BuildableName = "FormularTests.xctest"
+               BlueprintName = "FormularTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -50,6 +50,17 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFABE1E8298569930089F381"
+               BuildableName = "ExpressionParserTests.xctest"
+               BlueprintName = "ExpressionParserTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -13,11 +13,6 @@ struct CalculatorItemQueue<T: CalculateItem> {
     }
     
     @discardableResult
-    func removeRear() -> Node<T>? {
-        return queue.removeLast()
-    }
-    
-    @discardableResult
     func dequeue() -> Node<T>? {
         return queue.removeFirst()
     }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,0 +1,34 @@
+//
+//  ExpressionParser.swift
+//  Calculator
+//
+//  Created by 혜모리 on 2023/01/27.
+//
+
+enum ExpressionParser {
+    static func parse(from input: String) -> Formula {
+        let operatorValues = Operator.allCases.map { String($0.rawValue) }
+        let operands = componentsByOperators(from: input)
+        let operators = input.split(with: " ").filter { return operatorValues.contains($0) }
+        let formula = Formula()
+        
+        operands
+            .compactMap { Double($0) }
+            .forEach { formula.operands.enqueue($0) }
+        operators
+            .compactMap { Operator.init(rawValue: Character($0)) }
+            .forEach { formula.operators.enqueue($0) }
+        return formula
+    }
+    
+    private static func componentsByOperators(from input: String) -> [String] {
+        let operatorValues = Operator.allCases.map { String($0.rawValue) }
+        var inputs: [String] = []
+        let result: [String]
+        let delimiter: Character = " "
+        
+        inputs = input.split(with: delimiter)
+        result = inputs.filter { return operatorValues.contains($0) == false }
+        return result
+    }
+}

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -9,7 +9,7 @@ enum ExpressionParser {
     static func parse(from input: String) -> Formula {
         let operatorValues = Operator.allCases.map { String($0.rawValue) }
         let operands = componentsByOperators(from: input)
-        let operators = input.split(with: " ").filter { return operatorValues.contains($0) }
+        let operators = input.split(with: " ").filter { operatorValues.contains($0) }
         let formula = Formula()
         
         operands
@@ -28,7 +28,7 @@ enum ExpressionParser {
         let delimiter: Character = " "
         
         inputs = input.split(with: delimiter)
-        result = inputs.filter { return operatorValues.contains($0) == false }
+        result = inputs.filter { operatorValues.contains($0) == false }
         return result
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -9,7 +9,16 @@ struct Formula {
     var operands: CalculatorItemQueue<Double> = CalculatorItemQueue()
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue()
     
-    func result() {
+    func result() -> Double {
+        var result: Double = operands.dequeue()?.value ?? 0.0
         
+        while operands.queue.isEmpty == false {
+            guard let operatorValue = self.operators.dequeue()?.value,
+                  let rhs = operands.dequeue()?.value
+            else { break }
+            
+            result = operatorValue.calculate(lhs: result, rhs: rhs)
+        }
+        return result
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -10,7 +10,7 @@ struct Formula {
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue()
     
     func result() -> Double {
-        var result: Double = operands.dequeue()?.value ?? 0.0
+        var result: Double = operands.dequeue()?.value ?? 0
         
         while operands.queue.isEmpty == false {
             guard let operatorValue = self.operators.dequeue()?.value,

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,0 +1,15 @@
+//
+//  Formula.swift
+//  Calculator
+//
+//  Created by 혜모리 on 2023/01/28.
+//
+
+struct Formula {
+    var operands: CalculatorItemQueue<Double> = CalculatorItemQueue()
+    var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue()
+    
+    func result() {
+        
+    }
+}

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -25,29 +25,6 @@ final class LinkedList<T: CalculateItem> {
     }
     
     @discardableResult
-    func removeLast() -> Node<T>? {
-        var currentNode = head
-        
-        guard isEmpty == false else {
-            return nil
-        }
-        
-        guard tail != nil else {
-            head = nil
-            return currentNode
-        }
-        
-        while currentNode?.next?.next != nil {
-            currentNode = currentNode?.next
-        }
-        
-        let lastNode = currentNode?.next
-        currentNode?.next = nil
-        tail = currentNode
-        return lastNode
-    }
-    
-    @discardableResult
     func removeFirst() -> Node<T>? {
         let firstNode = head
         

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -24,20 +24,20 @@ enum Operator: Character, CaseIterable, CalculateItem {
         }
     }
 
-    func add(lhs: Double, rhs: Double) -> Double {
+    private func add(lhs: Double, rhs: Double) -> Double {
         return lhs + rhs
     }
 
-    func subtract(lhs: Double, rhs: Double) -> Double {
+    private func subtract(lhs: Double, rhs: Double) -> Double {
         return lhs - rhs
     }
 
-    func divide(lhs: Double, rhs: Double) -> Double {
+    private func divide(lhs: Double, rhs: Double) -> Double {
         guard rhs != 0 else { return .nan }
         return lhs / rhs
     }
 
-    func multiply(lhs: Double, rhs: Double) -> Double {
+    private func multiply(lhs: Double, rhs: Double) -> Double {
         return lhs * rhs
     }
 }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -33,6 +33,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
     }
 
     func divide(lhs: Double, rhs: Double) -> Double {
+        guard rhs != 0 else { return .nan }
         return lhs / rhs
     }
 

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -1,0 +1,42 @@
+//
+//  Operator.swift
+//  Calculator
+//
+//  Created by 혜모리 on 2023/01/27.
+//
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+"
+    case subtract = "-"
+    case divide = "/"
+    case multiply = "*"
+
+    func calculate(lhs: Double, rhs: Double) -> Double {
+        switch self {
+        case .add :
+            return add(lhs: lhs, rhs: rhs)
+        case .subtract :
+            return subtract(lhs: lhs, rhs: rhs)
+        case .divide :
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply :
+            return multiply(lhs: lhs, rhs: rhs)
+        }
+    }
+
+    func add(lhs: Double, rhs: Double) -> Double {
+        return lhs + rhs
+    }
+
+    func subtract(lhs: Double, rhs: Double) -> Double {
+        return lhs - rhs
+    }
+
+    func divide(lhs: Double, rhs: Double) -> Double {
+        return lhs / rhs
+    }
+
+    func multiply(lhs: Double, rhs: Double) -> Double {
+        return lhs * rhs
+    }
+}

--- a/Calculator/Calculator/Model/extensions.swift
+++ b/Calculator/Calculator/Model/extensions.swift
@@ -1,10 +1,14 @@
 //
-//  String+CalculatorItem.swift
+//  extensions.swift
 //  Calculator
 //
 //  Created by 혜모리 on 2023/01/27.
 //
 
 extension String: CalculateItem {
+    
+}
+
+extension Double: CalculateItem {
     
 }

--- a/Calculator/Calculator/Model/extensions.swift
+++ b/Calculator/Calculator/Model/extensions.swift
@@ -6,7 +6,9 @@
 //
 
 extension String: CalculateItem {
-    
+    func split(with target: Character) -> [String] {
+        return self.components(separatedBy: String(target))
+    }
 }
 
 extension Double: CalculateItem {

--- a/Calculator/CalculatorItemQueueTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorItemQueueTests/CalculatorItemQueueTests.swift
@@ -47,20 +47,6 @@ final class CalculatorItemQueueTests: XCTestCase {
         XCTAssertEqual(expectation, tailOfQueue)
     }
     
-    func test_removeRear호출시_마지막으로입력한3이삭제되고_tail이2가된다() {
-        // given
-        sut.enqueue("1")
-        sut.enqueue("2")
-        sut.enqueue("3")
-        let expectation = "2"
-        
-        // when
-        sut.removeRear()
-        
-        // then
-        XCTAssertEqual(sut.queue.tail?.value, expectation)
-    }
-    
     func test_deququ호출시_맨처음입력한1이삭제되고_head는2가된다() {
         // given
         sut.enqueue("1")

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -21,7 +21,7 @@ final class ExpressionParserTests: XCTestCase {
         sut = nil
     }
 
-    func test_parse호출시_연산자와피연산자를나눠_Formula로반환한다() {
+    func test_parse호출시_연산자와피연산자를나눠_Formula로반환한뒤_각각맨앞의요소를비교한다() {
         // given
         let calculatorValue = "1 + 2 * 4 / 3 + -7 + 8"
         let operatorsExpectation: [Operator] = [.add, .multiply, .divide, .add, .add]

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -1,0 +1,37 @@
+//
+//  ExpressionParserTests.swift
+//  ExpressionParserTests
+//
+//  Created by 혜모리 on 2023/01/28.
+//
+
+import XCTest
+@testable import Calculator
+
+final class ExpressionParserTests: XCTestCase {
+    var sut: Formula!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Formula()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+
+    func test_parse호출시_연산자와피연산자를나눠_Formula로반환한다() {
+        // given
+        let calculatorValue = "1 + 2 * 4 / 3 + -7 + 8"
+        let operatorsExpectation: [Operator] = [.add, .multiply, .divide, .add, .add]
+        let operandsExpectation: [Double] = [1, 2, 4, 3, -7, 8]
+        
+        // when
+        sut = ExpressionParser.parse(from: calculatorValue)
+        
+        // then
+        XCTAssertEqual(operatorsExpectation[0], sut.operators.dequeue()?.value)
+        XCTAssertEqual(operandsExpectation[0], sut.operands.dequeue()?.value)
+    }
+}

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -21,17 +21,33 @@ final class ExpressionParserTests: XCTestCase {
         sut = nil
     }
 
-    func test_parse호출시_연산자와피연산자를나눠_Formula로반환한뒤_각각맨앞의요소를비교한다() {
+    func test_parse호출시_operandsExpectation요소와_operands의value가모두같다() {
         // given
         let calculatorValue = "1 + 2 * 4 / 3 + -7 + 8"
-        let operatorsExpectation: [Operator] = [.add, .multiply, .divide, .add, .add]
         let operandsExpectation: [Double] = [1, 2, 4, 3, -7, 8]
+        let operandsCount = operandsExpectation.count
         
         // when
         sut = ExpressionParser.parse(from: calculatorValue)
         
         // then
-        XCTAssertEqual(operatorsExpectation[0], sut.operators.dequeue()?.value)
-        XCTAssertEqual(operandsExpectation[0], sut.operands.dequeue()?.value)
+        for count in 0..<operandsCount {
+            XCTAssertEqual(operandsExpectation[count], sut.operands.dequeue()?.value)
+        }
+    }
+    
+    func test_parse호출시_operatorsExpectation요소와_operators의value가모두같다() {
+        // given
+        let calculatorValue = "1 + 2 * 4 / 3 + -7 + 8"
+        let operatorsExpectation: [Operator] = [.add, .multiply, .divide, .add, .add]
+        let operatorsCount = operatorsExpectation.count
+        
+        // when
+        sut = ExpressionParser.parse(from: calculatorValue)
+        
+        // then
+        for count in 0..<operatorsCount {
+            XCTAssertEqual(operatorsExpectation[count], sut.operators.dequeue()?.value)
+        }
     }
 }

--- a/Calculator/FormularTests/FormularTests.swift
+++ b/Calculator/FormularTests/FormularTests.swift
@@ -1,0 +1,49 @@
+//
+//  FormularTests.swift
+//  FormularTests
+//
+//  Created by 혜모리 on 2023/01/29.
+//
+
+import XCTest
+@testable import Calculator
+
+final class FormularTests: XCTestCase {
+    var sut: Formula!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Formula()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_result호출시_다음의연산결과는_724이다() {
+        // 1000 + 30 * 2 / 2.5 - 10.8 + -89.2
+        
+        // given
+        let expectation: Double = 724
+        
+        sut.operands.enqueue(1000)
+        sut.operands.enqueue(30)
+        sut.operands.enqueue(2)
+        sut.operands.enqueue(2.5)
+        sut.operands.enqueue(10.8)
+        sut.operands.enqueue(-89.2)
+        
+        sut.operators.enqueue(.add)
+        sut.operators.enqueue(.multiply)
+        sut.operators.enqueue(.divide)
+        sut.operators.enqueue(.subtract)
+        sut.operators.enqueue(.add)
+        
+        // when
+        let result = sut.result()
+        
+        // then
+        XCTAssertEqual(expectation, result)
+    }
+}

--- a/Calculator/FormularTests/FormularTests.swift
+++ b/Calculator/FormularTests/FormularTests.swift
@@ -21,6 +21,17 @@ final class FormularTests: XCTestCase {
         sut = nil
     }
     
+    func test_모든큐가비어있을때_result호출시_연산결과는0이다() {
+        // given
+        let expectation: Double = 0
+        
+        // when
+        let result = sut.result()
+        
+        // then
+        XCTAssertEqual(expectation, result)
+    }
+    
     func test_result호출시_다음의연산결과는_724이다() {
         // 1000 + 30 * 2 / 2.5 - 10.8 + -89.2
         
@@ -45,5 +56,26 @@ final class FormularTests: XCTestCase {
         
         // then
         XCTAssertEqual(expectation, result)
+    }
+    
+    func test_0으로나누는것이_연산에포함되어있을때_결과는NaN이다() {
+        // 2 * 1000 / 0 + 1
+        
+        // given
+        sut.operands.enqueue(2)
+        sut.operands.enqueue(1000)
+        sut.operands.enqueue(0)
+        sut.operands.enqueue(1)
+        
+        sut.operators.enqueue(.multiply)
+        sut.operators.enqueue(.divide)
+        sut.operators.enqueue(.add)
+        
+        // when
+        let result = sut.result()
+        print(result)
+        
+        // then
+        XCTAssertTrue(result.isNaN)
     }
 }

--- a/Calculator/LinkedListTests/LinkedListTests.swift
+++ b/Calculator/LinkedListTests/LinkedListTests.swift
@@ -45,28 +45,6 @@ final class LinkedListTests: XCTestCase {
         XCTAssertEqual(targetNode?.next?.value, expectation)
     }
     
-    func test_removeLast호출시_빈List인경우_nil을반환한다() {
-        // given, when
-        let result = sut.removeLast()
-        
-        // then
-        XCTAssertNil(result)
-    }
-    
-    func test_removeLast호출시_List에1_2_3이있는경우_3이삭제되고_tail은2가된다() {
-        // given
-        sut.appendLast("1")
-        sut.appendLast("2")
-        sut.appendLast("3")
-        let expectation = "2"
-
-        // when
-        sut.removeLast()
-
-        // then
-        XCTAssertEqual(sut.tail?.value, expectation)
-    }
-    
     func test_removeFirst호출시_빈List인경우_nil을반환한다() {
         // given, when
         let result = sut.removeFirst()


### PR DESCRIPTION
안녕하세요 웡빙! ( @wongbingg ) 
계산기 프로젝트 STEP2 PR 보냅니다!
한 기능에서 이틀을 보낸적이 처음이라 많이 어려워 몸과 마음이 힘들었습니다
TDD는 시간상 조금 부담이 돼서, Queue 부분만 최소한의 테스트를 할 수 있도록 Unit test 함수를 작성했습니다.
그럼 이번에도 리뷰 잘 부탁드립니다! 감사합니다 😊

---
## 고민한 내용

### 1️⃣ 요구사항 내 UML 분석
UML을 분석하여 기능을 만드는 것이 굉장히 어려운 일이었습니다. 많은 고민 끝에 아래와 같은 기준으로 기능을 구현했습니다.

- `String extension`
    - `split` 메서드 : Character 타입의 매개변수를 기준으로 String 값을 나누어 [String]로 반환하는 함수
- `Operator` : 연산자를 정의하는 역할
    - `add`, `subtract`, `divide`, `multiply` 메서드 : 입력한 매개변수인 lhs, rhs를 각각의 연산자로 연산해주는 함수
    - `calculrate` 메서드 : 연산자 모양을 확인한 후 알맞은 연산을 한 후 Double 타입으로 연산 결과값을 반환해주는 함수
- `ExpressionParser` : View에서 받아온 연산 문자열(String)을 파싱하여 큐에 담아주는 역할
    - `parse` 메서드 : 연산자 배열과 피연산자 배열을 앞에서부터 차근차근 enqueue해주는 함수
    - `componentsByOperators` 메서드 : View에서 받아온 연산 문자열(String)을 연산자를 기준으로 나누고, 연속되는 피연산자를 합쳐서 피연산자 배열을 만들어주는 함수
- `Formula` : 연산하는 역할
    - `result` 메서드 : 연산자, 피연산자 Queue와 Operator를 사용하여 계산한 후(calculrate) 결과를 담아주는 함수

### 2️⃣ split 구현 방법
문자열을 분리할 수 있는 기능인 `components`와 `split` 중 무엇을 쓸지 고민했습니다. 둘의 차이점을 간단하게 보자면 아래와 같습니다.

`components(separatedBy:)` : Foundation을 import 해야한다, 반환타입이 `[String]`이다
`split(separator:maxSplits:omittingEmptySubsequences:)` : Foundation을 import 하지 않아도 된다, 반환타입이 `[String.SubSequence]`이다

Foundation 프레임워크를 사용하지 않아도 되는 split도 괜찮았으나, 요구사항에 제시된 split 함수의 반환타입이 `[String]`이라 
굳이 String 변환 작업을 거치지 않고싶어 components를 사용하였습니다.

### 3️⃣ 0으로 나누기를 시도하는 경우
계산기에 0으로 나누기를 시도하는 경우 NaN으로 표시되는 기능이 있어 고민해보다가
동기 캠퍼 카키의 TIL을 보고 `.nan` 이라는 타입 프로퍼티의 존재를 알게되었습니다. 
`FloatingPoint` 프로토콜을 채택하는 부동 소수점 타입인 Double에서 사용할 수 있는 타입 프로퍼티입니다 `NaN(“not a number”)`
0으로 나눌 경우 .nan으로 리턴하도록 구현해 보았습니다.

``` swift
func divide(lhs: Double, rhs: Double) -> Double {
    guard rhs != 0 else { return .nan }
    return lhs / rhs
}
```

### 4️⃣ 연산식을 분리하는 방법
`componentsByOperators`가 이틀을 잡아먹은 주범이었습니다... 😭
처음에는 ["`+`", "`-`", "`/`", "`*`"]으로 `split`해버리면 간단하겠다고 생각했습니다.

너무나도 매직 리터럴 같아 Operator의 case의 rawValue를 쓰기위해 이것저것 조사하며 코드를 구현하다보니 마지막 쯤 음수의 존재를 떠올리게 됐습니다.
값이 1+-3*4+2*-3 이런 식으로 전달되면 음수도 양수로 분리되어버리는 상황이 발생하였습니다.
인수를 차례대로 확인해서 +-, --, *-, /- 등 연산자가 중복되는 요소를 찾아 그 다음 숫자를 음수로 바꿔야할지 그렇다면 어떻게 구현을 할지 이런저런 많은 고민을 해봤지만,
View에서 연산자, 피연산자를 붙일 때 특정 문자를 구분 용도로 붙여주는 것을 생각하고 `" "`으로 split하기로 결정하였습니다.
이런저런 조건이 들어가 코드가 복잡해지는 것보다는 단순하게 빈칸만으로도 원하는 결과를 가져올 수 있으니 그 편이 더 경제적이라고 판단했습니다.

### 5️⃣ removeLast 삭제
저번 스텝에서 removeLast 구현 이유를 질문해 주셨는데 이제야 이유를 알게됐습니다 ...❗️
STEP 2 내용을 검토해보니 Queue에서 rear를 삭제하는 기능은 필요없다고 판단되어 해당 기능은 삭제하였습니다.