### PR TITLE
계산기 [STEP3] 무리

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4BDFC915297FE1CF009E551B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		4BDFC916297FE296009E551B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 		4BDFC917297FE296009E551B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		4BF3F0F6299004D3000F27F5 /* Sign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF3F0F5299004D3000F27F5 /* Sign.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -56,6 +57,7 @@
 		4BC06361297F908A003829EE /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BC06363297F908A003829EE /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		4BDFC90A297FC25B009E551B /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
+		4BF3F0F5299004D3000F27F5 /* Sign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sign.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 				4BBDD6D82987808900EE8AB7 /* Extension.swift */,
 				4BBDD6D629877D1800EE8AB7 /* ExpressionParser.swift */,
 				4B9D21912984071000B26516 /* Operator.swift */,
+				4BF3F0F5299004D3000F27F5 /* Sign.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -308,6 +311,7 @@
 			files = (
 				4B6E8C0F2981478300E17956 /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				4BF3F0F6299004D3000F27F5 /* Sign.swift in Sources */,
 				4B9D21902983F41500B26516 /* Formula.swift in Sources */,
 				4BBDD6D92987808900EE8AB7 /* Extension.swift in Sources */,
 				4BDFC90B297FC25B009E551B /* CalculatorItemQueue.swift in Sources */,

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -244,6 +244,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="zeroButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JJL-vt-5k7"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -252,6 +255,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="zeroButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vXR-pp-oPy"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="220.5" width="382" height="52"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
@@ -108,6 +108,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ul3-vg-AuL"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -121,6 +124,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zh1-D4-vbP"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -129,6 +135,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="A4B-7v-dLK"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -137,6 +146,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cIr-E3-44E"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -145,6 +157,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9xg-6b-znl"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -158,6 +173,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aHA-qe-5Jk"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -166,6 +184,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4xm-PR-5g5"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -174,6 +195,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Cdw-9e-cON"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -182,6 +206,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hSz-eL-21O"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -195,6 +222,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6P3-Qf-3I6"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -203,6 +233,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="XT4-R4-dqs"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -211,6 +244,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cQL-wS-Nfs"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -219,6 +255,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AVT-vz-6pq"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -232,6 +271,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZbN-rT-d5G"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -240,6 +282,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rZn-u6-4Y0"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -259,25 +304,28 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5nM-sf-Wae"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="292.5" width="382" height="50"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="21" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
+                                                <rect key="frame" x="29" y="0.0" width="353" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -302,6 +350,26 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="inputOperandsLabel" destination="Lwz-OF-XHD" id="aXS-9e-oDW"/>
+                        <outlet property="inputOperatorsLabel" destination="HPC-iy-qdm" id="9hG-qq-9tV"/>
+                        <outletCollection property="operandsButton" destination="mSz-Y3-r5Z" collectionClass="NSMutableArray" id="k4I-Bw-z68"/>
+                        <outletCollection property="operandsButton" destination="nCE-qB-NiN" collectionClass="NSMutableArray" id="pmH-jH-xq6"/>
+                        <outletCollection property="operandsButton" destination="Rif-2S-UU2" collectionClass="NSMutableArray" id="mQo-DH-7DV"/>
+                        <outletCollection property="operandsButton" destination="X8H-iH-tSd" collectionClass="NSMutableArray" id="cgq-iY-lEe"/>
+                        <outletCollection property="operandsButton" destination="hQm-yz-XvG" collectionClass="NSMutableArray" id="oUf-Uz-Sxz"/>
+                        <outletCollection property="operandsButton" destination="vpW-df-OLm" collectionClass="NSMutableArray" id="WGA-zK-SRd"/>
+                        <outletCollection property="operandsButton" destination="OaY-Mw-CPv" collectionClass="NSMutableArray" id="d85-a3-zgb"/>
+                        <outletCollection property="operandsButton" destination="L6z-2G-Gar" collectionClass="NSMutableArray" id="CHr-Am-4RL"/>
+                        <outletCollection property="operandsButton" destination="xgT-2D-A49" collectionClass="NSMutableArray" id="WUn-7v-IQz"/>
+                        <outletCollection property="operandsButton" destination="zcj-xJ-ruw" collectionClass="NSMutableArray" id="AmS-4u-GXw"/>
+                        <outletCollection property="operandsButton" destination="sH6-8l-kje" collectionClass="NSMutableArray" id="YTU-0E-p8n"/>
+                        <outletCollection property="operatorsButton" destination="sbh-wC-koF" collectionClass="NSMutableArray" id="cw1-gP-mQw"/>
+                        <outletCollection property="operatorsButton" destination="nTe-Sn-Pvd" collectionClass="NSMutableArray" id="YOv-JL-5Gp"/>
+                        <outletCollection property="operatorsButton" destination="Tfz-eM-jll" collectionClass="NSMutableArray" id="2wS-Ue-xdJ"/>
+                        <outletCollection property="operatorsButton" destination="811-Pz-An6" collectionClass="NSMutableArray" id="gVf-hU-IzQ"/>
+                        <outletCollection property="operatorsButton" destination="Daw-iX-Owl" collectionClass="NSMutableArray" id="7ES-Q7-wMI"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -84,6 +84,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="allClearButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="B7G-x8-CNC"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -92,6 +95,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="clearEntryButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="X7H-SY-JoJ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -100,6 +106,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="changeSignButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aIC-BT-Qk5"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -282,9 +282,6 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
-                                                <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rZn-u6-4Y0"/>
-                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -304,9 +301,6 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
-                                                <connections>
-                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5nM-sf-Wae"/>
-                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -363,12 +357,10 @@
                         <outletCollection property="operandsButton" destination="L6z-2G-Gar" collectionClass="NSMutableArray" id="CHr-Am-4RL"/>
                         <outletCollection property="operandsButton" destination="xgT-2D-A49" collectionClass="NSMutableArray" id="WUn-7v-IQz"/>
                         <outletCollection property="operandsButton" destination="zcj-xJ-ruw" collectionClass="NSMutableArray" id="AmS-4u-GXw"/>
-                        <outletCollection property="operandsButton" destination="sH6-8l-kje" collectionClass="NSMutableArray" id="YTU-0E-p8n"/>
                         <outletCollection property="operatorsButton" destination="sbh-wC-koF" collectionClass="NSMutableArray" id="cw1-gP-mQw"/>
                         <outletCollection property="operatorsButton" destination="nTe-Sn-Pvd" collectionClass="NSMutableArray" id="YOv-JL-5Gp"/>
                         <outletCollection property="operatorsButton" destination="Tfz-eM-jll" collectionClass="NSMutableArray" id="2wS-Ue-xdJ"/>
                         <outletCollection property="operatorsButton" destination="811-Pz-An6" collectionClass="NSMutableArray" id="gVf-hU-IzQ"/>
-                        <outletCollection property="operatorsButton" destination="Daw-iX-Owl" collectionClass="NSMutableArray" id="7ES-Q7-wMI"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -334,6 +334,7 @@
                         <outlet property="dotButton" destination="h8q-5h-bnb" id="jBK-ro-ka8"/>
                         <outlet property="inputOperandsLabel" destination="Lwz-OF-XHD" id="aXS-9e-oDW"/>
                         <outlet property="inputOperatorsLabel" destination="HPC-iy-qdm" id="9hG-qq-9tV"/>
+                        <outlet property="scrollView" destination="BOT-7g-vxv" id="frb-tw-nW7"/>
                         <outlet property="stackView" destination="XRe-QE-UJf" id="gtR-FF-5FC"/>
                         <outletCollection property="operandsButton" destination="nCE-qB-NiN" collectionClass="NSMutableArray" id="pmH-jH-xq6"/>
                         <outletCollection property="operandsButton" destination="Rif-2S-UU2" collectionClass="NSMutableArray" id="mQo-DH-7DV"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -329,7 +329,7 @@
                     <connections>
                         <outlet property="allClearButton" destination="ped-N8-JbY" id="9xc-Cz-CBU"/>
                         <outlet property="calculationButton" destination="Daw-iX-Owl" id="g7R-Fe-iwd"/>
-                        <outlet property="changSignButton" destination="ows-U7-mNc" id="IdK-3P-KhT"/>
+                        <outlet property="changeSignButton" destination="ows-U7-mNc" id="IdK-3P-KhT"/>
                         <outlet property="clearEntryButton" destination="RLD-dY-LOA" id="iYk-3N-Nfq"/>
                         <outlet property="dotButton" destination="h8q-5h-bnb" id="jBK-ro-ka8"/>
                         <outlet property="inputOperandsLabel" destination="Lwz-OF-XHD" id="aXS-9e-oDW"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -244,9 +244,6 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
-                                                <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZbN-rT-d5G"/>
-                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -255,9 +252,6 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
-                                                <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cbx-kW-9gL"/>
-                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -335,7 +329,6 @@
                         <outlet property="inputOperandsLabel" destination="Lwz-OF-XHD" id="aXS-9e-oDW"/>
                         <outlet property="inputOperatorsLabel" destination="HPC-iy-qdm" id="9hG-qq-9tV"/>
                         <outlet property="stackView" destination="XRe-QE-UJf" id="gtR-FF-5FC"/>
-                        <outletCollection property="operandsButton" destination="mSz-Y3-r5Z" collectionClass="NSMutableArray" id="k4I-Bw-z68"/>
                         <outletCollection property="operandsButton" destination="nCE-qB-NiN" collectionClass="NSMutableArray" id="pmH-jH-xq6"/>
                         <outletCollection property="operandsButton" destination="Rif-2S-UU2" collectionClass="NSMutableArray" id="mQo-DH-7DV"/>
                         <outletCollection property="operandsButton" destination="X8H-iH-tSd" collectionClass="NSMutableArray" id="cgq-iY-lEe"/>
@@ -349,7 +342,8 @@
                         <outletCollection property="operatorsButton" destination="nTe-Sn-Pvd" collectionClass="NSMutableArray" id="YOv-JL-5Gp"/>
                         <outletCollection property="operatorsButton" destination="Tfz-eM-jll" collectionClass="NSMutableArray" id="2wS-Ue-xdJ"/>
                         <outletCollection property="operatorsButton" destination="811-Pz-An6" collectionClass="NSMutableArray" id="gVf-hU-IzQ"/>
-                        <outletCollection property="operandsButton" destination="sH6-8l-kje" collectionClass="NSMutableArray" id="OBe-y9-brq"/>
+                        <outletCollection property="zeroButton" destination="mSz-Y3-r5Z" collectionClass="NSMutableArray" id="hqZ-XW-peu"/>
+                        <outletCollection property="zeroButton" destination="sH6-8l-kje" collectionClass="NSMutableArray" id="BxJ-N6-zhB"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -255,6 +255,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cbx-kW-9gL"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -346,6 +349,7 @@
                         <outletCollection property="operatorsButton" destination="nTe-Sn-Pvd" collectionClass="NSMutableArray" id="YOv-JL-5Gp"/>
                         <outletCollection property="operatorsButton" destination="Tfz-eM-jll" collectionClass="NSMutableArray" id="2wS-Ue-xdJ"/>
                         <outletCollection property="operatorsButton" destination="811-Pz-An6" collectionClass="NSMutableArray" id="gVf-hU-IzQ"/>
