### PR TITLE
계산기 [Step 2] redmango

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		5D7AC4952A25E8C300AFE620 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7AC4942A25E8C300AFE620 /* CalculatorItemQueue.swift */; };
 		5D7AC4972A25E8EE00AFE620 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7AC4962A25E8EE00AFE620 /* CalculateItem.swift */; };
 		5D7AC49F2A25E94B00AFE620 /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7AC49E2A25E94B00AFE620 /* LinkedListTests.swift */; };
+		5D9A077D2A2D0AC700F6E112 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A077C2A2D0AC700F6E112 /* Operator.swift */; };
+		5D9A07802A2F652800F6E112 /* Double+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A077F2A2F652800F6E112 /* Double+.swift */; };
+		5D9A07822A2F653600F6E112 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07812A2F653600F6E112 /* String+.swift */; };
+		5D9A07842A2F658800F6E112 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07832A2F658700F6E112 /* ExpressionParser.swift */; };
+		5D9A07862A2F65B600F6E112 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07852A2F65B600F6E112 /* Formula.swift */; };
 		5DCA9B0E2A27A13B00ACBFF6 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA9B0D2A27A13B00ACBFF6 /* Node.swift */; };
 		5DCA9B122A27A21000ACBFF6 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA9B112A27A21000ACBFF6 /* LinkedList.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -45,6 +50,11 @@
 		5D7AC4962A25E8EE00AFE620 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		5D7AC49C2A25E94B00AFE620 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5D7AC49E2A25E94B00AFE620 /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
+		5D9A077C2A2D0AC700F6E112 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		5D9A077F2A2F652800F6E112 /* Double+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+.swift"; sourceTree = "<group>"; };
+		5D9A07812A2F653600F6E112 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		5D9A07832A2F658700F6E112 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		5D9A07852A2F65B600F6E112 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		5DCA9B0D2A27A13B00ACBFF6 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		5DCA9B112A27A21000ACBFF6 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -116,6 +126,9 @@
 				5D7AC4942A25E8C300AFE620 /* CalculatorItemQueue.swift */,
 				5DCA9B0D2A27A13B00ACBFF6 /* Node.swift */,
 				5DCA9B112A27A21000ACBFF6 /* LinkedList.swift */,
+				5D9A077C2A2D0AC700F6E112 /* Operator.swift */,
+				5D9A07832A2F658700F6E112 /* ExpressionParser.swift */,
+				5D9A07852A2F65B600F6E112 /* Formula.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -134,6 +147,16 @@
 				5D7AC49E2A25E94B00AFE620 /* LinkedListTests.swift */,
 			);
 			path = LinkedListTests;
+			sourceTree = "<group>";
+		};
+		5D9A077E2A2F650D00F6E112 /* extension */ = {
+			isa = PBXGroup;
+			children = (
+				5D9A077F2A2F652800F6E112 /* Double+.swift */,
+				5D9A07812A2F653600F6E112 /* String+.swift */,
+			);
+			name = extension;
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		C713D9352570E5EB001C3AFC = {
@@ -159,6 +182,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				5D9A077E2A2F650D00F6E112 /* extension */,
 				5D7AC4932A25E88700AFE620 /* Protocol */,
 				5D7AC4922A25E88500AFE620 /* Model */,
 				5D7AC4912A25E88200AFE620 /* Controller */,
@@ -315,11 +339,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				5D7AC4972A25E8EE00AFE620 /* CalculateItem.swift in Sources */,
+				5D9A07802A2F652800F6E112 /* Double+.swift in Sources */,
+				5D9A07862A2F65B600F6E112 /* Formula.swift in Sources */,
+				5D9A07822A2F653600F6E112 /* String+.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorMainViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				5DCA9B0E2A27A13B00ACBFF6 /* Node.swift in Sources */,
 				5D7AC4952A25E8C300AFE620 /* CalculatorItemQueue.swift in Sources */,
+				5D9A077D2A2D0AC700F6E112 /* Operator.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				5D9A07842A2F658800F6E112 /* ExpressionParser.swift in Sources */,
 				5DCA9B122A27A21000ACBFF6 /* LinkedList.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		5D9A07842A2F658800F6E112 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07832A2F658700F6E112 /* ExpressionParser.swift */; };
 		5D9A07862A2F65B600F6E112 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07852A2F65B600F6E112 /* Formula.swift */; };
 		5D9A078A2A2F98D400F6E112 /* ExpressionParserTeste.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07892A2F98D400F6E112 /* ExpressionParserTeste.swift */; };
