### PR TITLE
계산기 2 [STEP1] 리지, vetto, Andrew

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		FBB0AC6F29936AF5009F7334 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB0AC6E29936AF5009F7334 /* CalculatorError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +66,7 @@
 		C713D94A2570E5ED001C3AFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FBB0AC6E29936AF5009F7334 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +168,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				FBB0AC6D29936ADD009F7334 /* CalculatorError */,
 				98DE0B9A298F845E00082EC2 /* Application */,
 				98B18833297FCE38008D8AC2 /* Model */,
 				98DE0B9B298F848600082EC2 /* Controller */,
@@ -177,6 +180,14 @@
 				C713D94F2570E5ED001C3AFC /* Info.plist */,
 			);
 			path = Calculator;
+			sourceTree = "<group>";
+		};
+		FBB0AC6D29936ADD009F7334 /* CalculatorError */ = {
+			isa = PBXGroup;
+			children = (
+				FBB0AC6E29936AF5009F7334 /* CalculatorError.swift */,
+			);
+			path = CalculatorError;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -297,6 +308,7 @@
 				98B1885029810F72008D8AC2 /* CalculateItemProtocol.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				98DE0BA1298F93B600082EC2 /* Symbol.swift in Sources */,
+				FBB0AC6F29936AF5009F7334 /* CalculatorError.swift in Sources */,
 				98B1DF442983A18A001C9AEF /* String+Extension.swift in Sources */,
 				98B18848297FE9C7008D8AC2 /* Node.swift in Sources */,
 				98B1DF4A2983A94B001C9AEF /* Formula.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 		FBB0AC6F29936AF5009F7334 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB0AC6E29936AF5009F7334 /* CalculatorError.swift */; };
+		FBF131C429938E0F00C725CC /* Number.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF131C329938E0F00C725CC /* Number.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +68,7 @@
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FBB0AC6E29936AF5009F7334 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
+		FBF131C329938E0F00C725CC /* Number.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Number.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 				98B1DF472983A803001C9AEF /* ExpressionParser.swift */,
 				98B1DF492983A94B001C9AEF /* Formula.swift */,
 				98DE0BA0298F93B600082EC2 /* Symbol.swift */,
+				FBF131C329938E0F00C725CC /* Number.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -307,6 +310,7 @@
 				C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */,
 				98B1885029810F72008D8AC2 /* CalculateItemProtocol.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
+				FBF131C429938E0F00C725CC /* Number.swift in Sources */,
 				98DE0BA1298F93B600082EC2 /* Symbol.swift in Sources */,
 				FBB0AC6F29936AF5009F7334 /* CalculatorError.swift in Sources */,
 				98B1DF442983A18A001C9AEF /* String+Extension.swift in Sources */,

--- a/Calculator/Calculator/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/Base.lproj/Main.storyboard
@@ -22,11 +22,6 @@
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="332" y="0.0" width="50" height="50"/>
-                                            </stackView>
-                                        </subviews>
                                     </stackView>
                                 </subviews>
                                 <constraints>

--- a/Calculator/Calculator/CalculatorError/CalculatorError.swift
+++ b/Calculator/Calculator/CalculatorError/CalculatorError.swift
@@ -1,0 +1,10 @@
+//
+//  CalculatorError.swift
+//  Calculator
+//
+//  Created by 리지, vetto, Andrew on 2023/02/08.
+//
+
+enum CalculatorError: Error {
+     case divideByZero
+ }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -28,22 +28,15 @@ final class CalculatorViewController: UIViewController {
         super.viewDidLoad()
     }
     