+                        <outletCollection property="operandsButton" destination="sH6-8l-kje" collectionClass="NSMutableArray" id="OBe-y9-brq"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -327,30 +327,10 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="allClearButton" destination="ped-N8-JbY" id="9xc-Cz-CBU"/>
-                        <outlet property="calculationButton" destination="Daw-iX-Owl" id="g7R-Fe-iwd"/>
-                        <outlet property="changeSignButton" destination="ows-U7-mNc" id="IdK-3P-KhT"/>
-                        <outlet property="clearEntryButton" destination="RLD-dY-LOA" id="iYk-3N-Nfq"/>
-                        <outlet property="dotButton" destination="h8q-5h-bnb" id="jBK-ro-ka8"/>
                         <outlet property="inputOperandsLabel" destination="Lwz-OF-XHD" id="aXS-9e-oDW"/>
                         <outlet property="inputOperatorsLabel" destination="HPC-iy-qdm" id="9hG-qq-9tV"/>
                         <outlet property="scrollView" destination="BOT-7g-vxv" id="frb-tw-nW7"/>
                         <outlet property="stackView" destination="XRe-QE-UJf" id="gtR-FF-5FC"/>
-                        <outletCollection property="operandsButton" destination="nCE-qB-NiN" collectionClass="NSMutableArray" id="pmH-jH-xq6"/>
-                        <outletCollection property="operandsButton" destination="Rif-2S-UU2" collectionClass="NSMutableArray" id="mQo-DH-7DV"/>
-                        <outletCollection property="operandsButton" destination="X8H-iH-tSd" collectionClass="NSMutableArray" id="cgq-iY-lEe"/>
-                        <outletCollection property="operandsButton" destination="hQm-yz-XvG" collectionClass="NSMutableArray" id="oUf-Uz-Sxz"/>
-                        <outletCollection property="operandsButton" destination="vpW-df-OLm" collectionClass="NSMutableArray" id="WGA-zK-SRd"/>
-                        <outletCollection property="operandsButton" destination="OaY-Mw-CPv" collectionClass="NSMutableArray" id="d85-a3-zgb"/>
-                        <outletCollection property="operandsButton" destination="L6z-2G-Gar" collectionClass="NSMutableArray" id="CHr-Am-4RL"/>
-                        <outletCollection property="operandsButton" destination="xgT-2D-A49" collectionClass="NSMutableArray" id="WUn-7v-IQz"/>
-                        <outletCollection property="operandsButton" destination="zcj-xJ-ruw" collectionClass="NSMutableArray" id="AmS-4u-GXw"/>
-                        <outletCollection property="operatorsButton" destination="sbh-wC-koF" collectionClass="NSMutableArray" id="cw1-gP-mQw"/>
-                        <outletCollection property="operatorsButton" destination="nTe-Sn-Pvd" collectionClass="NSMutableArray" id="YOv-JL-5Gp"/>
-                        <outletCollection property="operatorsButton" destination="Tfz-eM-jll" collectionClass="NSMutableArray" id="2wS-Ue-xdJ"/>
-                        <outletCollection property="operatorsButton" destination="811-Pz-An6" collectionClass="NSMutableArray" id="gVf-hU-IzQ"/>
-                        <outletCollection property="zeroButton" destination="mSz-Y3-r5Z" collectionClass="NSMutableArray" id="hqZ-XW-peu"/>
-                        <outletCollection property="zeroButton" destination="sH6-8l-kje" collectionClass="NSMutableArray" id="BxJ-N6-zhB"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -16,47 +16,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="220.5" width="382" height="52"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
+                                <rect key="frame" x="16" y="248.5" width="382" height="24"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="24"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -367,7 +331,7 @@
                         <outlet property="dotButton" destination="h8q-5h-bnb" id="jBK-ro-ka8"/>
                         <outlet property="inputOperandsLabel" destination="Lwz-OF-XHD" id="aXS-9e-oDW"/>
                         <outlet property="inputOperatorsLabel" destination="HPC-iy-qdm" id="9hG-qq-9tV"/>
-                        <outlet property="scrollView" destination="BOT-7g-vxv" id="plZ-g0-Q5b"/>
+                        <outlet property="stackView" destination="XRe-QE-UJf" id="gtR-FF-5FC"/>
                         <outletCollection property="operandsButton" destination="mSz-Y3-r5Z" collectionClass="NSMutableArray" id="k4I-Bw-z68"/>
                         <outletCollection property="operandsButton" destination="nCE-qB-NiN" collectionClass="NSMutableArray" id="pmH-jH-xq6"/>
                         <outletCollection property="operandsButton" destination="Rif-2S-UU2" collectionClass="NSMutableArray" id="mQo-DH-7DV"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -299,6 +299,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="dotButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uyo-vs-AQZ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -361,8 +364,10 @@
                         <outlet property="calculationButton" destination="Daw-iX-Owl" id="g7R-Fe-iwd"/>
                         <outlet property="changSignButton" destination="ows-U7-mNc" id="IdK-3P-KhT"/>
                         <outlet property="clearEntryButton" destination="RLD-dY-LOA" id="iYk-3N-Nfq"/>
+                        <outlet property="dotButton" destination="h8q-5h-bnb" id="jBK-ro-ka8"/>
                         <outlet property="inputOperandsLabel" destination="Lwz-OF-XHD" id="aXS-9e-oDW"/>
                         <outlet property="inputOperatorsLabel" destination="HPC-iy-qdm" id="9hG-qq-9tV"/>
+                        <outlet property="scrollView" destination="BOT-7g-vxv" id="plZ-g0-Q5b"/>
                         <outletCollection property="operandsButton" destination="mSz-Y3-r5Z" collectionClass="NSMutableArray" id="k4I-Bw-z68"/>
                         <outletCollection property="operandsButton" destination="nCE-qB-NiN" collectionClass="NSMutableArray" id="pmH-jH-xq6"/>
                         <outletCollection property="operandsButton" destination="Rif-2S-UU2" collectionClass="NSMutableArray" id="mQo-DH-7DV"/>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -49,7 +49,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="allClearButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="B7G-x8-CNC"/>