+		5DA805942A30903C0081E2E0 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA805932A30903C0081E2E0 /* CalculatorError.swift */; };
 		5DCA9B0E2A27A13B00ACBFF6 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA9B0D2A27A13B00ACBFF6 /* Node.swift */; };
 		5DCA9B122A27A21000ACBFF6 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA9B112A27A21000ACBFF6 /* LinkedList.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -59,6 +60,7 @@
 		5D9A07832A2F658700F6E112 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		5D9A07852A2F65B600F6E112 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		5D9A07892A2F98D400F6E112 /* ExpressionParserTeste.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExpressionParserTeste.swift; path = LinkedListTests/ExpressionParserTeste.swift; sourceTree = SOURCE_ROOT; };
+		5DA805932A30903C0081E2E0 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
 		5DCA9B0D2A27A13B00ACBFF6 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		5DCA9B112A27A21000ACBFF6 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -165,6 +167,15 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		5DA805922A308EC60081E2E0 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				5DA805932A30903C0081E2E0 /* CalculatorError.swift */,
+			);
+			name = Error;
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
@@ -188,6 +199,7 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				5DA805922A308EC60081E2E0 /* Error */,
 				5D9A077E2A2F650D00F6E112 /* extension */,
 				5D7AC4932A25E88700AFE620 /* Protocol */,
 				5D7AC4922A25E88500AFE620 /* Model */,
@@ -349,6 +361,7 @@
 				5D7AC4972A25E8EE00AFE620 /* CalculateItem.swift in Sources */,
 				5D9A07802A2F652800F6E112 /* Double+.swift in Sources */,
 				5D9A07862A2F65B600F6E112 /* Formula.swift in Sources */,
+				5DA805942A30903C0081E2E0 /* CalculatorError.swift in Sources */,
 				5D9A07822A2F653600F6E112 /* String+.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorMainViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		5D9A07822A2F653600F6E112 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07812A2F653600F6E112 /* String+.swift */; };
 		5D9A07842A2F658800F6E112 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07832A2F658700F6E112 /* ExpressionParser.swift */; };
 		5D9A07862A2F65B600F6E112 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07852A2F65B600F6E112 /* Formula.swift */; };
+		5D9A078A2A2F98D400F6E112 /* ExpressionParserTeste.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07892A2F98D400F6E112 /* ExpressionParserTeste.swift */; };
 		5DCA9B0E2A27A13B00ACBFF6 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA9B0D2A27A13B00ACBFF6 /* Node.swift */; };
 		5DCA9B122A27A21000ACBFF6 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA9B112A27A21000ACBFF6 /* LinkedList.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -55,6 +56,7 @@
 		5D9A07812A2F653600F6E112 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		5D9A07832A2F658700F6E112 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		5D9A07852A2F65B600F6E112 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		5D9A07892A2F98D400F6E112 /* ExpressionParserTeste.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExpressionParserTeste.swift; path = LinkedListTests/ExpressionParserTeste.swift; sourceTree = SOURCE_ROOT; };
 		5DCA9B0D2A27A13B00ACBFF6 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		5DCA9B112A27A21000ACBFF6 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -95,6 +97,7 @@
 		5D3894FE2A27DD58007F6D52 /* CalculatorItemQueueTests */ = {
 			isa = PBXGroup;
 			children = (
+				5D9A07892A2F98D400F6E112 /* ExpressionParserTeste.swift */,
 				5D3894FF2A27DD58007F6D52 /* CalculatorItemQueueTests.swift */,
 			);
 			path = CalculatorItemQueueTests;
@@ -330,6 +333,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5D9A078A2A2F98D400F6E112 /* ExpressionParserTeste.swift in Sources */,
 				5D7AC49F2A25E94B00AFE620 /* LinkedListTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		5D7AC4952A25E8C300AFE620 /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7AC4942A25E8C300AFE620 /* CalculatorItemQueue.swift */; };
 		5D7AC4972A25E8EE00AFE620 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7AC4962A25E8EE00AFE620 /* CalculateItem.swift */; };
 		5D7AC49F2A25E94B00AFE620 /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7AC49E2A25E94B00AFE620 /* LinkedListTests.swift */; };
+		5D8FD97A2A305FA600E4187D /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D8FD9792A305FA600E4187D /* FormulaTests.swift */; };
 		5D9A077D2A2D0AC700F6E112 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A077C2A2D0AC700F6E112 /* Operator.swift */; };
 		5D9A07802A2F652800F6E112 /* Double+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A077F2A2F652800F6E112 /* Double+.swift */; };
 		5D9A07822A2F653600F6E112 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07812A2F653600F6E112 /* String+.swift */; };
@@ -51,6 +52,7 @@
 		5D7AC4962A25E8EE00AFE620 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		5D7AC49C2A25E94B00AFE620 /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5D7AC49E2A25E94B00AFE620 /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