-    private func setupOperandAndOperator() {
-        resetOperand()
-        resetOperator()
-    }
-    
     @IBAction private func didTapACButton() {
-        calculateStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        resetCalculatorItemView()
         resetOperand()
         resetOperator()
         expression.removeAll()
     }
     
     @IBAction private func didTapCEButton() {
-        if isCalculated == false {
-            calculateOperand = Symbol.zero
-        }
+        resetOperand()
     }
     
     @IBAction private func didTapChangeSignButton() {
@@ -97,7 +90,7 @@ final class CalculatorViewController: UIViewController {
         
         isCalculated = false
         calculateOperator = operatorSign
-        calculateOperand = Symbol.zero
+        resetOperand()
     }
     
     @IBAction private func didTapNumberButton(_ sender: UIButton) {
@@ -181,17 +174,16 @@ final class CalculatorViewController: UIViewController {
         return stackView
     }
     
+    private func resetCalculatorItemView() {
+            calculateStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        }
+    
     private func resetOperand() {
         calculateOperand = Symbol.zero
     }
     
     private func resetOperator() {
         calculateOperator = Symbol.blank
-    }
-    
-    private func resetLabel() {
-        resetOperand()
-        resetOperator()
     }
 }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -69,15 +69,8 @@ final class CalculatorViewController: UIViewController {
                                       operand: formatNumber)
         
         var formula = ExpressionParser.parse(from: expression.joined(separator: Symbol.blank))
-        
-        let result = formula.result()
-        
-        if result.isNaN {
-            calculateOperand = Symbol.nan
-        } else {
-            calculateOperand = NumberFormatter.convertToString(fromDouble: result)
-        }
-        
+        guard let result = formula.result() else { return }
+        calculateOperand = NumberFormatter.convertToString(fromDouble: result)
         isCalculated = true
         resetOperator()
         expression.removeAll()

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -42,7 +42,6 @@ final class CalculatorViewController: UIViewController {
     @IBAction private func didTapChangeSignButton() {
         guard calculateOperand != Symbol.zero,
               calculateOperand != Symbol.nan else { return }
-        
         guard let calculateNumberFirst = calculateOperand.first else { return }
         
         if calculateNumberFirst == Character(Symbol.minus) {
@@ -56,7 +55,6 @@ final class CalculatorViewController: UIViewController {
         guard !isCalculated, calculateOperator != Symbol.empty else { return }
         guard let calculatedNumber = operandLabel.text?.withoutComma else { return }
         guard let number = Double(calculatedNumber) else { return }
-        
         let formatNumber = NumberFormatter.convertToString(fromDouble: number)
         
         addExpressionAndCalculateItem(sign: calculateOperator,
@@ -88,7 +86,6 @@ final class CalculatorViewController: UIViewController {
                                       number: calculatedNumber,
                                       operand: calculatedOperand)
         scrollToBottom()
-        
         isCalculated = false
         calculateOperator = operatorSign
         resetOperand()
@@ -98,17 +95,10 @@ final class CalculatorViewController: UIViewController {
         guard calculateOperand.count <= Symbol.maxSignificantDigits else { return }
         guard let number = sender.currentTitle else { return }
         
-        if isCalculated {
-            guard number != Symbol.zero, number != Symbol.doubleZero else { return }
-            
-            calculateOperand = number
-            isCalculated = false
-            return
-        }
+        isCalculated = false
         
         if calculateOperand == Symbol.zero {
             guard number != Symbol.zero, number != Symbol.doubleZero else { return }
-            
             calculateOperand = number
         } else {
             if calculateOperand.contains(Symbol.dot) {
@@ -121,7 +111,6 @@ final class CalculatorViewController: UIViewController {
     
     @IBAction private func didTapDotButton(_ sender: UIButton) {
         guard !calculateOperand.contains(Symbol.dot) else { return }
-        
         calculateOperand += Symbol.dot
     }
     
@@ -150,7 +139,6 @@ final class CalculatorViewController: UIViewController {
         label.textColor = .white
         label.font = UIFont.preferredFont(forTextStyle: .title3)
         label.adjustsFontForContentSizeCategory = true
-        
         return label
     }
 

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -18,7 +18,7 @@ final class CalculatorViewController: UIViewController {
             operandLabel.text = calculateOperand
         }
     }
-    private var calculateOperator: String = Symbol.blank {
+    private var calculateOperator: String = Symbol.empty {
         didSet {
             operatorLabel.text = calculateOperator
         }
@@ -53,7 +53,7 @@ final class CalculatorViewController: UIViewController {
     }
     
     @IBAction private func didTapResultButton() {
-        guard !isCalculated, calculateOperator != Symbol.blank else { return }
+        guard !isCalculated, calculateOperator != Symbol.empty else { return }
         guard let calculatedNumber = operandLabel.text?.withoutComma else { return }
         guard let number = Double(calculatedNumber) else { return }
         
@@ -63,7 +63,7 @@ final class CalculatorViewController: UIViewController {
                                       number: "\(number)",
                                       operand: formatNumber)
         
-        var formula = ExpressionParser.parse(from: expression.joined(separator: Symbol.blank))
+        var formula = ExpressionParser.parse(from: expression.joined(separator: Symbol.empty))
         guard let result = formula.result() else { return }
         calculateOperand = NumberFormatter.convertToString(fromDouble: result)
         isCalculated = true
@@ -74,7 +74,7 @@ final class CalculatorViewController: UIViewController {
     @IBAction private func didTapOperatorButton(_ sender: UIButton) {
         guard let operatorSign = sender.currentTitle else { return }
         guard calculateOperand != Symbol.zero else {
-            if  calculateOperator != Symbol.blank {
+            if  calculateOperator != Symbol.empty {
                 calculateOperator = operatorSign
             }
             return
@@ -135,11 +135,8 @@ final class CalculatorViewController: UIViewController {
     }
     
     private func addToCalculateItem(left: String, right: String) {
-        let operatorUILabel = generateUILabel(title: left)
-        let operandUILabel = generateUILabel(title: right)
-        let stackView = generateUIStackView(left: operatorUILabel, right: operandUILabel)
-        
-        calculateStackView.addArrangedSubview(stackView)
+        let calculateLabel = generateUILabel()
+        calculateStackView.addArrangedSubview(calculateLabel)
         scrollToBottom()
     }
     
@@ -153,25 +150,20 @@ final class CalculatorViewController: UIViewController {
         calculateScrollView.setContentOffset(bottomOffset, animated: true)
     }
     
-    private func generateUILabel(title: String) -> UILabel {
+    private func generateUILabel() -> UILabel {
         let label = UILabel()
-        label.text = title
+        label.text = calculateOperator + Symbol.blank + NumberFormatter.convertToString(fromString: calculateOperand)
         label.textColor = .white
         label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.adjustsFontForContentSizeCategory = true
         
         return label
     }
-    
-    private func generateUIStackView(left: UILabel, right: UILabel) -> UIStackView {
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.addArrangedSubview(left)
-        stackView.addArrangedSubview(right)
-        stackView.alignment = .fill
-        stackView.distribution = .fill
-        stackView.spacing = 8
-        
-        return stackView
+
+    private func addStackView() {
+        let stackLabel = generateUILabel()
+        calculateStackView.addArrangedSubview(stackLabel)
+        scrollToBottom()
     }
     
     private func resetCalculatorItemView() {
@@ -183,7 +175,6 @@ final class CalculatorViewController: UIViewController {
     }
     
     private func resetOperator() {
-        calculateOperator = Symbol.blank
+        calculateOperator = Symbol.empty
     }
 }
-

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -60,10 +60,7 @@ final class CalculatorViewController: UIViewController {
         addExpressionAndCalculateItem(sign: calculateOperator,
                                       number: "\(number)",
                                       operand: formatNumber)
-        
-        var formula = ExpressionParser.parse(from: expression.joined(separator: Symbol.empty))
-        guard let result = formula.result() else { return }
-        calculateOperand = NumberFormatter.convertToString(fromDouble: result)
+        calculateOperand = calculate()
         isCalculated = true
         resetOperator()
         expression.removeAll()
@@ -81,7 +78,7 @@ final class CalculatorViewController: UIViewController {
         
         guard let calculatedNumber = operandLabel.text?.withoutComma else { return }
         let calculatedOperand = NumberFormatter.convertToString(fromString: calculatedNumber)
-            
+        
         addExpressionAndCalculateItem(sign: calculateOperator,
                                       number: calculatedNumber,
                                       operand: calculatedOperand)
@@ -92,7 +89,7 @@ final class CalculatorViewController: UIViewController {
     }
     
     @IBAction private func didTapNumberButton(_ sender: UIButton) {
-        guard calculateOperand.count <= Symbol.maxSignificantDigits else { return }
+        guard calculateOperand.count <= Number.maxSignificantDigits else { return }
         guard let number = sender.currentTitle else { return }
         
         isCalculated = false
@@ -124,6 +121,13 @@ final class CalculatorViewController: UIViewController {
         expression.append(number)
     }
     
+    private func calculate() -> String {
+        var formula = ExpressionParser.parse(from: expression.joined(separator: Symbol.empty))
+        guard let result = formula.result() else { return Symbol.empty }
+        
+        return NumberFormatter.convertToString(fromDouble: result)
+    }
+    
     private func scrollToBottom() {
         let bottomOffset = CGPoint(
             x: Number.origin,
@@ -141,7 +145,7 @@ final class CalculatorViewController: UIViewController {
         label.adjustsFontForContentSizeCategory = true
         return label
     }
-
+    
     private func addStackView() {
         let stackLabel = generateUILabel()
         calculateStackView.addArrangedSubview(stackLabel)
@@ -149,8 +153,8 @@ final class CalculatorViewController: UIViewController {
     }
     
     private func resetCalculatorItemView() {
-            calculateStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        }
+        calculateStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    }
     
     private func resetOperand() {
         calculateOperand = Symbol.zero

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -131,11 +131,9 @@ final class CalculatorViewController: UIViewController {
     }
     
     @IBAction private func didTapDotButton(_ sender: UIButton) {
-        guard let dot = sender.currentTitle else { return }
         guard !calculateOperand.contains(Symbol.dot) else { return }
         
-        guard !isCalculated else { return }
-        calculateOperand += dot
+        calculateOperand += Symbol.dot
     }
     
     private func addExpressionAndCalculateItem(sign: String, number: String, operand: String) {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -69,6 +69,7 @@ final class CalculatorViewController: UIViewController {
         isCalculated = true
         resetOperator()
         expression.removeAll()
+        scrollToBottom()
     }
     
     @IBAction private func didTapOperatorButton(_ sender: UIButton) {
@@ -126,7 +127,7 @@ final class CalculatorViewController: UIViewController {
     
     private func addExpressionAndCalculateItem(sign: String, number: String, operand: String) {
         appendExpression(sign: sign, number: number)
-        addToCalculateItem(left: sign, right: operand)
+        addStackView()
     }
     
     private func appendExpression(sign: String, number: String) {
@@ -134,18 +135,11 @@ final class CalculatorViewController: UIViewController {
         expression.append(number)
     }
     
-    private func addToCalculateItem(left: String, right: String) {
-        let calculateLabel = generateUILabel()
-        calculateStackView.addArrangedSubview(calculateLabel)
-        scrollToBottom()
-    }
-    
     private func scrollToBottom() {
         let bottomOffset = CGPoint(
-            x: 0,
+            x: Number.origin,
             y: calculateScrollView.contentSize.height - calculateScrollView.bounds.height
         )
-        
         calculateScrollView.layoutIfNeeded()
         calculateScrollView.setContentOffset(bottomOffset, animated: true)
     }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -37,6 +37,7 @@ final class CalculatorViewController: UIViewController {
         calculateStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         resetOperand()
         resetOperator()
+        expression.removeAll()
     }
     
     @IBAction private func didTapCEButton() {
@@ -46,7 +47,8 @@ final class CalculatorViewController: UIViewController {
     }
     
     @IBAction private func didTapChangeSignButton() {
-        guard calculateOperand != Symbol.zero else { return }
+        guard calculateOperand != Symbol.zero,
+              calculateOperand != Symbol.nan else { return }
         
         guard let calculateNumberFirst = calculateOperand.first else { return }
         

--- a/Calculator/Calculator/Extension/NumberFormatter+Extension.swift
+++ b/Calculator/Calculator/Extension/NumberFormatter+Extension.swift
@@ -9,7 +9,6 @@ extension NumberFormatter {
         
         numberFormatter.numberStyle = .decimal
         numberFormatter.roundingMode = .halfUp
-        numberFormatter.maximumSignificantDigits = Symbol.maxSignificantDigits
         
         guard let number = numberFormatter.string(for: fromDouble) else { return Symbol.empty }
         

--- a/Calculator/Calculator/Extension/NumberFormatter+Extension.swift
+++ b/Calculator/Calculator/Extension/NumberFormatter+Extension.swift
@@ -9,16 +9,16 @@ extension NumberFormatter {
         
         numberFormatter.numberStyle = .decimal
         numberFormatter.roundingMode = .halfUp
-        numberFormatter.maximumSignificantDigits = 20
+        numberFormatter.maximumSignificantDigits = Symbol.maxSignificantDigits
         
-        guard let number = numberFormatter.string(for: fromDouble) else { return "" }
+        guard let number = numberFormatter.string(for: fromDouble) else { return Symbol.empty }
         
         return number
     }
     
     static func convertToString(fromString: String) -> String {
         let number = fromString.filter({ $0 != Character(Symbol.comma) })
-        guard let doubleInput = Double(number) else { return "" }
+        guard let doubleInput = Double(number) else { return Symbol.empty }
         
         return convertToString(fromDouble: doubleInput)
     }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -19,8 +19,4 @@ struct CalculatorItemQueue<Element: CalculateItem> {
     mutating func dequeue() -> Element? {
         return calculatorList.removeFirst()
     }
-    
-    mutating func clear() {
-        calculatorList.removeAll()
-    }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -5,11 +5,11 @@ import Foundation
 
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        let operandsArray = componentsByOperators(from: input).compactMap { Double($0) }
-        let operatorsArray = input.compactMap { Operator(rawValue: $0) }
+        let operandsList = componentsByOperators(from: input).compactMap { Double($0) }
+        let operatorsList = input.compactMap { Operator(rawValue: $0) }
 
-        let operandQueue = CalculatorItemQueue(with: operandsArray)
-        let operatorQueue = CalculatorItemQueue(with: operatorsArray)
+        let operandQueue = CalculatorItemQueue(with: operandsList)
+        let operatorQueue = CalculatorItemQueue(with: operatorsList)
         
         return Formula(operands: operandQueue, operators: operatorQueue)
     }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -8,8 +8,8 @@ enum ExpressionParser {
         let operandsList = componentsByOperators(from: input).compactMap { Double($0) }
         let operatorsList = input.compactMap { Operator(rawValue: $0) }
 
-        let operandQueue = CalculatorItemQueue(with: operandsList)
-        let operatorQueue = CalculatorItemQueue(with: operatorsList)
+        let operandQueue = CalculatorItemQueue<Double>(with: operandsList)
+        let operatorQueue = CalculatorItemQueue<Operator>(with: operatorsList)
         
         return Formula(operands: operandQueue, operators: operatorQueue)
     }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -10,14 +10,20 @@ struct Formula {
         self.operators = operators
     }
     
-    mutating func result() -> Double {
+    mutating func result() -> Double? {
         guard var result = operands.dequeue() else { return 0 }
         
         while !operands.isEmpty && !operators.isEmpty {
             guard let operand = operands.dequeue(),
                   let `operator` = operators.dequeue() else { return result }
             
-            result = `operator`.calculate(lhs: result, rhs: operand)
+            do {
+                result = try `operator`.calculate(lhs: result, rhs: operand)
+            } catch CalculatorError.divideByZero {
+                return .nan
+            } catch {
+                return nil
+            }
         }
         
         return result

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -11,7 +11,7 @@ struct Formula {
     }
     
     mutating func result() -> Double? {
-        guard var result = operands.dequeue() else { return 0 }
+        guard var result = operands.dequeue() else { return Double.zero }
         
         while !operands.isEmpty && !operators.isEmpty {
             guard let operand = operands.dequeue(),

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -27,9 +27,4 @@ struct LinkedList<Element: CalculateItem> {
         self.head = head?.next
         return node.data
     }
-    
-    mutating func removeAll() {
-        self.head = nil
-        self.tail = nil
-    }
 }

--- a/Calculator/Calculator/Model/Number.swift
+++ b/Calculator/Calculator/Model/Number.swift
@@ -1,0 +1,11 @@
+//
+//  Number.swift
+//  Calculator
+//
+//  Created by 리지, vetto, Andrew on 2023/02/08.
+//
+
+enum Number {
+    static let maxSignificantDigits = 20
+    static let origin: Double = 0
+}

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -7,14 +7,14 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "÷"
     case multiply = "×"
     
-    func calculate(lhs: Double, rhs: Double) -> Double {
+    func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {
         case .add:
             return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            return divide(lhs: lhs, rhs: rhs)
+            return try divide(lhs: lhs, rhs: rhs)
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
         }
@@ -28,8 +28,11 @@ enum Operator: Character, CaseIterable, CalculateItem {
         return lhs - rhs
     }
     
-    private func divide(lhs: Double, rhs: Double) -> Double {
-        return rhs.isZero ? .nan : lhs / rhs
+    private func divide(lhs: Double, rhs: Double) throws -> Double {
+        guard rhs != .zero else {
+            throw CalculatorError.divideByZero
+        }
+        return lhs / rhs
     }
     
     private func multiply(lhs: Double, rhs: Double) -> Double {

--- a/Calculator/Calculator/Model/Symbol.swift
+++ b/Calculator/Calculator/Model/Symbol.swift
@@ -2,7 +2,6 @@
 //  created by vetto on 2023/02/05
 
 enum Symbol {
-    // MARK: String
     static let zero = "0"
     static let doubleZero = "00"
     static let comma = ","
@@ -11,7 +10,4 @@ enum Symbol {
     static let nan = "NaN"
     static let minus = "-"
     static let empty = ""
-    
-    // MARK: Int
-    static let maxSignificantDigits = 20
 }

--- a/Calculator/Calculator/Model/Symbol.swift
+++ b/Calculator/Calculator/Model/Symbol.swift
@@ -6,10 +6,11 @@ enum Symbol {
     static let zero = "0"
     static let doubleZero = "00"
     static let comma = ","
-    static let blank = ""
+    static let blank = " "
     static let dot = "."
     static let nan = "NaN"
     static let minus = "-"
+    static let empty = ""
     
     // MARK: Int
     static let maxSignificantDigits = 20


### PR DESCRIPTION
@Judy-999 주디 안녕하세요 😀
병합하는 방법 수정하여 다시 PR 보냅니다!

Model 부분은 Andrew 코드를 많이 활용하였고 viewController에서 기능적으로 많이 달라 버튼별로 나누고 리팩토링과정을 조금씩 거치면서 정상적으로 실행 될 수 있게 병합을 하였습니다. 기본적으로 vetto의 linkedList를 기반으로 병합하기 위해 vetto의 프로젝트에서 새 브랜치를 만들었습니다.

## UML을 기반으로 한 코드병합


**Model**
> 파일별로 병합
- CalculatorItemQueue (vetto)
    - LinkedList 구현 : 팀원이 사용해보지 않은 데이터 구조 선택
- Operator.divide (리지)
    - 오류 처리 구문: 리지가 구현한 NaN 오류처리 선택
- ExpressionParser (Andrew & vetto)
    - `parse` (Andrew)
    - `componentsByOperators` 고차함수 flatMap 이용 (vetto)
- Formula (Andrew & 리지)
    - 프로퍼티, 메서드 (Andrew), do-catch 구문 (리지)
- Extension String (Andrew)
    - 고차함수 활용

**ViewController**
> 버튼의 기능에 따라 병합

- AC버튼 (리지) 
    - 메서드로 분리하여 여러곳에서 재활용
- CE버튼 (vetto, 리지) 
    - 둘의 코드가 일치
- +/- 버튼 (vetto)
    - 기능적으로는 유사했으나 사용한 명령어에 따라 직관적인 vetto의 코드를 선택 (vetto: `first`, `removeFirst()`, 리지: `firstIndex(of:)`, `remove(at:)` 사용)
- 결과버튼 (vetto, 리지)
    - 계산하는 과정을 따로 메서드로 분리 (리지)
    - 조건과 NumberFormatter 적용 (vetto)
- 숫자입력버튼 (vetto, 리지)
    - 계산 부울 변수를 초기화 하는 메서드 (리지)
    - 조건과 조건과 NumberFormatter 적용 (vetto)
- 연산자입력버튼 (vetto, 리지)
    - 전반적인 코드 (vetto)
    - `hasSuffix` 로 `.` 으로끝나는 숫자 조건 적용 (리지)
- NumberFormatter적용 (vetto)
    - extension 으로 구현하여 전역에서 활용 (콤마, 불필요한 소수점 제거, 20자리)
- 스택뷰 (리지)
    - UILabel을 stackView의 쌓는 형식
- 스크롤뷰 (vetto)
    - 자동으로 스크롤뷰가 올라오도록 구현할때, `layoutIfNeeded()`사용

**View(Storyboard)**
- 스택뷰를 리지로 선택하면서 스토리보드상 불필요한 스택뷰 제거

## 고민했던 점

### queue구현 방식
* 팀원들의 큐 구현 방식이 달라 어떤 것을 고를지 고민했습니다. 한명은 LinkedList를 이용해서 구현하였고 2명은 DoubleStack을 이용하여 구현하였습니다. 처음에는 많은 사람이 작성했던 더블 스택을 이용하여 병합하려 했지만 팀원들의 의견으로 다수가 사용을 안 해봤던 링크드리스트를 사용해서 병합하는 것으로 상의했습니다.

### 메서드 병합
* 기본적으로 계산기의 작동 방식이 queue라는 점에서는 같았지만 내부 로직에서는 완전 다른 로직이었기 때문에 어떻게 병합할까에 대해서 많은 고민이 있었습니다. 팀원들과 상의한 결과 내부 로직에서 공통된 것은 그대로 두고 좋은 기능을 기반으로 구분하고 가져와서 병합하는 식으로 메서드를 병합하였습니다.

## 조언받고 싶은 점 && 해결되지 않은 점 (피드백 반영)

### 숫자 뒤에 소수점이 붙은 숫자
- 숫자 뒤에 소수점을 붙이고 아무 소수점숫자를 적지 않는 상태(ex: 15.)에서 사칙연산을 할 경우 스크롤뷰 연산에 올라가야될지 올라가지 말아야할지 Judy의 의견을 듣고 싶습니다.

> 15.를 숫자로 생각하면 결국 15.0과 동일할테니 불필요한 소수점은 제거하고 15로 연산에 포함되어야 할 것 같아요! 아이폰 계산기에서 확인해보면 동일하게 작동하네요 🙂

➡️ `15.`를 입력하고 연산자를 입력했을 때 `.`은 사라지고 `15`만 스택뷰에 올라가도록 수정하였습니다.

### 전역 변수 사용
- 프로젝트에서 전역변수 expression을 사용해서 연산자와 피연산자를 받고 있습니다. 여러 함수에서 사용하기 때문에 전역으로 사용해도 괜찮은 방법일까요 아니면 전역 변수를 지양하는 쪽으로 코드를 짜야할까요 Judy의 의견을 듣고 싶습니다.

> 전역변수는 최소로 가지는게 좋지만 여러 함수에서 사용하기 때문에 이러한 이유가 있다면 "최소"에 포함될 수 있겠네요.
> 만약 전역 변수로 두지 않으면 어떤 방식으로 가능할까요? 🤔 고민해보시고 알려주세요!

➡️ 코드를 합칠 때, 리지는 지역변수를 사용하여 stackView의 subView를 `forEach`로 돌면서 그 값들을 받아 계산을 하였고, vetto는 전역변수를 사용 연산자 버튼이랑 결과 버튼을 눌렀을 때 연산자와 숫자의 Label이 stackView의 들어갈 수 있게 하였습니다. 두가지를 비교했을 때, forEach로 모든 stackView를 도는 것이 메모리를 낭비한다고 판단하여 최소한의 전역변수를 사용한 vetto의 방법을 선택하였습니다.

### 계산을 하는 순서
- 피연산자 연산자 피연산자 순서로 누르면 바로 계산 되는 방법과 모든 피연산자와 연산자를 받고 나서 =을 하면 한꺼번에 연산을 하는 방법 중에서 각각의 장단점에 대해서 생각해봤습니다. 바로 계산되는 방법은 좀 더 자연스럽게 계산기를 구현할 수 있고 =을 누르고 나서 한꺼번에 계산할 때는 후에 연산자 우선순위를 적용할 때 조금더 수월하게 적용할 수 있다는 장점을 생각했습니다. 이 점에 대해서 Judy의 의견을 듣고 싶습니다.

> 한 번에 계산할 때는 =을 누르기 전까지는 연산하지 않으니 간편할 것 같아요. 또한 적어주신 대로 연산자 우선순위도 적용할 수 있겠죠.

> 바로 계산되는 방법의 장점인 자연스럽게 계산기를 구현에서 자연스럽다는게 어떤 의미일까요? 또한 연산자 이후 숫자를 입력하면 계산한 값이 바로 띄워지는 걸까요? 만약 아니라면 사용자에게는 큰 차이가 없을 것 같네요. 그리고 바로 연산이 되기 때문에 연산자 우선순위는 적용할 수 없거나 복잡할 것 같네요.

➡️ 실제 아이폰 계산기 앱처럼 숫자와 연산자 버튼을 누르면 계산되는 것이 자연스럽다고 생각했었습니다. 저희가 구현한 계산기 방법은 = 버튼을 눌러야 화면에 띄어지기 때문에 주디의 의견대로 크게 상관없을 것 같습니다!