+                                                    <action selector="allClearButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="h3h-OV-gsZ"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
@@ -60,7 +60,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="clearEntryButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="X7H-SY-JoJ"/>
+                                                    <action selector="clearEntryButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="e7p-kY-z28"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
@@ -71,7 +71,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="changeSignButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aIC-BT-Qk5"/>
+                                                    <action selector="changeSignButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ejr-Tx-Q3y"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
@@ -82,7 +82,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ul3-vg-AuL"/>
+                                                    <action selector="operatorsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="c64-2B-qaw"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -98,7 +98,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zh1-D4-vbP"/>
+                                                    <action selector="operandsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8ZQ-uO-kF0"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
@@ -109,7 +109,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="A4B-7v-dLK"/>
+                                                    <action selector="operandsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Hwj-S9-n5a"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
@@ -120,7 +120,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cIr-E3-44E"/>
+                                                    <action selector="operandsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="yGI-WY-J1L"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
@@ -131,7 +131,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9xg-6b-znl"/>
+                                                    <action selector="operatorsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5ir-R1-JRb"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -147,7 +147,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aHA-qe-5Jk"/>
+                                                    <action selector="operandsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dwF-Sv-mXG"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
@@ -158,7 +158,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4xm-PR-5g5"/>
+                                                    <action selector="operandsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JOs-Zv-9Ty"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
@@ -169,7 +169,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Cdw-9e-cON"/>
+                                                    <action selector="operandsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="thI-Sw-Dmc"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
@@ -180,7 +180,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hSz-eL-21O"/>
+                                                    <action selector="operatorsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qjK-eH-0Xo"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -196,7 +196,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6P3-Qf-3I6"/>
+                                                    <action selector="operandsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="v4c-Uv-s4a"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
@@ -207,7 +207,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="XT4-R4-dqs"/>
+                                                    <action selector="operandsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="J8r-AS-gac"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
@@ -218,7 +218,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operandsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cQL-wS-Nfs"/>
+                                                    <action selector="operandsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5C3-MV-BDX"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
@@ -229,7 +229,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="operatorsButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AVT-vz-6pq"/>
+                                                    <action selector="operatorsButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hTP-ca-Wos"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -245,7 +245,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="zeroButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JJL-vt-5k7"/>
+                                                    <action selector="zeroButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zwp-LS-Fcx"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
@@ -256,7 +256,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="zeroButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vXR-pp-oPy"/>
+                                                    <action selector="zeroButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="XAv-ZE-mys"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
@@ -267,7 +267,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="dotButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uyo-vs-AQZ"/>
+                                                    <action selector="dotButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pPr-d0-igL"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
@@ -281,7 +281,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="calculationButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QxO-d9-T7i"/>
+                                                    <action selector="calculationButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tjK-oK-QDL"/>
                                                 </connections>
                                             </button>
                                         </subviews>

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -301,6 +301,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="calculationButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QxO-d9-T7i"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -345,6 +348,10 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="allClearButton" destination="ped-N8-JbY" id="9xc-Cz-CBU"/>
+                        <outlet property="calculationButton" destination="Daw-iX-Owl" id="g7R-Fe-iwd"/>
+                        <outlet property="changSignButton" destination="ows-U7-mNc" id="IdK-3P-KhT"/>
+                        <outlet property="clearEntryButton" destination="RLD-dY-LOA" id="iYk-3N-Nfq"/>
                         <outlet property="inputOperandsLabel" destination="Lwz-OF-XHD" id="aXS-9e-oDW"/>
                         <outlet property="inputOperatorsLabel" destination="HPC-iy-qdm" id="9hG-qq-9tV"/>
                         <outletCollection property="operandsButton" destination="mSz-Y3-r5Z" collectionClass="NSMutableArray" id="k4I-Bw-z68"/>

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -77,12 +77,20 @@ class ViewController: UIViewController {
     
     func formatNumber(_ result: Double) -> String {
         let numberFormatter = NumberFormatter()
+        numberFormatter.maximumIntegerDigits = 20
         numberFormatter.numberStyle = .decimal
+        
         numberFormatter.usesSignificantDigits = true
-        numberFormatter.maximumSignificantDigits = 20
         numberFormatter.roundingMode = .halfUp
+        numberFormatter.maximumSignificantDigits = 20
 
         return numberFormatter.string(from: NSNumber(value: result)) ?? ""
+    }
+    
+    func removeComma(_ inputString: String) -> String {
+        let removedCommaString = inputString.replacingOccurrences(of: ",", with: "")
+        
+        return removedCommaString
     }
     
     func settingScrollView() {
@@ -99,8 +107,18 @@ class ViewController: UIViewController {
         if currentOperand == Sign.zero {
             inputOperandsLabel.text = number
         } else {
-            inputOperandsLabel.text = currentOperand + number
+            let currentNumber = currentOperand + number
+            let removedNumber = removeComma(currentNumber)
+            let formattedString = formatNumber(Double(removedNumber) ?? 0 )
+            
+            inputOperandsLabel.text = formattedString
         }
+    }
+    
+    @IBAction func zeroButtonDidTapped(_ sender: UIButton) {
+        guard let zero = sender.currentTitle,
+              currentOperand != Sign.zero else { return }
+        inputOperandsLabel.text = currentOperand + zero
     }
     
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
@@ -127,12 +145,6 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func zeroButtonDidTapped(_ sender: UIButton) {
-        guard let zero = sender.currentTitle,
-              currentOperand != Sign.zero else { return }
-        inputOperandsLabel.text = currentOperand + zero
-    }
-    
     @IBAction func dotButtonDidTapped(_ sender: UIButton) {
         guard let dot = sender.currentTitle,
               currentOperand.contains(Sign.dot) == false else { return }
@@ -148,12 +160,14 @@ class ViewController: UIViewController {
         currentInputFormula.append(currentOperand)
         
         let stringFormula = currentInputFormula.joined(separator: " ")
-        var parsedFormula = ExpressionParser.parse(from: stringFormula)
+        let removedCommaFormula = removeComma(stringFormula)
+        var parsedFormula = ExpressionParser.parse(from: removedCommaFormula)
         let result = parsedFormula.result()
         print(result)
 
         inputOperatorsLabel.text = ""
         inputOperandsLabel.text = formatNumber(result)
+        print(formatNumber(result))
         oldInputFormula.append(String(result))
         currentInputFormula = []
     }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -78,9 +78,10 @@ class ViewController: UIViewController {
         // 얘는 어디다 써야할까? - currentOperand에 나타나는 숫자
         // inputOperandLabel.text 에 적용하면... 3.0 -> 3으로 인식
         // 넘버포매터 적용한애 자릿수..? 문제...? 으윽...
-        
+        //
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumSignificantDigits = 20
 
         return numberFormatter.string(from: NSNumber(value: result)) ?? ""
     }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -99,7 +99,7 @@ class ViewController: UIViewController {
     }
     
     // 1. 숫자누르고 +- 눌렀을때 -숫자 나오게
-    // 2. 처음 숫자 누르고 스택뷰에 연산자없이 숫자만 입력
+    // 2. 처음 숫자 누르고 스택뷰에 연산자없이 숫자만 입력 o
     // 3. 아무것도 입력하지 않은 0일때 연산자누르면 연산자 한번만 입력
     // 4. ac시 스택뷰 리셋
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
@@ -112,7 +112,7 @@ class ViewController: UIViewController {
                 let lastElement = currentInputFormula.last else { return }
         
         // 연산자 입력 시 동작?
-        // 1. inputOperandsLabel에 입력된 숫자가 currentFormula로 들어감 ㅇ
+        // 1. inputOperandsLabel에 입력된 숫자가 currentFormula로 들어감
         // 2. (처음 입력한 값이라면) stackView에 operator 비우고 operand자리에만 숫자 들어감 ㅇ
         // 3. 0을 입력하지 않았을때 inputOperator가 0이라면 연산자는 마지막에 누른 한개만 들어감
 
@@ -121,14 +121,13 @@ class ViewController: UIViewController {
                 newStackView = makeStackView(Sign.nothing, lastElement)
             }
             else if currentInputFormula.count != 0 && currentInputFormula.count > 1 {
-                let oldOperator = currentInputFormula[currentInputFormula.count-2]
+                let oldOperator = currentInputFormula[currentInputFormula.count-3]
                 newStackView = makeStackView(oldOperator, lastElement)
             }
             currentInputFormula.append(Sign.blank)
             currentInputFormula.append(currentSign)
             currentInputFormula.append(Sign.blank)
-            
-      
+        
             IsOperatortapped = true
         }
         /*
@@ -172,16 +171,29 @@ class ViewController: UIViewController {
     
     
     @IBAction func dotButtonDidTapped(_ sender: UIButton) {
-        if currentInputFormula.last == "." {
-            printex()
-        } else {
-            currentInputFormula[currentInputFormula.count-1] += Sign.dot
-            printex()
+        if let lastElement = currentInputFormula.last {
+            if lastElement.hasSuffix(".") {
+                print("lastElement: \(lastElement)")
+            } else {
+                currentInputFormula[currentInputFormula.count-1] += Sign.dot
+            }
+        } else if currentInputFormula.isEmpty {
+            currentInputFormula.append(Sign.zero + Sign.dot)
+            print(currentInputFormula)
         }
+            
+            
+//        if currentInputFormula.last == "." {
+//            printex()
+//        } else {
+//            currentInputFormula[currentInputFormula.count-1] += Sign.dot
+//            printex()
+//        }
     }
     
     @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
-        let stringFormula = currentInputFormula.joined(separator: " ")
+        let stringFormula = currentInputFormula.joined(separator: "")
+        print("stringformula :\(stringFormula)")
         var parsedFormula = ExpressionParser.parse(from: stringFormula)
         let result = parsedFormula.result()
         IsOperatortapped = false

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -91,7 +91,7 @@ class ViewController: UIViewController {
     }
     
     //MARK: - IBAciton
-    @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
+    @IBAction func operandsButtonTapped(_ sender: UIButton) {
         guard let number = sender.currentTitle else { return }
         
         if currentOperand == Sign.zero {
@@ -105,13 +105,13 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func zeroButtonDidTapped(_ sender: UIButton) {
+    @IBAction func zeroButtonTapped(_ sender: UIButton) {
         guard let zero = sender.currentTitle,
               currentOperand != Sign.zero else { return }
         inputOperandsLabel.text = currentOperand + zero
     }
     
-    @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
+    @IBAction func operatorsButtonTapped(_ sender: UIButton) {
         var newStackView: UIStackView = UIStackView()
         
         guard let currentSign = sender.currentTitle else { return }
@@ -135,13 +135,13 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func dotButtonDidTapped(_ sender: UIButton) {
+    @IBAction func dotButtonTapped(_ sender: UIButton) {
         guard let dot = sender.currentTitle,
               currentOperand.contains(Sign.dot) == false else { return }
         inputOperandsLabel.text = currentOperand + dot
     }
     
-    @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
+    @IBAction func calculationButtonTapped(_ sender: UIButton) {
         let newStackView = makeStackView(currentOperator, currentOperand)
         stackView.addArrangedSubview(newStackView)
         settingScrollView()
@@ -160,14 +160,14 @@ class ViewController: UIViewController {
         currentInputFormula = []
     }
     
-    @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
+    @IBAction func allClearButtonTapped(_ sender: UIButton) {
         reset()
         currentInputFormula = []
         oldInputFormula = []
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
     }
     
-    @IBAction func changeSignButtonDidTapped(_ sender: UIButton) {
+    @IBAction func changeSignButtonTapped(_ sender: UIButton) {
         guard currentOperand != Sign.zero else { return }
         
         if currentOperand.hasPrefix(Sign.minus) {
@@ -177,7 +177,7 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func clearEntryButtonDidTapped(_ sender: UIButton) {
+    @IBAction func clearEntryButtonTapped(_ sender: UIButton) {
         inputOperandsLabel.text = Sign.zero
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -109,17 +109,16 @@ class ViewController: UIViewController {
         print("스택뷰 피연산자: \(currentInputFormula)")
     }
     
+    @IBAction func zeroButtonDidTapped(_ sender: UIButton) {
+        guard let zero = sender.currentTitle,
+              currentOperand != Sign.zero else { return }
+        inputOperandsLabel.text = currentOperand + zero
+    }
+    
     @IBAction func dotButtonDidTapped(_ sender: UIButton) {
-        if let lastElement = currentInputFormula.last {
-            if lastElement.hasSuffix(".") {
-                print("lastElement: \(lastElement)")
-            } else {
-                currentInputFormula[currentInputFormula.count-1] += Sign.dot
-            }
-        } else if currentInputFormula.isEmpty {
-            currentInputFormula.append(Sign.zero + Sign.dot)
-            print(currentInputFormula)
-        }
+        guard let dot = sender.currentTitle,
+              currentOperand.contains(Sign.dot) == false else { return }
+        inputOperandsLabel.text = currentOperand + dot
     }
     
     @IBAction func calculationButtonDidTapped(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -86,6 +86,7 @@ class ViewController: UIViewController {
         numberFormatter.numberStyle = .decimal
         numberFormatter.usesSignificantDigits = true
         numberFormatter.maximumSignificantDigits = 20
+        numberFormatter.roundingMode = .halfUp
 
         return numberFormatter.string(from: NSNumber(value: result)) ?? ""
     }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -24,17 +24,16 @@ class ViewController: UIViewController {
     
     enum Sign {
         static let dot = "."
-        static let doubleZero = "00"
         static let blank = " "
         static let nothing = ""
         static let minus = "-"
         static let zero = "0"
     }
     
-    let operrands = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    let operrands = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "00"]
     let operators = ["+", "−", "÷", "×"]
-    var currentInputFormula: String = Sign.zero
-    var oldInputFormula: String = Sign.nothing
+    var currentInputFormula: [String] = []
+    var oldInputFormula: [String] = []
     var currentTappedNumber: String = Sign.nothing
     var IsOperatortapped: Bool = false
 
@@ -86,15 +85,14 @@ class ViewController: UIViewController {
     
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         let number = operrands[sender.tag]
-        currentTappedNumber = "\(number)"
         
-        if currentInputFormula == Sign.zero {
-            currentInputFormula = "\(number)"
+        if currentInputFormula.isEmpty {
+            currentInputFormula.append(number)
         } else {
-            currentInputFormula = currentInputFormula + "\(number)"
+            currentInputFormula.append(number)
         }
-        let splitedFormula = currentInputFormula.split(with: " ")
-        let currentOperand = splitedFormula.last
+        
+        let currentOperand = currentInputFormula.last
         IsOperatortapped = false
         inputOperandsLabel.text = currentOperand
         printex()
@@ -106,28 +104,31 @@ class ViewController: UIViewController {
     // 4. ac시 스택뷰 리셋
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
         var newStackView: UIStackView = UIStackView()
-        let splitedFormula = currentInputFormula.split(with: " ")
+        
         inputOperatorsLabel.text = operators[sender.tag]
         
         
         guard let currentSign = inputOperatorsLabel.text,
-                let splitedOperand = splitedFormula.last else { return }
+                let lastElement = currentInputFormula.last else { return }
         
         // 연산자 입력 시 동작?
         // 1. inputOperandsLabel에 입력된 숫자가 currentFormula로 들어감 ㅇ
         // 2. (처음 입력한 값이라면) stackView에 operator 비우고 operand자리에만 숫자 들어감 ㅇ
         // 3. 0을 입력하지 않았을때 inputOperator가 0이라면 연산자는 마지막에 누른 한개만 들어감
-        print(splitedFormula)
+
         if IsOperatortapped == false {
-            if splitedFormula.count == 1 {
-                newStackView = makeStackView(Sign.nothing, splitedOperand)
+            if currentInputFormula.count == 1 {
+                newStackView = makeStackView(Sign.nothing, lastElement)
             }
-            else if splitedFormula.count != 0 && splitedFormula.count > 1 {
-                let oldOperator = splitedFormula[splitedFormula.count-2]
-                newStackView = makeStackView(oldOperator, splitedOperand)
+            else if currentInputFormula.count != 0 && currentInputFormula.count > 1 {
+                let oldOperator = currentInputFormula[currentInputFormula.count-2]
+                newStackView = makeStackView(oldOperator, lastElement)
             }
-        
-            currentInputFormula = currentInputFormula + Sign.blank + currentSign + Sign.blank
+            currentInputFormula.append(Sign.blank)
+            currentInputFormula.append(currentSign)
+            currentInputFormula.append(Sign.blank)
+            
+      
             IsOperatortapped = true
         }
         /*
@@ -174,24 +175,25 @@ class ViewController: UIViewController {
         if currentInputFormula.last == "." {
             printex()
         } else {
-            currentInputFormula += Sign.dot
+            currentInputFormula[currentInputFormula.count-1] += Sign.dot
             printex()
         }
     }
     
     @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
-        var parsedFormula = ExpressionParser.parse(from: currentInputFormula)
+        let stringFormula = currentInputFormula.joined(separator: " ")
+        var parsedFormula = ExpressionParser.parse(from: stringFormula)
         let result = parsedFormula.result()
         IsOperatortapped = false
         inputOperandsLabel.text = String(result)
-        oldInputFormula = String(result)
+        oldInputFormula.append(String(result))
         
         printex()
     }
     
     @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
-        currentInputFormula = Sign.zero
-        oldInputFormula = Sign.nothing
+        currentInputFormula = []
+        oldInputFormula = []
         //stackView.removeArrangedSubview(newStackView)
         printex()
     }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -37,15 +37,12 @@ class ViewController: UIViewController {
     var currentOperator: String {
         return inputOperatorsLabel.text ?? Sign.nothing
     }
-    
     var currentInputFormula: [String] = []
     var oldInputFormula: [String] = []
 
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        allocateOperrandsTag()
-        allocateOperatorsTag()
         reset()
     }
     
@@ -76,23 +73,6 @@ class ViewController: UIViewController {
         return view
     }
     
-    func printex(){
-        print("current: \(currentInputFormula)")
-        print("old: \(oldInputFormula)")
-    }
-    
-    func allocateOperrandsTag() {
-        for index in 0..<operandsButton.count {
-            operandsButton[index].tag = index
-        }
-    }
-    
-    func allocateOperatorsTag() {
-        for index in 0..<operatorsButton.count {
-            operatorsButton[index].tag = index
-        }
-    }
-    
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         guard let number = sender.currentTitle else { return }
         
@@ -101,8 +81,6 @@ class ViewController: UIViewController {
         } else {
             inputOperandsLabel.text = currentOperand + number
         }
-        
-        printex()
     }
     
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
@@ -157,8 +135,6 @@ class ViewController: UIViewController {
 
         inputOperandsLabel.text = String(result)
         oldInputFormula.append(String(result))
-        
-        printex()
     }
     
     @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
@@ -180,6 +156,5 @@ class ViewController: UIViewController {
     
     @IBAction func clearEntryButtonDidTapped(_ sender: UIButton) {
         inputOperandsLabel.text = Sign.zero
-        printex()
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -22,26 +22,27 @@ class ViewController: UIViewController {
     @IBOutlet weak var inputOperatorsLabel: UILabel!
     @IBOutlet var stackView: UIStackView!
     
-    let operrands = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    let operators = ["+", "−", "÷", "×"]
-    var currentInputFormula: String = "0"
-    var oldInputFormula: String = ""
-    var formula: [String] = []
-    var currentTappedNumber: String = ""
-    
     enum Sign {
         static let dot = "."
         static let doubleZero = "00"
-        static let black = " "
+        static let blank = " "
         static let nothing = ""
         static let minus = "-"
+        static let zero = "0"
     }
     
+    let operrands = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    let operators = ["+", "−", "÷", "×"]
+    var currentInputFormula: String = Sign.zero
+    var oldInputFormula: String = Sign.nothing
+    var currentTappedNumber: String = Sign.nothing
+    var IsOperatortapped: Bool = false
+
     override func viewDidLoad() {
         super.viewDidLoad()
         allocateOperrandsTag()
         allocateOperatorsTag()
-        updateCurrentInputScreen()
+
     }
     
     func makeStackView(_ operatorSign: String, _ operand: String) -> UIStackView {
@@ -83,52 +84,97 @@ class ViewController: UIViewController {
         }
     }
     
-    func updateCurrentInputScreen() {
-        inputOperandsLabel.text = currentInputFormula
-    }
-    
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         let number = operrands[sender.tag]
         currentTappedNumber = "\(number)"
         
-        if currentInputFormula == "0" {
+        if currentInputFormula == Sign.zero {
             currentInputFormula = "\(number)"
-            updateCurrentInputScreen()
-            printex()
         } else {
             currentInputFormula = currentInputFormula + "\(number)"
-            printex()
         }
+        let splitedFormula = currentInputFormula.split(with: " ")
+        let currentOperand = splitedFormula.last
+        IsOperatortapped = false
+        inputOperandsLabel.text = currentOperand
+        printex()
     }
     
+    // 1. 숫자누르고 +- 눌렀을때 -숫자 나오게
+    // 2. 처음 숫자 누르고 스택뷰에 연산자없이 숫자만 입력
+    // 3. 아무것도 입력하지 않은 0일때 연산자누르면 연산자 한번만 입력
+    // 4. ac시 스택뷰 리셋
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
+        var newStackView: UIStackView = UIStackView()
+        let splitedFormula = currentInputFormula.split(with: " ")
         inputOperatorsLabel.text = operators[sender.tag]
         
-        guard let currentSign = inputOperatorsLabel.text else { return }
         
-        if oldInputFormula != "" {
-            currentInputFormula = oldInputFormula + " " + currentSign + " "
+        guard let currentSign = inputOperatorsLabel.text,
+                let splitedOperand = splitedFormula.last else { return }
+        
+        // 연산자 입력 시 동작?
+        // 1. inputOperandsLabel에 입력된 숫자가 currentFormula로 들어감 ㅇ
+        // 2. (처음 입력한 값이라면) stackView에 operator 비우고 operand자리에만 숫자 들어감 ㅇ
+        // 3. 0을 입력하지 않았을때 inputOperator가 0이라면 연산자는 마지막에 누른 한개만 들어감
+        print(splitedFormula)
+        if IsOperatortapped == false {
+            if splitedFormula.count == 1 {
+                newStackView = makeStackView(Sign.nothing, splitedOperand)
+            }
+            else if splitedFormula.count != 0 && splitedFormula.count > 1 {
+                let oldOperator = splitedFormula[splitedFormula.count-2]
+                newStackView = makeStackView(oldOperator, splitedOperand)
+            }
+        
+            currentInputFormula = currentInputFormula + Sign.blank + currentSign + Sign.blank
+            IsOperatortapped = true
+        }
+        /*
+        else if oldInputFormula != Sign.nothing {
+            print("if")
+            newStackView = makeStackView(currentSign, splitedOperand)
+            currentInputFormula = oldInputFormula + Sign.blank + currentSign + Sign.blank
+            printex()
+            
+        } else if oldInputFormula == Sign.nothing {
+            newStackView = makeStackView(currentSign, splitedOperand)
+            inputOperandsLabel.text = currentOperand
+            currentInputFormula = currentInputFormula + Sign.blank + currentSign + Sign.blank
+            
+        } else {
+            newStackView = makeStackView(currentSign, splitedOperand)
+            inputOperandsLabel.text = currentOperand
+            currentInputFormula = currentInputFormula + Sign.blank + currentSign + Sign.blank
+        }
+        
+        else if inputOperandsLabel.text == Sign.zero && currentTappedNumber != Sign.zero {
+            //currentsign만! 바뀜
+            currentInputFormula = oldInputFormula + Sign.blank + currentSign + Sign.blank
             printex()
         } else {
-            currentInputFormula = currentInputFormula + " " + currentSign + " "
+            currentInputFormula = currentInputFormula + Sign.blank + currentSign + Sign.blank
             printex()
             let newStackView = makeStackView(currentSign, currentTappedNumber)
         }
+        */
         
-        let newStackView = makeStackView(currentSign, currentTappedNumber)
+        
+        inputOperandsLabel.text = Sign.zero
+        
         print("스택뷰 연산자: \(currentSign)")
         print("스택뷰 피연산자: \(currentInputFormula)")
-      
+       
         stackView.addArrangedSubview(newStackView)
     }
     
+    
+    
     @IBAction func dotButtonDidTapped(_ sender: UIButton) {
         if currentInputFormula.last == "." {
-            updateCurrentInputScreen()
             printex()
         } else {
-            currentInputFormula += "."
-            updateCurrentInputScreen()
+            currentInputFormula += Sign.dot
             printex()
         }
     }
@@ -136,24 +182,26 @@ class ViewController: UIViewController {
     @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
         var parsedFormula = ExpressionParser.parse(from: currentInputFormula)
         let result = parsedFormula.result()
+        IsOperatortapped = false
         inputOperandsLabel.text = String(result)
         oldInputFormula = String(result)
+        
         printex()
     }
     
     @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
-        currentInputFormula = "0"
-        oldInputFormula = ""
+        currentInputFormula = Sign.zero
+        oldInputFormula = Sign.nothing
         //stackView.removeArrangedSubview(newStackView)
         printex()
     }
     
     @IBAction func changeSignButtonDidTapped(_ sender: UIButton) {
-        
+
     }
     
     @IBAction func clearEntryButtonDidTapped(_ sender: UIButton) {
-        inputOperandsLabel.text = "0"
+        inputOperandsLabel.text = Sign.zero
         printex()
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+final class ViewController: UIViewController {
     
     //MARK: - UIButton Outlet
     @IBOutlet var operandsButton: [UIButton]!

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
     @IBOutlet var zeroButton: [UIButton]!
     @IBOutlet weak var allClearButton: UIButton!
     @IBOutlet weak var clearEntryButton: UIButton!
-    @IBOutlet weak var changSignButton: UIButton!
+    @IBOutlet weak var changeSignButton: UIButton!
     @IBOutlet weak var calculationButton: UIButton!
     @IBOutlet weak var dotButton: UIButton!
     

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -15,6 +15,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var clearEntryButton: UIButton!
     @IBOutlet weak var changSignButton: UIButton!
     @IBOutlet weak var calculationButton: UIButton!
+    @IBOutlet weak var dotButton: UIButton!
     
     //MARK: - UILabel Outlet
     @IBOutlet weak var inputOperandsLabel: UILabel!
@@ -22,13 +23,15 @@ class ViewController: UIViewController {
     
     let operrands = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     let operators = ["+", "-", "/", "*"]
-    var currentInputFormula: String = ""
+    var currentInputFormula: String = "0"
+    var oldInputFormula: String = ""
     var formula: [String] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
         allocateOperrandsTag()
         allocateOperatorsTag()
+        updateCurrentInputScreen()
     }
     
     func allocateOperrandsTag() {
@@ -43,27 +46,53 @@ class ViewController: UIViewController {
         }
     }
     
+    func updateCurrentInputScreen() {
+        inputOperandsLabel.text = currentInputFormula
+    }
+    
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         let number = operrands[sender.tag]
-        currentInputFormula = currentInputFormula + "\(number)"
-        inputOperandsLabel.text = currentInputFormula
+        if currentInputFormula == "0" {
+            currentInputFormula = "\(number)"
+            updateCurrentInputScreen()
+        } else {
+            currentInputFormula = currentInputFormula + "\(number)"
+        }
+
     }
     
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
         inputOperatorsLabel.text = operators[sender.tag]
         
         guard let currentSign = inputOperatorsLabel.text else { return }
-        currentInputFormula = currentInputFormula + " " + currentSign + " "
+        
+        if oldInputFormula != "" {
+            currentInputFormula = oldInputFormula + " " + currentSign + " "
+
+        } else {
+            currentInputFormula = currentInputFormula + " " + currentSign + " "
+        }
+    }
+    
+    @IBAction func dotButtonDidTapped(_ sender: UIButton) {
+        if currentInputFormula.last == "." {
+            updateCurrentInputScreen()
+        } else {
+            currentInputFormula += "."
+            updateCurrentInputScreen()
+        }
     }
     
     @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
         var parsedFormula = ExpressionParser.parse(from: currentInputFormula)
         let result = parsedFormula.result()
         inputOperandsLabel.text = String(result)
+        oldInputFormula = String(result)
     }
     
     @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