+		5D8FD9792A305FA600E4187D /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		5D9A077C2A2D0AC700F6E112 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		5D9A077F2A2F652800F6E112 /* Double+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+.swift"; sourceTree = "<group>"; };
 		5D9A07812A2F653600F6E112 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
@@ -97,6 +99,7 @@
 		5D3894FE2A27DD58007F6D52 /* CalculatorItemQueueTests */ = {
 			isa = PBXGroup;
 			children = (
+				5D8FD9792A305FA600E4187D /* FormulaTests.swift */,
 				5D9A07892A2F98D400F6E112 /* ExpressionParserTeste.swift */,
 				5D3894FF2A27DD58007F6D52 /* CalculatorItemQueueTests.swift */,
 			);
@@ -334,6 +337,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5D9A078A2A2F98D400F6E112 /* ExpressionParserTeste.swift in Sources */,
+				5D8FD97A2A305FA600E4187D /* FormulaTests.swift in Sources */,
 				5D7AC49F2A25E94B00AFE620 /* LinkedListTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+               BuildableName = "Calculator.app"
+               BlueprintName = "Calculator"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5D7AC49B2A25E94B00AFE620"
+               BuildableName = "CalculatorTests.xctest"
+               BlueprintName = "CalculatorTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5D3894FC2A27DD58007F6D52"
+               BuildableName = "CalculatorItemQueueTests.xctest"
+               BlueprintName = "CalculatorItemQueueTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C713D93D2570E5EB001C3AFC"
+            BuildableName = "Calculator.app"
+            BlueprintName = "Calculator"
+            ReferencedContainer = "container:Calculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -15,7 +15,7 @@ enum ExpressionParser {
             .forEach { formula.operands.enqueue($0) }
         
         inputStrings
-            .filter { $0.count == 1 }
+            .filter { Double($0) == nil }
             .compactMap { Operator(rawValue: Character($0)) }
             .forEach { formula.operators.enqueue($0) }
         

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -6,11 +6,17 @@
 //
 
 enum ExpressionParser {
-//    static func parse(from input: String) -> Formula {
-//        
-//    }
+    static func parse(from input: String) -> Formula {
+        var formula = Formula()
+        let inputStrings = componentsByOperators(from: input)
+        
+        inputStrings.compactMap{ Double($0) }.forEach{ formula.operands.enqueue($0) }
+        input.compactMap{ Operator(rawValue: $0) }.forEach{ formula.operatos.enqueue($0) }
+        
+        return formula
+    }
     
     static func componentsByOperators(from input: String) -> [String] {
-        return ["1"]
+        return input.split(with: " ")
     }
 }

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -17,7 +17,7 @@ enum ExpressionParser {
         inputStrings
             .filter { $0.count == 1 }
             .compactMap { Operator(rawValue: Character($0)) }
-            .forEach { formula.operatos.enqueue($0) }
+            .forEach { formula.operators.enqueue($0) }
         
         return formula
     }

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -5,9 +5,9 @@
 //  Created by redmango1446 on 2023/06/06.
 //
 
-enum ExpressionParser<T> {
-//    static func parse(from input: String) -> Formula<T> {
-//
+enum ExpressionParser {
+//    static func parse(from input: String) -> Formula {
+//        
 //    }
     
     static func componentsByOperators(from input: String) -> [String] {

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -10,8 +10,15 @@ enum ExpressionParser {
         var formula = Formula()
         let inputStrings = componentsByOperators(from: input)
         
+        let operatorCharacter = inputStrings.compactMap{
+            if $0.count == 1 {
+                return Operator(rawValue: Character($0))
+            }
+            return nil
+        }
+        
         inputStrings.compactMap{ Double($0) }.forEach{ formula.operands.enqueue($0) }
-        input.compactMap{ Operator(rawValue: $0) }.forEach{ formula.operatos.enqueue($0) }
+        operatorCharacter.forEach{ formula.operatos.enqueue($0) }
         
         return formula
     }

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -10,15 +10,14 @@ enum ExpressionParser {
         var formula = Formula()
         let inputStrings = componentsByOperators(from: input)
         
-        let operatorCharacter = inputStrings.compactMap{
-            if $0.count == 1 {
-                return Operator(rawValue: Character($0))
-            }
-            return nil
-        }
+        inputStrings
+            .compactMap { Double($0) }
+            .forEach { formula.operands.enqueue($0) }
         
-        inputStrings.compactMap{ Double($0) }.forEach{ formula.operands.enqueue($0) }
-        operatorCharacter.forEach{ formula.operatos.enqueue($0) }
+        inputStrings
+            .filter { $0.count == 1 }
+            .compactMap { Operator(rawValue: Character($0)) }
+            .forEach { formula.operatos.enqueue($0) }
         
         return formula
     }

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -23,7 +23,7 @@ enum ExpressionParser {
         return formula
     }
     
-    static func componentsByOperators(from input: String) -> [String] {
+    private static func componentsByOperators(from input: String) -> [String] {
         return input.split(with: " ")
     }
 }

--- a/Calculator/Calculator/ExpressionParser.swift
+++ b/Calculator/Calculator/ExpressionParser.swift
@@ -1,0 +1,16 @@
+//
+//  ExpressionParser.swift
+//  Calculator
+//
+//  Created by redmango1446 on 2023/06/06.
+//
+
+enum ExpressionParser<T> {
+//    static func parse(from input: String) -> Formula<T> {
+//
+//    }
+    
+    static func componentsByOperators(from input: String) -> [String] {
+        return ["1"]
+    }
+}

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -7,7 +7,7 @@
 
 struct Formula {
     var operands: CalculatorItemQueue<Double> = CalculatorItemQueue()
-    var operatos: CalculatorItemQueue<Operator> = CalculatorItemQueue()
+    var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue()
     
     mutating func result() throws -> Double {
         
@@ -15,7 +15,7 @@ struct Formula {
             return 0
         }
         
-        while let currentOperator = operatos.dequeue() {
+        while let currentOperator = operators.dequeue() {
             
             guard let secondOperand = operands.dequeue() else {
                 throw CalculatorError.incompleteFormula

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -6,8 +6,8 @@
 //
 
 struct Formula {
-    var operands: CalculatorItemQueue<Double>
-    var operatos: CalculatorItemQueue<Operator>
+    var operands: CalculatorItemQueue<Double> = CalculatorItemQueue()
+    var operatos: CalculatorItemQueue<Operator> = CalculatorItemQueue()
     
     func result() -> Double {
         return 0.1 //임시값

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -1,0 +1,15 @@
+//
+//  Formula.swift
+//  Calculator
+//
+//  Created by redmango1446 on 2023/06/06.
+//
+
+struct Formula<T> {
+    var operands: CalculatorItemQueue<T>
+    var operatos: CalculatorItemQueue<T>
+    
+    func result() -> Double {
+        return 0.1 //임시값
+    }
+}

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -5,9 +5,9 @@
 //  Created by redmango1446 on 2023/06/06.
 //
 
-struct Formula<T> {
-    var operands: CalculatorItemQueue<T>
-    var operatos: CalculatorItemQueue<T>
+struct Formula {
+    var operands: CalculatorItemQueue<Double>
+    var operatos: CalculatorItemQueue<Operator>
     
     func result() -> Double {
         return 0.1 //임시값

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -9,7 +9,27 @@ struct Formula {
     var operands: CalculatorItemQueue<Double> = CalculatorItemQueue()
     var operatos: CalculatorItemQueue<Operator> = CalculatorItemQueue()
     
-    func result() -> Double {
-        return 0.1 //임시값
+    mutating func result() -> Double {
+        var result: Double = 0
+        
+        guard !operatos.isEmpty else {
+            return 0.1 // 추후 에러처리
+        }
+        
+        guard var lhs = operands.dequeue() else {
+            return 0.2 // 추후 에러처리
+        }
+        
+        while !operatos.isEmpty {
+            
+            guard let rhs = operands.dequeue(), let currentOperator = operatos.dequeue() else {
+                return 0.3 // 추후 에러처리
+            }
+            
+            result = currentOperator.calculate(lhs: lhs, rhs: rhs)
+            lhs = result
+        }
+        
+        return result
     }
 }

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -9,24 +9,24 @@ struct Formula {
     var operands: CalculatorItemQueue<Double> = CalculatorItemQueue()
     var operatos: CalculatorItemQueue<Operator> = CalculatorItemQueue()
     
-    mutating func result() -> Double {
+    mutating func result() throws -> Double {
         var result: Double = 0
         
         guard !operatos.isEmpty else {
-            return 0.1 // 추후 에러처리
+            return operands.dequeue() ?? 0
         }
         
         guard var lhs = operands.dequeue() else {
-            return 0.2 // 추후 에러처리
+            return 0
         }
         
-        while !operatos.isEmpty {
+        while let currentOperator = operatos.dequeue() {
             
-            guard let rhs = operands.dequeue(), let currentOperator = operatos.dequeue() else {
-                return 0.3 // 추후 에러처리
+            guard let rhs = operands.dequeue() else {
+                throw CalculatorError.incompleteFormula
             }
             
-            result = currentOperator.calculate(lhs: lhs, rhs: rhs)
+            result = try currentOperator.calculate(lhs: lhs, rhs: rhs)
             lhs = result
         }
         

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -10,26 +10,20 @@ struct Formula {
     var operatos: CalculatorItemQueue<Operator> = CalculatorItemQueue()
     
     mutating func result() throws -> Double {
-        var result: Double = 0
         
-        guard !operatos.isEmpty else {
-            return operands.dequeue() ?? 0
-        }
-        
-        guard var lhs = operands.dequeue() else {
+        guard var firstOperand = operands.dequeue() else {
             return 0
         }
         
         while let currentOperator = operatos.dequeue() {
             
-            guard let rhs = operands.dequeue() else {
+            guard let secondOperand = operands.dequeue() else {
                 throw CalculatorError.incompleteFormula
             }
             
-            result = try currentOperator.calculate(lhs: lhs, rhs: rhs)
-            lhs = result
+            firstOperand = try currentOperator.calculate(lhs: firstOperand, rhs: secondOperand)
         }
         
-        return result
+        return firstOperand
     }
 }

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -8,26 +8,35 @@
 enum Operator: Character, CaseIterable {
     case add = "+"
     case subtract = "-"
-    case divide = "/"
-    case multiply = "*"
+    case divide = "÷"
+    case multiply = "×"
     
     func calculate(lhs: Double, rhs:Double) -> Double {
-        return 0.1 // 임시 값
+        switch self {
+        case .add:
+            return add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            return subtract(lhs: lhs, rhs: rhs)
+        case .divide:
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
+        }
     }
     
     func add(lhs: Double, rhs:Double) -> Double {
-        return 0.1 // 임시 값
+        return lhs + rhs
     }
     
     func subtract(lhs: Double, rhs:Double) -> Double {
-        return 0.1 // 임시 값
+        return lhs - rhs
     }
     
     func divide(lhs: Double, rhs:Double) -> Double {
-        return 0.1 // 임시 값
+        return lhs / rhs // 0나누기 처리 해야함
     }
     
     func multiply(lhs: Double, rhs:Double) -> Double {
-        return 0.1 // 임시 값
+        return lhs * rhs
     }
 }

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -1,0 +1,33 @@
+//
+//  Operator.swift
+//  Calculator
+//
+//  Created by redmango1446 on 2023/06/05.
+//
+
+enum Operator: Character, CaseIterable {
+    case add = "+"
+    case subtract = "-"
+    case divide = "/"
+    case multiply = "*"
+    
+    func calculate(lhs: Double, rhs:Double) -> Double {
+        return 0.1 // 임시 값
+    }
+    
+    func add(lhs: Double, rhs:Double) -> Double {
+        return 0.1 // 임시 값
+    }
+    
+    func subtract(lhs: Double, rhs:Double) -> Double {
+        return 0.1 // 임시 값
+    }
+    
+    func divide(lhs: Double, rhs:Double) -> Double {
+        return 0.1 // 임시 값
+    }
+    
+    func multiply(lhs: Double, rhs:Double) -> Double {
+        return 0.1 // 임시 값
+    }
+}

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -24,20 +24,20 @@ enum Operator: Character, CaseIterable {
         }
     }
     
-    func add(lhs: Double, rhs:Double) -> Double {
+    private func add(lhs: Double, rhs:Double) -> Double {
         return lhs + rhs
     }
     
-    func subtract(lhs: Double, rhs:Double) -> Double {
+    private func subtract(lhs: Double, rhs:Double) -> Double {
         return lhs - rhs
     }
     
-    func divide(lhs: Double, rhs:Double) throws -> Double {
+    private func divide(lhs: Double, rhs:Double) throws -> Double {
         guard rhs != 0.0 else { throw CalculatorError.divideError }
         return lhs / rhs
     }
     
-    func multiply(lhs: Double, rhs:Double) -> Double {
+    private func multiply(lhs: Double, rhs:Double) -> Double {
         return lhs * rhs
     }
 }

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -11,14 +11,14 @@ enum Operator: Character, CaseIterable {
     case divide = "÷"
     case multiply = "×"
     
-    func calculate(lhs: Double, rhs:Double) -> Double {
+    func calculate(lhs: Double, rhs:Double) throws -> Double {
         switch self {
         case .add:
             return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            return divide(lhs: lhs, rhs: rhs)
+            return try divide(lhs: lhs, rhs: rhs)
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
         }
@@ -32,8 +32,9 @@ enum Operator: Character, CaseIterable {
         return lhs - rhs
     }
     
-    func divide(lhs: Double, rhs:Double) -> Double {
-        return lhs / rhs // 0나누기 처리 해야함
+    func divide(lhs: Double, rhs:Double) throws -> Double {
+        guard rhs != 0.0 else { throw CalculatorError.divideError }
+        return lhs / rhs
     }
     
     func multiply(lhs: Double, rhs:Double) -> Double {

--- a/Calculator/Calculator/Protocol/CalculatorError.swift
+++ b/Calculator/Calculator/Protocol/CalculatorError.swift
@@ -1,0 +1,13 @@
+//
+//  CalculatorError.swift
+//  Calculator
+//
+//  Created by redmango1446 on 2023/06/07.
+//
+
+import Foundation
+
+enum CalculatorError: Error {
+    case divideError
+    case incompleteFormula
+}

--- a/Calculator/Calculator/Protocol/Double+.swift
+++ b/Calculator/Calculator/Protocol/Double+.swift
@@ -1,0 +1,8 @@
+//
+//  Double+.swift
+//  Calculator
+//
+//  Created by redmango1446 on 2023/06/06.
+//
+
+extension Double: CalculateItem { }

--- a/Calculator/Calculator/Protocol/String+.swift
+++ b/Calculator/Calculator/Protocol/String+.swift
@@ -5,8 +5,10 @@
 //  Created by redmango1446 on 2023/06/06.
 //
 
+import Foundation
+
 extension String {
     func split(with target: Character) -> [String] {
-        return ["1"] // 임시값
+        return self.components(separatedBy: String(target))
     }
 }

--- a/Calculator/Calculator/Protocol/String+.swift
+++ b/Calculator/Calculator/Protocol/String+.swift
@@ -1,0 +1,12 @@
+//
+//  String+.swift
+//  Calculator
+//
+//  Created by redmango1446 on 2023/06/06.
+//
+
+extension String {
+    func split(with target: Character) -> [String] {
+        return ["1"] // 임시값
+    }
+}

--- a/Calculator/CalculatorItemQueueTests/FormulaTests.swift
+++ b/Calculator/CalculatorItemQueueTests/FormulaTests.swift
@@ -23,10 +23,10 @@ final class FormulaTests: XCTestCase {
     func test_result_1과_10을_더하면_예상값은_11이다() {
         // given
         let input = "1 + 10"
+        sut = ExpressionParser.parse(from: input)
         
         // when
-        sut = ExpressionParser.parse(from: input)
-        let result = sut.result()
+        let result = try! sut.result()
         let expectedValue: Double = 11
         
         // then
@@ -36,10 +36,10 @@ final class FormulaTests: XCTestCase {
     func test_result_1에서_10을_빼면_예상값은_마이너스9이다() {
         // given
         let input = "1 - 10"
+        sut = ExpressionParser.parse(from: input)
         
         // when
-        sut = ExpressionParser.parse(from: input)
-        let result = sut.result()
+        let result = try! sut.result()
         let expectedValue: Double = -9
         
         // then
@@ -49,24 +49,24 @@ final class FormulaTests: XCTestCase {
     func test_result_1과_마이너스10을_더하면_예상값은_마이너스9다() {
         // given
         let input = "1 + -10"
+        sut = ExpressionParser.parse(from: input)
         
         // when
-        sut = ExpressionParser.parse(from: input)
-        let result = sut.result()
+        let result = try! sut.result()
         let expectedValue: Double = -9
         
         // then
         XCTAssertEqual(result, expectedValue)
     }
 
-    func test_result_10을_2로_나누면_예상값은_5다() {
+    func test_result_1을_2로_나누면_예상값은_0점5다() {
         // given
-        let input = "10 ÷ 2"
+        let input = "1 ÷ 2"
+        sut = ExpressionParser.parse(from: input)
         
         // when
-        sut = ExpressionParser.parse(from: input)
-        let result = sut.result()
-        let expectedValue: Double = 5
+        let result = try! sut.result()
+        let expectedValue: Double = 0.5
         
         // then
         XCTAssertEqual(result, expectedValue)
@@ -75,10 +75,10 @@ final class FormulaTests: XCTestCase {
     func test_result_10_곱하기_2를_하며_예상값은_20다() {
         // given
         let input = "10 × 2"
+        sut = ExpressionParser.parse(from: input)
         
         // when
-        sut = ExpressionParser.parse(from: input)
-        let result = sut.result()
+        let result = try! sut.result()
         let expectedValue: Double = 20
         
         // then
@@ -88,14 +88,60 @@ final class FormulaTests: XCTestCase {
     func test_result_2와_10을_더하고_2로_나누면_예상값은_6이다() {
         // given
         let input = "2 + 10 ÷ 2"
+        sut = ExpressionParser.parse(from: input)
         
         // when
-        sut = ExpressionParser.parse(from: input)
-        let result = sut.result()
+        let result = try! sut.result()
         let expectedValue: Double = 6
         
         // then
         XCTAssertEqual(result, expectedValue)
     }
+    
+    func test_result_2을_0으로_나누면_divideError에러에_걸린다() {
+        // given
+        let input = "2 ÷ 0"
+        sut = ExpressionParser.parse(from: input)
+        
+        let errorMassage: CalculatorError = CalculatorError.divideError
+        var error: CalculatorError?
+        
+        // when
+        XCTAssertThrowsError(try sut.result()){ result in
+            error = result as? CalculatorError
+        }
 
+        // then
+        XCTAssertEqual(error, errorMassage)
+    }
+    
+    func test_result_0을_2로_나누면_예상값은_0이다() {
+        // given
+        let input = "0 ÷ 2"
+        sut = ExpressionParser.parse(from: input)
+        
+        // when
+        let result = try! sut.result()
+        let expectedValue: Double = 0
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_result_2_나누기만_입력하면_divideError에러에_걸린다() {
+        // given
+        let input = "2 ÷"
+        sut = ExpressionParser.parse(from: input)
+        
+        let errorMassage: CalculatorError = CalculatorError.incompleteFormula
+        var error: CalculatorError?
+        
+        // when
+        XCTAssertThrowsError(try sut.result()){ result in
+            error = result as? CalculatorError
+        }
+
+        // then
+        XCTAssertEqual(error, errorMassage)
+    }
 }

--- a/Calculator/CalculatorItemQueueTests/FormulaTests.swift
+++ b/Calculator/CalculatorItemQueueTests/FormulaTests.swift
@@ -1,0 +1,101 @@
+//
+//  FormulaTests.swift
+//  Calculator
+//
+//  Created by redmango1446 on 2023/06/07.
+//
+
+import XCTest
+@testable import Calculator
+
+final class FormulaTests: XCTestCase {
+    var sut: Formula!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+    
+    func test_result_1과_10을_더하면_예상값은_11이다() {
+        // given
+        let input = "1 + 10"
+        
+        // when
+        sut = ExpressionParser.parse(from: input)
+        let result = sut.result()
+        let expectedValue: Double = 11
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_result_1에서_10을_빼면_예상값은_마이너스9이다() {
+        // given
+        let input = "1 - 10"
+        
+        // when
+        sut = ExpressionParser.parse(from: input)
+        let result = sut.result()
+        let expectedValue: Double = -9
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_result_1과_마이너스10을_더하면_예상값은_마이너스9다() {
+        // given
+        let input = "1 + -10"
+        
+        // when
+        sut = ExpressionParser.parse(from: input)
+        let result = sut.result()
+        let expectedValue: Double = -9
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+
+    func test_result_10을_2로_나누면_예상값은_5다() {
+        // given
+        let input = "10 ÷ 2"
+        
+        // when
+        sut = ExpressionParser.parse(from: input)
+        let result = sut.result()
+        let expectedValue: Double = 5
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_result_10_곱하기_2를_하며_예상값은_20다() {
+        // given
+        let input = "10 × 2"
+        
+        // when
+        sut = ExpressionParser.parse(from: input)
+        let result = sut.result()
+        let expectedValue: Double = 20
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_result_2와_10을_더하고_2로_나누면_예상값은_6이다() {
+        // given
+        let input = "2 + 10 ÷ 2"
+        
+        // when
+        sut = ExpressionParser.parse(from: input)
+        let result = sut.result()
+        let expectedValue: Double = 6
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+
+}

--- a/Calculator/LinkedListTests/ExpressionParserTeste.swift
+++ b/Calculator/LinkedListTests/ExpressionParserTeste.swift
@@ -11,10 +11,11 @@ import XCTest
 final class ExpressionParserTeste: XCTestCase {
 
     override func setUpWithError() throws {
-
+        try super.setUpWithError()
     }
 
     override func tearDownWithError() throws {
+        try super.tearDownWithError()
     }
 
     func test1_parse_1_더하기_10을_넣고_operands를_dequeue를_하면_1을_반환한다() {

--- a/Calculator/LinkedListTests/ExpressionParserTeste.swift
+++ b/Calculator/LinkedListTests/ExpressionParserTeste.swift
@@ -1,0 +1,73 @@
+//
+//  ExpressionParserTeste.swift
+//  CalculatorTests
+//
+//  Created by redmango1446 on 2023/06/07.
+//
+
+import XCTest
+@testable import Calculator
+
+final class ExpressionParserTeste: XCTestCase {
+
+    override func setUpWithError() throws {
+
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func test1_parse_1_더하기_10을_넣으면_1을_반환한다() {
+        // given
+        let input = "1 + 10"
+        
+        // when
+        var formula = ExpressionParser.parse(from: input)
+        let result = formula.operands.dequeue()
+        let expectedValue: Double = 1
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test2_parse_1_더하기_10을_넣으면_10을_반환한다() {
+        // given
+        let input = "1 + 10"
+        
+        // when
+        var formula = ExpressionParser.parse(from: input)
+        var result = formula.operands.dequeue()
+            result = formula.operands.dequeue()
+        let expectedValue: Double = 10
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test3_parse_1_더하기_10을_넣으면_더하기를_반환한다() {
+        // given
+        let input = "1 + 10"
+        
+        // when
+        var formula = ExpressionParser.parse(from: input)
+        let result = formula.operatos.dequeue()
+        let expectedValue = Operator.add
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test4_parse_1_더하기_10_빼기_1을_넣으면_빼기를_반환한다() {
+        // given
+        let input = "1 + 10 - 1"
+        
+        // when
+        var formula = ExpressionParser.parse(from: input)
+        var result = formula.operatos.dequeue()
+            result = formula.operatos.dequeue()
+        let expectedValue = Operator.subtract
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+}

--- a/Calculator/LinkedListTests/ExpressionParserTeste.swift
+++ b/Calculator/LinkedListTests/ExpressionParserTeste.swift
@@ -17,7 +17,7 @@ final class ExpressionParserTeste: XCTestCase {
     override func tearDownWithError() throws {
     }
 
-    func test1_parse_1_더하기_10을_넣으면_1을_반환한다() {
+    func test1_parse_1_더하기_10을_넣고_operands를_dequeue를_하면_1을_반환한다() {
         // given
         let input = "1 + 10"
         
@@ -30,7 +30,7 @@ final class ExpressionParserTeste: XCTestCase {
         XCTAssertEqual(result, expectedValue)
     }
     
-    func test2_parse_1_더하기_10을_넣으면_10을_반환한다() {
+    func test2_parse_1_더하기_10을_넣고_operands를_dequeue를_2번_하면_10을_반환한다() {
         // given
         let input = "1 + 10"
         
@@ -44,7 +44,7 @@ final class ExpressionParserTeste: XCTestCase {
         XCTAssertEqual(result, expectedValue)
     }
     
-    func test3_parse_1_더하기_10을_넣으면_더하기를_반환한다() {
+    func test3_parse_1_더하기_10을_넣고_operatos를_dequeue하면_더하기를_반환한다() {
         // given
         let input = "1 + 10"
         
@@ -57,7 +57,7 @@ final class ExpressionParserTeste: XCTestCase {
         XCTAssertEqual(result, expectedValue)
     }
     
-    func test4_parse_1_더하기_10_빼기_1을_넣으면_빼기를_반환한다() {
+    func test4_parse_1_더하기_10_빼기_1을_넣고_operatos를_2번_dequeue하면_빼기를_반환한다() {
         // given
         let input = "1 + 10 - 1"
         

--- a/Calculator/LinkedListTests/ExpressionParserTeste.swift
+++ b/Calculator/LinkedListTests/ExpressionParserTeste.swift
@@ -51,7 +51,7 @@ final class ExpressionParserTeste: XCTestCase {
         
         // when
         var formula = ExpressionParser.parse(from: input)
-        let result = formula.operatos.dequeue()
+        let result = formula.operators.dequeue()
         let expectedValue = Operator.add
         
         // then
@@ -64,8 +64,8 @@ final class ExpressionParserTeste: XCTestCase {
         
         // when
         var formula = ExpressionParser.parse(from: input)
-        var result = formula.operatos.dequeue()
-            result = formula.operatos.dequeue()
+        var result = formula.operators.dequeue()
+            result = formula.operators.dequeue()
         let expectedValue = Operator.subtract
         
         // then

--- a/Calculator/LinkedListTests/ExpressionParserTeste.swift
+++ b/Calculator/LinkedListTests/ExpressionParserTeste.swift
@@ -20,7 +20,7 @@ final class ExpressionParserTeste: XCTestCase {
 
     func test1_parse_1_더하기_10을_넣고_operands를_dequeue를_하면_1을_반환한다() {
         // given
-        let input = "1 + 10"
+        let input = "1 + 1"
         
         // when
         var formula = ExpressionParser.parse(from: input)


### PR DESCRIPTION
밈 늦은 pr 보냅니다 ㅠㅠ
@JoSH0318 

# STEP 2
## 고민되었던 점
### `1 - -1`
처음엔 음수 계산을 고려하지 않고 구현했기에 `parse`메서드를 호출하면 `-1`의 `-`도 연산자로 등록되었습니다. 즉 `1 - - 1`을 입력한 거나 마찬가지였습니다. 결국 입력값을 공백을 기준으로 잘라 `1` `-` `-1`을 만든 뒤 String의 `count`값이 1개인 문자열들을 `Character` ->`Operator` 순서로 타입을 변경시켜 nil을 제거하고 반환해 주는 `compactMap`을 활용해새로운 상수에 넣어 사용했습니다.

### 구문 분리 기준과 split
UML에 따라 String에 익스텐션으로 `split`메서드를 추가해 줬습니다. 초기엔 `Operator` enum 타입의 `lawValue`을 기준으로 구문 분리를 하려 했으나 `split`메서드를 활용해서 구현하기엔 무리가 있다는 걸 깨달았습니다. `components` 메서드를 활용하면 가능할 듯 하나, `split`메서드가 추가된 이유가 있겠거니 생각을 했기 때문에 그것을 활용하는 방법으로 가려면 아무래도 공백을 기준으로 구문 분리를 해줘야 할듯싶어 그렇게 진행하였습니다. 물론 사용자가 공백을 입력하는 버튼이나 방법은 없지만 추후 viewController에서 값을 받아 올 때 공백을 추가하거나 다른 방식의 처리 방법을 구현하면 될 걸로 생각하고 있습니다.

## 해결되지 않은 점
### UML
linkedList와 Node의 관계가 의존이라고 하셨는데 어떠한 기준으로 연관이 아니라 의존 관계인지 지금도 의문이 풀리지 않고 있습니다.

## 조언을 얻고 싶은 부분

### `extension` `split`
~~이거 왜 있는 거예요?~~
split 메서드의 존재 이유를 생각해 보려 했지만 아직 잘 모르겠습니다.
기능적으로는 의미가 없어 보이는데 의존성이나 그 외 개념적인 이유 때문일까 고민은 하고 있지만 아직 공부가 부족해 알 수 없었습니다.

### UnitTest
`ExpressionParser`의 테스트가 맞는 방법으로 진행된 건지 의문입니다. enum 타입의 메서드에 static을 선언함으로써 인스턴스화를 막아놓았으니 전역변수처럼 사용해서 테스트를 진행했지만 이게 맞는 건지 모르겠습니다.