-        currentInputFormula = ""
+        currentInputFormula = "0"
+        oldInputFormula = ""
     }
     
     @IBAction func changeSignButtonDidTapped(_ sender: UIButton) {
@@ -71,6 +100,6 @@ class ViewController: UIViewController {
     }
     
     @IBAction func clearEntryButtonDidTapped(_ sender: UIButton) {
-        inputOperandsLabel.text = ""
+        inputOperandsLabel.text = "0"
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -73,6 +73,16 @@ class ViewController: UIViewController {
         return view
     }
     
+    func formatNumber(_ result: Int) -> String {
+        // 얘는 왜 써야할까? - 소숫점 표시, 숫자 반올림
+        // 얘는 어디다 써야할까? - currentOperand에 나타나는 숫자
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        
+        return ""
+    }
+    
+    //MARK: - IBAciton
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         guard let number = sender.currentTitle else { return }
         
@@ -104,9 +114,9 @@ class ViewController: UIViewController {
             inputOperatorsLabel.text = currentSign
             inputOperandsLabel.text = Sign.zero
         }
-        
-        print("스택뷰 연산자: \(currentSign)")
-        print("스택뷰 피연산자: \(currentInputFormula)")
+        print("스택뷰 연산자: \(currentOperator)")
+        print("스택뷰 피연산자: \(currentOperand)")
+        print("포뮬러: \(currentInputFormula)")
     }
     
     @IBAction func zeroButtonDidTapped(_ sender: UIButton) {
@@ -132,8 +142,10 @@ class ViewController: UIViewController {
         var parsedFormula = ExpressionParser.parse(from: stringFormula)
         let result = parsedFormula.result()
 
+        inputOperatorsLabel.text = ""
         inputOperandsLabel.text = String(result)
         oldInputFormula.append(String(result))
+        currentInputFormula = []
     }
     
     @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
@@ -144,7 +156,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func changeSignButtonDidTapped(_ sender: UIButton) {
-        guard currentOperand != "0" else { return }
+        guard currentOperand != Sign.zero else { return }
         
         if currentOperand.hasPrefix("-") {
             inputOperandsLabel.text = currentOperand.trimmingCharacters(in: ["-"])

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -21,7 +21,10 @@ class ViewController: UIViewController {
     //MARK: - UILabel Outlet
     @IBOutlet weak var inputOperandsLabel: UILabel!
     @IBOutlet weak var inputOperatorsLabel: UILabel!
+    
+    //MARK: - UIView Outlet
     @IBOutlet var stackView: UIStackView!
+    @IBOutlet var scrollView: UIScrollView!
     
     enum Sign {
         static let dot = "."
@@ -86,6 +89,13 @@ class ViewController: UIViewController {
         return numberFormatter.string(from: NSNumber(value: result)) ?? ""
     }
     
+    func settingScrollView() {
+        scrollView.layoutIfNeeded()
+        scrollView.setContentOffset(CGPoint(x: 0,
+                                            y: scrollView.contentSize.height - scrollView.bounds.height),
+                                    animated: false)
+    }
+    
     //MARK: - IBAciton
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         guard let number = sender.currentTitle else { return }
@@ -107,6 +117,7 @@ class ViewController: UIViewController {
         } else {
             newStackView = makeStackView(currentOperator, currentOperand)
             stackView.addArrangedSubview(newStackView)
+            settingScrollView()
             
             if currentOperator == "" {
                 currentInputFormula.append(currentOperand)
@@ -139,6 +150,7 @@ class ViewController: UIViewController {
         // 마지막 스택뷰 위로 올려주기
         let newStackView = makeStackView(currentOperator, currentOperand)
         stackView.addArrangedSubview(newStackView)
+        settingScrollView()
         
         // 포뮬라에 연산자, 피연산자 올리기
         currentInputFormula.append(currentOperator)

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -77,9 +77,8 @@ class ViewController: UIViewController {
     
     func formatNumber(_ result: Double) -> String {
         let numberFormatter = NumberFormatter()
-        numberFormatter.maximumIntegerDigits = 20
-        numberFormatter.numberStyle = .decimal
         
+        numberFormatter.numberStyle = .decimal
         numberFormatter.usesSignificantDigits = true
         numberFormatter.roundingMode = .halfUp
         numberFormatter.maximumSignificantDigits = 20
@@ -163,11 +162,9 @@ class ViewController: UIViewController {
         let removedCommaFormula = removeComma(stringFormula)
         var parsedFormula = ExpressionParser.parse(from: removedCommaFormula)
         let result = parsedFormula.result()
-        print(result)
 
         inputOperatorsLabel.text = ""
         inputOperandsLabel.text = formatNumber(result)
-        print(formatNumber(result))
         oldInputFormula.append(String(result))
         currentInputFormula = []
     }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -86,7 +86,7 @@ final class ViewController: UIViewController {
         scrollView.layoutIfNeeded()
         scrollView.setContentOffset(CGPoint(x: 0,
                                             y: scrollView.contentSize.height - scrollView.bounds.height),
-                                    animated: false)
+                                    animated: true)
     }
     
     //MARK: - IBAciton

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -7,8 +7,40 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
+    @IBOutlet var operandsButton: [UIButton]!
+    @IBOutlet var operatorsButton: [UIButton]!
+    @IBOutlet weak var inputOperandsLabel: UILabel!
+    @IBOutlet weak var inputOperatorsLabel: UILabel!
+    
+    let operrands = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 00, 000]
+    let operators = ["+", "-", "/", "*", "="]
     override func viewDidLoad() {
         super.viewDidLoad()
+        allocateOperrandsTag()
+        allocateOperatorsTag()
     }
+    
+    func allocateOperrandsTag() {
+        for index in 0..<operandsButton.count {
+            operandsButton[index].tag = index
+        }
+    }
+    
+    func allocateOperatorsTag() {
+        for index in 0..<operatorsButton.count {
+            operatorsButton[index].tag = index
+        }
+    }
+    
+    @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
+        let number = operrands[sender.tag]
+        var screen = inputOperandsLabel.text
+        
+    }
+    
+    @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
+        print(operators[sender.tag])
+    }
+        
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -8,9 +8,15 @@ import UIKit
 
 class ViewController: UIViewController {
     
+    //MARK: - UIButton Outlet
     @IBOutlet var operandsButton: [UIButton]!
     @IBOutlet var operatorsButton: [UIButton]!
+    @IBOutlet weak var allClearButton: UIButton!
+    @IBOutlet weak var clearEntryButton: UIButton!
+    @IBOutlet weak var changSignButton: UIButton!
+    @IBOutlet weak var calculationButton: UIButton!
     
+    //MARK: - UILabel Outlet
     @IBOutlet weak var inputOperandsLabel: UILabel!
     @IBOutlet weak var inputOperatorsLabel: UILabel!
     
@@ -40,17 +46,23 @@ class ViewController: UIViewController {
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         let number = operrands[sender.tag]
         currentInputFormula = currentInputFormula + "\(number)"
-        
-        //inputOperandsLabel.text = currentInputFormula
     }
     
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
         inputOperatorsLabel.text = operators[sender.tag]
         
         guard let currentSign = inputOperatorsLabel.text else { return }
-        currentInputFormula = currentInputFormula + currentSign
-
-        print(currentInputFormula)
+        currentInputFormula = currentInputFormula + " " + currentSign + " "
     }
     
+    @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
+        var parsedFormula = ExpressionParser.parse(from: currentInputFormula)
+        let result = parsedFormula.result()
+        inputOperandsLabel.text = String(result)
+    }
+    
+    @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
+        currentInputFormula = ""
+        inputOperandsLabel.text = currentInputFormula
+    }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -46,6 +46,7 @@ class ViewController: UIViewController {
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         let number = operrands[sender.tag]
         currentInputFormula = currentInputFormula + "\(number)"
+        inputOperandsLabel.text = currentInputFormula
     }
     
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
@@ -63,6 +64,13 @@ class ViewController: UIViewController {
     
     @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
         currentInputFormula = ""
-        inputOperandsLabel.text = currentInputFormula
+    }
+    
+    @IBAction func changeSignButtonDidTapped(_ sender: UIButton) {
+        
+    }
+    
+    @IBAction func clearEntryButtonDidTapped(_ sender: UIButton) {
+        inputOperandsLabel.text = ""
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -85,16 +85,38 @@ class ViewController: UIViewController {
     
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         let number = operrands[sender.tag]
-        
-        if currentInputFormula.isEmpty {
+        guard var lastOperand = currentInputFormula.last else {
+            return currentInputFormula.append(number)
+        }
+        if lastOperand.hasSuffix(".") {
+            lastOperand += number
+            currentInputFormula[currentInputFormula.count-1] = lastOperand
+        } else if operators.contains(lastOperand) == false {
+            //마지막이 연산자 아님 = 한 인덱스에 여러숫자붙이고싶음.. "456"처럼..
+            currentInputFormula[currentInputFormula.count-1] = lastOperand + number
+        } else if operators.contains(lastOperand) {
+            //마지막이 연산자임
             currentInputFormula.append(number)
+        }
+            
+        /*
+        if currentInputFormula.isEmpty {
+            
+            currentInputFormula.append(number)
+            
         } else {
             currentInputFormula.append(number)
         }
         
-        let currentOperand = currentInputFormula.last
+        guard var currentOperand = currentInputFormula.last else { return }
+        if currentOperand.hasSuffix(".") {
+            currentOperand += number
+        }
+        */
+        
+        
         IsOperatortapped = false
-        inputOperandsLabel.text = currentOperand
+        inputOperandsLabel.text = lastOperand
         printex()
     }
     
@@ -109,26 +131,35 @@ class ViewController: UIViewController {
         
         
         guard let currentSign = inputOperatorsLabel.text,
-                let lastElement = currentInputFormula.last else { return }
+              let lastElement = currentInputFormula.last else { return }
         
         // 연산자 입력 시 동작?
         // 1. inputOperandsLabel에 입력된 숫자가 currentFormula로 들어감
         // 2. (처음 입력한 값이라면) stackView에 operator 비우고 operand자리에만 숫자 들어감 ㅇ
         // 3. 0을 입력하지 않았을때 inputOperator가 0이라면 연산자는 마지막에 누른 한개만 들어감
-
+        
+        // 연산자입력이 안됐었음
         if IsOperatortapped == false {
+            //입력된 포뮬라의 요소가 한개라면 = 피연산자만 입력
             if currentInputFormula.count == 1 {
+                //스택뷰에 아무것도 안붙이고 숫자만 올리기
                 newStackView = makeStackView(Sign.nothing, lastElement)
             }
+            // 포뮬라가 0개가 아니고 1개보다 많을때
             else if currentInputFormula.count != 0 && currentInputFormula.count > 1 {
+                //연산자는 포뮬라의 카운트-3에 위치
                 let oldOperator = currentInputFormula[currentInputFormula.count-3]
                 newStackView = makeStackView(oldOperator, lastElement)
             }
-            currentInputFormula.append(Sign.blank)
+            
+            //currentInputFormula.append(Sign.blank)
             currentInputFormula.append(currentSign)
-            currentInputFormula.append(Sign.blank)
-        
+            //currentInputFormula.append(Sign.blank)
+            
             IsOperatortapped = true
+        } else {
+            currentInputFormula[currentInputFormula.count-1] = currentSign
+            print("else: \(currentInputFormula.count)")
         }
         /*
         else if oldInputFormula != Sign.nothing {
@@ -192,7 +223,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
-        let stringFormula = currentInputFormula.joined(separator: "")
+        let stringFormula = currentInputFormula.joined(separator: " ")
         print("stringformula :\(stringFormula)")
         var parsedFormula = ExpressionParser.parse(from: stringFormula)
         let result = parsedFormula.result()

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -91,7 +91,8 @@ final class ViewController: UIViewController {
     
     //MARK: - IBAciton
     @IBAction private func operandsButtonTapped(_ sender: UIButton) {
-        guard let number = sender.currentTitle else { return }
+        guard let number = sender.currentTitle,
+              currentOperand.count < 19 else { return }
         
         if currentOperand == Sign.zero {
             inputOperandsLabel.text = number

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -81,9 +81,10 @@ class ViewController: UIViewController {
         // 얘는 어디다 써야할까? - currentOperand에 나타나는 숫자
         // inputOperandLabel.text 에 적용하면... 3.0 -> 3으로 인식
         // 넘버포매터 적용한애 자릿수..? 문제...? 으윽...
-        //
+        // 411.2346 + 12.335 = 423.5805999999996 ????? 이게 무슨 오류람
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
+        numberFormatter.usesSignificantDigits = true
         numberFormatter.maximumSignificantDigits = 20
 
         return numberFormatter.string(from: NSNumber(value: result)) ?? ""

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -98,22 +98,6 @@ class ViewController: UIViewController {
             //마지막이 연산자임
             currentInputFormula.append(number)
         }
-            
-        /*
-        if currentInputFormula.isEmpty {
-            
-            currentInputFormula.append(number)
-            
-        } else {
-            currentInputFormula.append(number)
-        }
-        
-        guard var currentOperand = currentInputFormula.last else { return }
-        if currentOperand.hasSuffix(".") {
-            currentOperand += number
-        }
-        */
-        
         
         IsOperatortapped = false
         inputOperandsLabel.text = lastOperand
@@ -151,45 +135,12 @@ class ViewController: UIViewController {
                 let oldOperator = currentInputFormula[currentInputFormula.count-3]
                 newStackView = makeStackView(oldOperator, lastElement)
             }
-            
-            //currentInputFormula.append(Sign.blank)
             currentInputFormula.append(currentSign)
-            //currentInputFormula.append(Sign.blank)
-            
             IsOperatortapped = true
         } else {
             currentInputFormula[currentInputFormula.count-1] = currentSign
             print("else: \(currentInputFormula.count)")
         }
-        /*
-        else if oldInputFormula != Sign.nothing {
-            print("if")
-            newStackView = makeStackView(currentSign, splitedOperand)
-            currentInputFormula = oldInputFormula + Sign.blank + currentSign + Sign.blank
-            printex()
-            
-        } else if oldInputFormula == Sign.nothing {
-            newStackView = makeStackView(currentSign, splitedOperand)
-            inputOperandsLabel.text = currentOperand
-            currentInputFormula = currentInputFormula + Sign.blank + currentSign + Sign.blank
-            
-        } else {
-            newStackView = makeStackView(currentSign, splitedOperand)
-            inputOperandsLabel.text = currentOperand
-            currentInputFormula = currentInputFormula + Sign.blank + currentSign + Sign.blank
-        }
-        
-        else if inputOperandsLabel.text == Sign.zero && currentTappedNumber != Sign.zero {
-            //currentsign만! 바뀜
-            currentInputFormula = oldInputFormula + Sign.blank + currentSign + Sign.blank
-            printex()
-        } else {
-            currentInputFormula = currentInputFormula + Sign.blank + currentSign + Sign.blank
-            printex()
-            let newStackView = makeStackView(currentSign, currentTappedNumber)
-        }
-        */
-        
         
         inputOperandsLabel.text = Sign.zero
         
@@ -198,9 +149,7 @@ class ViewController: UIViewController {
        
         stackView.addArrangedSubview(newStackView)
     }
-    
-    
-    
+
     @IBAction func dotButtonDidTapped(_ sender: UIButton) {
         if let lastElement = currentInputFormula.last {
             if lastElement.hasSuffix(".") {
@@ -212,14 +161,6 @@ class ViewController: UIViewController {
             currentInputFormula.append(Sign.zero + Sign.dot)
             print(currentInputFormula)
         }
-            
-            
-//        if currentInputFormula.last == "." {
-//            printex()
-//        } else {
-//            currentInputFormula[currentInputFormula.count-1] += Sign.dot
-//            printex()
-//        }
     }
     
     @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
@@ -237,7 +178,6 @@ class ViewController: UIViewController {
     @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
         currentInputFormula = []
         oldInputFormula = []
-        //stackView.removeArrangedSubview(newStackView)
         printex()
     }
     

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -8,16 +8,6 @@ import UIKit
 
 final class ViewController: UIViewController {
     
-    //MARK: - UIButton Outlet
-    @IBOutlet var operandsButton: [UIButton]!
-    @IBOutlet var operatorsButton: [UIButton]!
-    @IBOutlet var zeroButton: [UIButton]!
-    @IBOutlet private weak var allClearButton: UIButton!
-    @IBOutlet private weak var clearEntryButton: UIButton!
-    @IBOutlet private weak var changeSignButton: UIButton!
-    @IBOutlet private weak var calculationButton: UIButton!
-    @IBOutlet private weak var dotButton: UIButton!
-    
     //MARK: - UILabel Outlet
     @IBOutlet private weak var inputOperandsLabel: UILabel!
     @IBOutlet private weak var inputOperatorsLabel: UILabel!

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -29,6 +29,14 @@ class ViewController: UIViewController {
     var formula: [String] = []
     var currentTappedNumber: String = ""
     
+    enum Sign {
+        static let dot = "."
+        static let doubleZero = "00"
+        static let black = " "
+        static let nothing = ""
+        static let minus = "-"
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         allocateOperrandsTag()
@@ -104,6 +112,7 @@ class ViewController: UIViewController {
         } else {
             currentInputFormula = currentInputFormula + " " + currentSign + " "
             printex()
+            let newStackView = makeStackView(currentSign, currentTappedNumber)
         }
         
         let newStackView = makeStackView(currentSign, currentTappedNumber)

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -73,13 +73,16 @@ class ViewController: UIViewController {
         return view
     }
     
-    func formatNumber(_ result: Int) -> String {
+    func formatNumber(_ result: Double) -> String {
         // 얘는 왜 써야할까? - 소숫점 표시, 숫자 반올림
         // 얘는 어디다 써야할까? - currentOperand에 나타나는 숫자
+        // inputOperandLabel.text 에 적용하면... 3.0 -> 3으로 인식
+        // 넘버포매터 적용한애 자릿수..? 문제...? 으윽...
+        
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
-        
-        return ""
+
+        return numberFormatter.string(from: NSNumber(value: result)) ?? ""
     }
     
     //MARK: - IBAciton
@@ -132,18 +135,23 @@ class ViewController: UIViewController {
     }
     
     @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
+        // 마지막 스택뷰 위로 올려주기
         let newStackView = makeStackView(currentOperator, currentOperand)
-        
         stackView.addArrangedSubview(newStackView)
+        
+        // 포뮬라에 연산자, 피연산자 올리기
         currentInputFormula.append(currentOperator)
         currentInputFormula.append(currentOperand)
         
+        // Formula parse
         let stringFormula = currentInputFormula.joined(separator: " ")
         var parsedFormula = ExpressionParser.parse(from: stringFormula)
         let result = parsedFormula.result()
+        print(result)
 
+        // 초기화
         inputOperatorsLabel.text = ""
-        inputOperandsLabel.text = String(result)
+        inputOperandsLabel.text = formatNumber(result)
         oldInputFormula.append(String(result))
         currentInputFormula = []
     }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -71,17 +71,11 @@ class ViewController: UIViewController {
         
         view.addArrangedSubview(operatorLabel)
         view.addArrangedSubview(operandLabel)
-        //[operatorLabel, operandLabel].forEach(view.addArrangedSubview(_:))
         
         return view
     }
     
     func formatNumber(_ result: Double) -> String {
-        // 얘는 왜 써야할까? - 소숫점 표시, 숫자 반올림
-        // 얘는 어디다 써야할까? - currentOperand에 나타나는 숫자
-        // inputOperandLabel.text 에 적용하면... 3.0 -> 3으로 인식
-        // 넘버포매터 적용한애 자릿수..? 문제...? 으윽...
-        // 411.2346 + 12.335 = 423.5805999999996 ????? 이게 무슨 오류람
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         numberFormatter.usesSignificantDigits = true
@@ -131,9 +125,6 @@ class ViewController: UIViewController {
             inputOperatorsLabel.text = currentSign
             inputOperandsLabel.text = Sign.zero
         }
-        print("스택뷰 연산자: \(currentOperator)")
-        print("스택뷰 피연산자: \(currentOperand)")
-        print("포뮬러: \(currentInputFormula)")
     }
     
     @IBAction func zeroButtonDidTapped(_ sender: UIButton) {
@@ -149,22 +140,18 @@ class ViewController: UIViewController {
     }
     
     @IBAction func calculationButtonDidTapped(_ sender: UIButton) {
-        // 마지막 스택뷰 위로 올려주기
         let newStackView = makeStackView(currentOperator, currentOperand)
         stackView.addArrangedSubview(newStackView)
         settingScrollView()
         
-        // 포뮬라에 연산자, 피연산자 올리기
         currentInputFormula.append(currentOperator)
         currentInputFormula.append(currentOperand)
         
-        // Formula parse
         let stringFormula = currentInputFormula.joined(separator: " ")
         var parsedFormula = ExpressionParser.parse(from: stringFormula)
         let result = parsedFormula.result()
         print(result)
 
-        // 초기화
         inputOperatorsLabel.text = ""
         inputOperandsLabel.text = formatNumber(result)
         oldInputFormula.append(String(result))

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -10,11 +10,15 @@ class ViewController: UIViewController {
     
     @IBOutlet var operandsButton: [UIButton]!
     @IBOutlet var operatorsButton: [UIButton]!
+    
     @IBOutlet weak var inputOperandsLabel: UILabel!
     @IBOutlet weak var inputOperatorsLabel: UILabel!
     
-    let operrands = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 00, 000]
-    let operators = ["+", "-", "/", "*", "="]
+    let operrands = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    let operators = ["+", "-", "/", "*"]
+    var currentInputFormula: String = ""
+    var formula: [String] = []
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         allocateOperrandsTag()
@@ -35,12 +39,18 @@ class ViewController: UIViewController {
     
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         let number = operrands[sender.tag]
-        var screen = inputOperandsLabel.text
+        currentInputFormula = currentInputFormula + "\(number)"
         
+        //inputOperandsLabel.text = currentInputFormula
     }
     
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
-        print(operators[sender.tag])
-    }
+        inputOperatorsLabel.text = operators[sender.tag]
         
+        guard let currentSign = inputOperatorsLabel.text else { return }
+        currentInputFormula = currentInputFormula + currentSign
+
+        print(currentInputFormula)
+    }
+    
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -26,14 +26,6 @@ class ViewController: UIViewController {
     @IBOutlet var stackView: UIStackView!
     @IBOutlet var scrollView: UIScrollView!
     
-    enum Sign {
-        static let dot = "."
-        static let blank = " "
-        static let nothing = ""
-        static let minus = "-"
-        static let zero = "0"
-    }
-    
     var currentOperand: String {
         return inputOperandsLabel.text ?? Sign.zero
     }
@@ -43,7 +35,6 @@ class ViewController: UIViewController {
     var currentInputFormula: [String] = []
     var oldInputFormula: [String] = []
 
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         reset()
@@ -83,7 +74,7 @@ class ViewController: UIViewController {
         numberFormatter.roundingMode = .halfUp
         numberFormatter.maximumSignificantDigits = 20
 
-        return numberFormatter.string(from: NSNumber(value: result)) ?? ""
+        return numberFormatter.string(from: NSNumber(value: result)) ?? Sign.nothing
     }
     
     func removeComma(_ inputString: String) -> String {
@@ -132,7 +123,7 @@ class ViewController: UIViewController {
             stackView.addArrangedSubview(newStackView)
             settingScrollView()
             
-            if currentOperator == "" {
+            if currentOperator == Sign.nothing {
                 currentInputFormula.append(currentOperand)
             } else {
                 currentInputFormula.append(currentOperator)
@@ -163,7 +154,7 @@ class ViewController: UIViewController {
         var parsedFormula = ExpressionParser.parse(from: removedCommaFormula)
         let result = parsedFormula.result()
 
-        inputOperatorsLabel.text = ""
+        inputOperatorsLabel.text = Sign.nothing
         inputOperandsLabel.text = formatNumber(result)
         oldInputFormula.append(String(result))
         currentInputFormula = []
@@ -179,7 +170,7 @@ class ViewController: UIViewController {
     @IBAction func changeSignButtonDidTapped(_ sender: UIButton) {
         guard currentOperand != Sign.zero else { return }
         
-        if currentOperand.hasPrefix("-") {
+        if currentOperand.hasPrefix(Sign.minus) {
             inputOperandsLabel.text = currentOperand.trimmingCharacters(in: ["-"])
         } else {
             inputOperandsLabel.text = Sign.minus + currentOperand

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -142,6 +142,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func calculationButtonTapped(_ sender: UIButton) {
+        guard currentInputFormula.isEmpty == false else { return }
         let newStackView = makeStackView(currentOperator, currentOperand)
         stackView.addArrangedSubview(newStackView)
         settingScrollView()

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -20,18 +20,47 @@ class ViewController: UIViewController {
     //MARK: - UILabel Outlet
     @IBOutlet weak var inputOperandsLabel: UILabel!
     @IBOutlet weak var inputOperatorsLabel: UILabel!
+    @IBOutlet var stackView: UIStackView!
     
     let operrands = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    let operators = ["+", "-", "/", "*"]
+    let operators = ["+", "−", "÷", "×"]
     var currentInputFormula: String = "0"
     var oldInputFormula: String = ""
     var formula: [String] = []
+    var currentTappedNumber: String = ""
     
     override func viewDidLoad() {
         super.viewDidLoad()
         allocateOperrandsTag()
         allocateOperatorsTag()
         updateCurrentInputScreen()
+    }
+    
+    func makeStackView(_ operatorSign: String, _ operand: String) -> UIStackView {
+        let view = UIStackView()
+        let operandLabel = UILabel()
+        let operatorLabel = UILabel()
+        
+        operatorLabel.text = operatorSign
+        operatorLabel.textColor = .white
+        operandLabel.text = operand
+        operandLabel.textColor = .white
+        
+        view.axis = .horizontal
+        view.alignment = .fill
+        view.distribution = .fill
+        view.spacing = 8
+
+        view.addArrangedSubview(operatorLabel)
+        view.addArrangedSubview(operandLabel)
+        //[operatorLabel, operandLabel].forEach(view.addArrangedSubview(_:))
+
+        return view
+    }
+    
+    func printex(){
+        print("current: \(currentInputFormula)")
+        print("old: \(oldInputFormula)")
     }
     
     func allocateOperrandsTag() {
@@ -52,13 +81,16 @@ class ViewController: UIViewController {
     
     @IBAction func operandsButtonDidTapped(_ sender: UIButton) {
         let number = operrands[sender.tag]
+        currentTappedNumber = "\(number)"
+        
         if currentInputFormula == "0" {
             currentInputFormula = "\(number)"
             updateCurrentInputScreen()
+            printex()
         } else {
             currentInputFormula = currentInputFormula + "\(number)"
+            printex()
         }
-
     }
     
     @IBAction func operatorsButtonDidTapped(_ sender: UIButton) {
@@ -68,18 +100,27 @@ class ViewController: UIViewController {
         
         if oldInputFormula != "" {
             currentInputFormula = oldInputFormula + " " + currentSign + " "
-
+            printex()
         } else {
             currentInputFormula = currentInputFormula + " " + currentSign + " "
+            printex()
         }
+        
+        let newStackView = makeStackView(currentSign, currentTappedNumber)
+        print("스택뷰 연산자: \(currentSign)")
+        print("스택뷰 피연산자: \(currentInputFormula)")
+      
+        stackView.addArrangedSubview(newStackView)
     }
     
     @IBAction func dotButtonDidTapped(_ sender: UIButton) {
         if currentInputFormula.last == "." {
             updateCurrentInputScreen()
+            printex()
         } else {
             currentInputFormula += "."
             updateCurrentInputScreen()
+            printex()
         }
     }
     
@@ -88,11 +129,14 @@ class ViewController: UIViewController {
         let result = parsedFormula.result()
         inputOperandsLabel.text = String(result)
         oldInputFormula = String(result)
+        printex()
     }
     
     @IBAction func allClearButtonDidTapped(_ sender: UIButton) {
         currentInputFormula = "0"
         oldInputFormula = ""
+        //stackView.removeArrangedSubview(newStackView)
+        printex()
     }
     
     @IBAction func changeSignButtonDidTapped(_ sender: UIButton) {
@@ -101,5 +145,6 @@ class ViewController: UIViewController {
     
     @IBAction func clearEntryButtonDidTapped(_ sender: UIButton) {
         inputOperandsLabel.text = "0"
+        printex()
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -34,7 +34,8 @@ final class ViewController: UIViewController {
     }
     private var currentInputFormula: [String] = []
     private var oldInputFormula: [String] = []
-
+    private let numberFormatter = NumberFormatter()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         resetLabelsText()
@@ -67,8 +68,6 @@ final class ViewController: UIViewController {
     }
     
     private func formatNumber(_ result: Double) -> String {
-        let numberFormatter = NumberFormatter()
-        
         numberFormatter.numberStyle = .decimal
         numberFormatter.usesSignificantDigits = true
         numberFormatter.roundingMode = .halfUp

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -37,10 +37,10 @@ final class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        reset()
+        resetLabelsText()
     }
     
-    func reset() {
+    func resetLabelsText() {
         inputOperandsLabel.text = Sign.zero
         inputOperatorsLabel.text = Sign.nothing
     }
@@ -162,7 +162,7 @@ final class ViewController: UIViewController {
     }
     
     @IBAction func allClearButtonTapped(_ sender: UIButton) {
-        reset()
+        resetLabelsText()
         currentInputFormula = []
         oldInputFormula = []
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -12,40 +12,40 @@ final class ViewController: UIViewController {
     @IBOutlet var operandsButton: [UIButton]!
     @IBOutlet var operatorsButton: [UIButton]!
     @IBOutlet var zeroButton: [UIButton]!
-    @IBOutlet weak var allClearButton: UIButton!
-    @IBOutlet weak var clearEntryButton: UIButton!
-    @IBOutlet weak var changeSignButton: UIButton!
-    @IBOutlet weak var calculationButton: UIButton!
-    @IBOutlet weak var dotButton: UIButton!
+    @IBOutlet private weak var allClearButton: UIButton!
+    @IBOutlet private weak var clearEntryButton: UIButton!
+    @IBOutlet private weak var changeSignButton: UIButton!
+    @IBOutlet private weak var calculationButton: UIButton!
+    @IBOutlet private weak var dotButton: UIButton!
     
     //MARK: - UILabel Outlet
-    @IBOutlet weak var inputOperandsLabel: UILabel!
-    @IBOutlet weak var inputOperatorsLabel: UILabel!
+    @IBOutlet private weak var inputOperandsLabel: UILabel!
+    @IBOutlet private weak var inputOperatorsLabel: UILabel!
     
     //MARK: - UIView Outlet
-    @IBOutlet var stackView: UIStackView!
-    @IBOutlet var scrollView: UIScrollView!
+    @IBOutlet private var stackView: UIStackView!
+    @IBOutlet private var scrollView: UIScrollView!
     
-    var currentOperand: String {
+    private var currentOperand: String {
         return inputOperandsLabel.text ?? Sign.zero
     }
-    var currentOperator: String {
+    private var currentOperator: String {
         return inputOperatorsLabel.text ?? Sign.nothing
     }
-    var currentInputFormula: [String] = []
-    var oldInputFormula: [String] = []
+    private var currentInputFormula: [String] = []
+    private var oldInputFormula: [String] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
         resetLabelsText()
     }
     
-    func resetLabelsText() {
+    private func resetLabelsText() {
         inputOperandsLabel.text = Sign.zero
         inputOperatorsLabel.text = Sign.nothing
     }
     
-    func makeStackView(_ operatorSign: String, _ operand: String) -> UIStackView {
+    private func makeStackView(_ operatorSign: String, _ operand: String) -> UIStackView {
         let view = UIStackView()
         let operandLabel = UILabel()
         let operatorLabel = UILabel()
@@ -66,7 +66,7 @@ final class ViewController: UIViewController {
         return view
     }
     
-    func formatNumber(_ result: Double) -> String {
+    private func formatNumber(_ result: Double) -> String {
         let numberFormatter = NumberFormatter()
         
         numberFormatter.numberStyle = .decimal
@@ -77,13 +77,13 @@ final class ViewController: UIViewController {
         return numberFormatter.string(from: NSNumber(value: result)) ?? Sign.nothing
     }
     
-    func removeComma(_ inputString: String) -> String {
+    private func removeComma(_ inputString: String) -> String {
         let removedCommaString = inputString.replacingOccurrences(of: ",", with: "")
         
         return removedCommaString
     }
     
-    func settingScrollView() {
+    private func settingScrollView() {
         scrollView.layoutIfNeeded()
         scrollView.setContentOffset(CGPoint(x: 0,
                                             y: scrollView.contentSize.height - scrollView.bounds.height),
@@ -91,7 +91,7 @@ final class ViewController: UIViewController {
     }
     
     //MARK: - IBAciton
-    @IBAction func operandsButtonTapped(_ sender: UIButton) {
+    @IBAction private func operandsButtonTapped(_ sender: UIButton) {
         guard let number = sender.currentTitle else { return }
         
         if currentOperand == Sign.zero {
@@ -105,13 +105,13 @@ final class ViewController: UIViewController {
         }
     }
     
-    @IBAction func zeroButtonTapped(_ sender: UIButton) {
+    @IBAction private func zeroButtonTapped(_ sender: UIButton) {
         guard let zero = sender.currentTitle,
               currentOperand != Sign.zero else { return }
         inputOperandsLabel.text = currentOperand + zero
     }
     
-    @IBAction func operatorsButtonTapped(_ sender: UIButton) {
+    @IBAction private func operatorsButtonTapped(_ sender: UIButton) {
         var newStackView: UIStackView = UIStackView()
         
         guard let currentSign = sender.currentTitle else { return }
@@ -135,13 +135,13 @@ final class ViewController: UIViewController {
         }
     }
     
-    @IBAction func dotButtonTapped(_ sender: UIButton) {
+    @IBAction private func dotButtonTapped(_ sender: UIButton) {
         guard let dot = sender.currentTitle,
               currentOperand.contains(Sign.dot) == false else { return }
         inputOperandsLabel.text = currentOperand + dot
     }
     
-    @IBAction func calculationButtonTapped(_ sender: UIButton) {
+    @IBAction private func calculationButtonTapped(_ sender: UIButton) {
         guard currentInputFormula.isEmpty == false else { return }
         let newStackView = makeStackView(currentOperator, currentOperand)
         stackView.addArrangedSubview(newStackView)
@@ -161,14 +161,14 @@ final class ViewController: UIViewController {
         currentInputFormula = []
     }
     
-    @IBAction func allClearButtonTapped(_ sender: UIButton) {
+    @IBAction private func allClearButtonTapped(_ sender: UIButton) {
         resetLabelsText()
         currentInputFormula = []
         oldInputFormula = []
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
     }
     
-    @IBAction func changeSignButtonTapped(_ sender: UIButton) {
+    @IBAction private func changeSignButtonTapped(_ sender: UIButton) {
         guard currentOperand != Sign.zero else { return }
         
         if currentOperand.hasPrefix(Sign.minus) {
@@ -178,7 +178,7 @@ final class ViewController: UIViewController {
         }
     }
     
-    @IBAction func clearEntryButtonTapped(_ sender: UIButton) {
+    @IBAction private func clearEntryButtonTapped(_ sender: UIButton) {
         inputOperandsLabel.text = Sign.zero
     }
 }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -7,9 +7,9 @@
 
 enum Operator: Character, CaseIterable {
     case add = "+"
-    case substract = "-"
-    case divide = "/"
-    case multiply = "*"
+    case substract = "−"
+    case divide = "÷"
+    case multiply = "×"
     
     func calculate(lhs: Double, rhs: Double) -> Double {
         var result: Double

--- a/Calculator/Calculator/Model/Sign.swift
+++ b/Calculator/Calculator/Model/Sign.swift
@@ -1,0 +1,14 @@
+//
+//  Sign.swift
+//  Calculator
+//
+//  Created by 무리 on 2023/02/06.
+//
+
+enum Sign {
+    static let dot = "."
+    static let blank = " "
+    static let nothing = ""
+    static let minus = "-"
+    static let zero = "0"
+}


### PR DESCRIPTION
@wongbingg 
안녕하세요 웡빙!! 주말은 잘 보내셨나요? 아주 늦은 STEP3 PR이 되었네요🥲 
이번 스텝 진행하면서 로직에 대한 고민…이라는걸 해보게 된 것 같아요…!
그럼 코멘트 부탁드리겠습니다😂!

---

## 고민했던 부분

### 1️⃣ 무수히 많은 IBOutlet와 currentTitle의 활용

1. IBOutlet
- 계산기의 숫자 버튼 하나하나를 `@IBOutlet`을 이용하여 각각 선언해주었습니다. 선언하고 보니 코드가 깔끔하지 않은 것 같아 좋은 방법이 없을까하며 구글링을 하다가 `IBOutlet Collection`에 대해 알게되었고, 코드에 적용해보았습니다.

```
// 수정 전
@IBOutlet weak var number0Button: UIButton!
@IBOutlet weak var number1Button: UIButton!
// ...
@IBOutlet weak var number9Button: UIButton!

// 수정 후
@IBOutlet var operandsButton: [UIButton]!

```

- `IBOutlet Collection`을 이용하여 코드를 한결 더 간결하게 사용할 수 있었습니다.
1. currentTitle
- 버튼을 누르면 숫자를 받아와야하는데, 어떻게 해야할까 하다가 이 전 프로젝트인 쥬스메이커에서 사용한 방법인 `tag` 를 이용해보았습니다. 숫자를 가진 배열을 만들어 반복문으로 `tag`를 할당하는 방식으로 숫자버튼의 액션을 사용했습니다.
- 그러다 동기캠퍼가 `currentTitle` 이라는 키워드를 던져주어 불필요한 변수와 함수를 줄일 수 있게되었습니다!

### 2️⃣ StackView 추가, 제거하기

1. ScrollView안의 StackView에 StackView 추가하기
- 계산기에서 숫자를 입력한 후 연산자를 입력하면 숫자는 입력을 받는 view 위에 위치해있는 `scrollView`안의 `stackView`안에 `stackView`로 추가되어야합니다.
- `stackView`를 동적으로 추가해주는 개념부터 어려웠고, 추가해줘도 얘가 어떻게 라벨을 두개가지고있고(피연산자, 연산자) 이 크기를 알까?하는 고민을 하게된것같습니다.
그러다 캠퍼에게 `arrangedSubview`키워드를 듣게되었습니다.
- `arrangedSubview`는 **stackView의 subView들을 모아놓은 배열**이고 이 `subView들`은 **stackView에 의해 크기나 기타 속성**들을 가지게됩니다.
`addArrangedSubview()`를 이용하여 원하는 방법으로 stackView를 동적으로 추가할 수 있었습니다!
1. 추가한 StackView 제거하기
- AC 버튼을 구현하며 추가해놓은 StackView를 제거하기 위해 공식문서에서 보았던 `removeArrangedSubview` 메서드를 사용하려고 했는데, operator버튼 액션쪽에서 지역변수로 선언 해놓은 stackView를 매개변수로 넣어주어야 했습니다. 
전역변수로 선언해서 사용해야하나? 하는 생각과 일단 제거가 정상적으로 되는지 보기 위해 사용해보았는데, stackView가 그대로 있는것을 볼수있었습니다🫠
공식문서를 다시 보니 `removeArrangeSubview` 는 다음과 같이 설명되어있었습니다.

>This method removes the provided view from the stack’s arrangedSubviews array. The stack view no longer manages the view’s position and size. However, this method doesn’t remove the provided view from the stack’s subviews
 array; therefore, the view is still displayed as part of the view hierarchy. 

- StackView의 `arrangedSubview` 배열에서 삭제하여 더이상 StackView에 의해 위치나 크기 등을 알수 없게 되지만, 뷰 계층구조에서는 보여진다고 설명되어있습니다.
- 동기 캠퍼의 TIL을 참고하여 StackView의 `arrangedSubviews` 에 접근하여 `remove()` 해주려고 했지만, `arrangedSubviews` 배열은 `get only property` 이기 때문에 접근할 수 없었습니다..
고민하다 결국 동기 캠퍼에게 질문하여 arrangedSubviews 배열의 `element`에 접근해 `removeFromSuperview()` 해주어 StackView를 제거할수있었습니다!

### 3️⃣ NumberFormatter 적용 후 결과값에 대한 연산

- 먼저 결과값에 `,` 를 찍기 위해 `NumberFormatter`를 이용했습니다. 구현해놓은 로직에서는 결과값에 바로 연산이 가능했는데 크기가 작은 숫자로만 연산을 해보다가 `,` 가 찍힌 숫자에 연산을 하게 되니 오류가 발생한 것 이었습니다.
- `ExpressionParser` 에서 `parse` 메서드의 로직은 요소가 `Double` 로 형변환이 되는지 확인 후 맞다면 피연산자 큐에, 아니라면 `Operator` 이기 때문에 연산자 큐에 `enqueue` 하게 되어있습니다.
계산기의 연산 결과가 계산기 현재 화면에 올라가게되고, 그 값을 이용하여 다음 연산을 이용하는데 현재화면에 올라간 숫자가 `,` 를 포함하고 있기 때문에 `parse` 로직에서 `Double`로 형변환이 되지 않고 `Operator` 도 아니기 때문에 발생했던 오류였습니다.
- 이것을 해결하기 위해 `,` 를 제거해줄 필요가 있다고 생각했습니다. 구글링으로 특정한 문자열들을 원하는 문자열로 치환하는 방법에 대한 블로그를 보게되어 `replacingOccurrences` 메서드를 사용해 `,` 를 제거한 후 오류를 처리할 수 있었습니다.

---

## 해결이 되지 않은 부분

### 1️⃣ 설정한 유효자릿수 ≠ 화면에 표시되는 숫자

![image](https://user-images.githubusercontent.com/115514179/216829814-5e5eac05-367e-4ded-8023-6d8e1d05397d.png)

- (입력창도 넘버포매터 적용 된 상태) 화면에 표시해주어야 하는 숫자는 20자리라고 되어있습니다. 
이를 위해 넘버포매터가 적용되는 유효한 자릿수를 나타내는 프로퍼티 `maximumSignificantDigits` 를 20으로 설정해두고 구현을 했습니다.
- 하지만 `1,234,567,890,123,456,789` 를 입력해도 화면에 표시되는 숫자는 `1,234,567,891,023,457,000` 으로 17자까지만 (18번째 자리에서 반올림한)유효한 숫자로 표시되고 있습니다.
- 이 부분은 numberFormatter의 어떠한 부분을 더 공부해보면 처리를 할 수 있을까요?

---

## 조언을 얻고싶은 부분

### 1️⃣ 로직에 대한 생각

- 새벽 코딩 중 동기의 도움을 받아 로직에 대한 부분을 전면 수정하게 되었는데요, 수정을 하며 연산을 하기만 급급했던 코드들이 드러나게되었습니다… 
if문으로 조건을 주고 오류가 나면 아무 상관없는 조건을 또 만들어서 적용하고… 이런식으로 구현하다보니 코드가 굉장히 복잡하고 확실하지도 않으면서 오류는 많이 나서 또 조건문을 주게되는 악순환이 있었거든요😂
- 동기가 해준 말중에 “연산하는데에 너무 집중하지말고, 연산을 구현하는게 아니라 계산기를 구현하는거니까 계산기가 해야하는 동작들에 생각해보세요”가 있었는데요… 동기가 대화를 이끌어나가주면서 어떠한 기능이 필요할지, 어떻게 입력이 되어야할지 등 질문을 던져주어 빠뜨린 부분이나 생각지도 못했던 부분들을 깨닫게 된것같아요.
- 하지만 이것을 혼자 생각해야한다면? 너무 어렵다고 느껴졌습니다🥲… 뭔가 구현에 급급해서 멀리 못보고 한치앞만 쳐다보면서 길을 걷는 느낌이었는데 혹시 로직에 대한 생각을 어떻게 해야할지 조언을 구할수 있을까요?