### PR TITLE
계산기 II [STEP 2] Erick, idinaloq, maxhyunm

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		45841ED32A24996000B959AE /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45841ED22A24996000B959AE /* Operator.swift */; };
 		45841ED52A24999D00B959AE /* Double+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45841ED42A24999D00B959AE /* Double+Extension.swift */; };
 		45841EEA2A24A09700B959AE /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45841EE92A24A09700B959AE /* CalculatorItemQueueTests.swift */; };
+		45A83C972A398C4100D5128E /* OperationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A83C962A398C4100D5128E /* OperationManagerTests.swift */; };
 		45C1A1BE2A31D41A005B7F24 /* CalculatorNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C1A1BD2A31D41A005B7F24 /* CalculatorNamespace.swift */; };
 		45CC295D2A28955900E28FFD /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CC295C2A28955900E28FFD /* OperatorTests.swift */; };
 		45CC29642A289A8A00E28FFD /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CC29632A289A8A00E28FFD /* String+Extension.swift */; };
@@ -52,6 +53,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		45A83C982A398C4100D5128E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 		45CC295E2A28955900E28FFD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
@@ -73,6 +81,8 @@
 		45841ED42A24999D00B959AE /* Double+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
 		45841EE72A24A09700B959AE /* CalculatorItemQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorItemQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		45841EE92A24A09700B959AE /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
+		45A83C942A398C4100D5128E /* OperationManagerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperationManagerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		45A83C962A398C4100D5128E /* OperationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationManagerTests.swift; sourceTree = "<group>"; };
 		45C1A1BD2A31D41A005B7F24 /* CalculatorNamespace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorNamespace.swift; sourceTree = "<group>"; };
 		45CC295A2A28955900E28FFD /* OperatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		45CC295C2A28955900E28FFD /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
@@ -107,6 +117,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		45841EE42A24A09700B959AE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		45A83C912A398C4100D5128E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -197,6 +214,14 @@
 			path = CalculatorItemQueueTests;
 			sourceTree = "<group>";
 		};
+		45A83C952A398C4100D5128E /* OperationManagerTests */ = {
+			isa = PBXGroup;
+			children = (
+				45A83C962A398C4100D5128E /* OperationManagerTests.swift */,
+			);
+			path = OperationManagerTests;
+			sourceTree = "<group>";
+		};
 		45CC295B2A28955900E28FFD /* OperatorTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -213,6 +238,7 @@
 				45CC295B2A28955900E28FFD /* OperatorTests */,
 				4547A2AC2A297DCB003EB63C /* FormulaTests */,
 				4547A2B92A298FFF003EB63C /* ExpressionParserTests */,
+				45A83C952A398C4100D5128E /* OperationManagerTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -225,6 +251,7 @@
 				45CC295A2A28955900E28FFD /* OperatorTests.xctest */,
 				4547A2AB2A297DCB003EB63C /* FormulaTests.xctest */,
 				4547A2B82A298FFF003EB63C /* ExpressionParserTests.xctest */,
+				45A83C942A398C4100D5128E /* OperationManagerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -300,6 +327,24 @@
 			productReference = 45841EE72A24A09700B959AE /* CalculatorItemQueueTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		45A83C932A398C4100D5128E /* OperationManagerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 45A83C9C2A398C4100D5128E /* Build configuration list for PBXNativeTarget "OperationManagerTests" */;
+			buildPhases = (
+				45A83C902A398C4100D5128E /* Sources */,
+				45A83C912A398C4100D5128E /* Frameworks */,
+				45A83C922A398C4100D5128E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				45A83C992A398C4100D5128E /* PBXTargetDependency */,
+			);
+			name = OperationManagerTests;
+			productName = OperationManagerTests;
+			productReference = 45A83C942A398C4100D5128E /* OperationManagerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		45CC29592A28955900E28FFD /* OperatorTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 45CC29602A28955900E28FFD /* Build configuration list for PBXNativeTarget "OperatorTests" */;
@@ -356,6 +401,10 @@
 						CreatedOnToolsVersion = 14.2;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					45A83C932A398C4100D5128E = {
+						CreatedOnToolsVersion = 14.2;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					45CC29592A28955900E28FFD = {
 						CreatedOnToolsVersion = 14.2;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
@@ -383,6 +432,7 @@
 				45CC29592A28955900E28FFD /* OperatorTests */,
 				4547A2AA2A297DCB003EB63C /* FormulaTests */,
 				4547A2B72A298FFF003EB63C /* ExpressionParserTests */,
+				45A83C932A398C4100D5128E /* OperationManagerTests */,
 			);
 		};
 /* End PBXProject section */
@@ -403,6 +453,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		45841EE52A24A09700B959AE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		45A83C922A398C4100D5128E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -453,6 +510,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		45A83C902A398C4100D5128E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				45A83C972A398C4100D5128E /* OperationManagerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		45CC29562A28955900E28FFD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -499,6 +564,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 45841EEB2A24A09700B959AE /* PBXContainerItemProxy */;
+		};
+		45A83C992A398C4100D5128E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 45A83C982A398C4100D5128E /* PBXContainerItemProxy */;
 		};
 		45CC295F2A28955900E28FFD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -652,6 +722,51 @@
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyeonsu.CalculatorItemQueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Release;
+		};
+		45A83C9A2A398C4100D5128E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hyeonsu.OperationManagerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Debug;
+		};
+		45A83C9B2A398C4100D5128E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hyeonsu.OperationManagerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -896,6 +1011,15 @@
 			buildConfigurations = (
 				45841EED2A24A09700B959AE /* Debug */,
 				45841EEE2A24A09700B959AE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		45A83C9C2A398C4100D5128E /* Build configuration list for PBXNativeTarget "OperationManagerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				45A83C9A2A398C4100D5128E /* Debug */,
+				45A83C9B2A398C4100D5128E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		45CC29682A289C5000E28FFD /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CC29672A289C5000E28FFD /* Formula.swift */; };
 		45EE8D932A35AC97002AF8A6 /* OperationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EE8D922A35AC97002AF8A6 /* OperationManager.swift */; };
 		BA7E6B7E2A3805D500BB833E /* OperandFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7E6B7D2A3805D500BB833E /* OperandFormatter.swift */; };
+		BA7E6B862A39984400BB833E /* OperandFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7E6B852A39984400BB833E /* OperandFormatterTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
@@ -67,6 +68,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		BA7E6B872A39984400BB833E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -91,6 +99,8 @@
 		45CC29672A289C5000E28FFD /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		45EE8D922A35AC97002AF8A6 /* OperationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationManager.swift; sourceTree = "<group>"; };
 		BA7E6B7D2A3805D500BB833E /* OperandFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperandFormatter.swift; sourceTree = "<group>"; };
+		BA7E6B832A39984300BB833E /* OperandFormatterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperandFormatterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BA7E6B852A39984400BB833E /* OperandFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperandFormatterTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -131,6 +141,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		45CC29572A28955900E28FFD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BA7E6B802A39984300BB833E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -230,6 +247,14 @@
 			path = OperatorTests;
 			sourceTree = "<group>";
 		};
+		BA7E6B842A39984400BB833E /* OperandFormatterTests */ = {
+			isa = PBXGroup;
+			children = (
+				BA7E6B852A39984400BB833E /* OperandFormatterTests.swift */,
+			);
+			path = OperandFormatterTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
@@ -239,6 +264,7 @@
 				4547A2AC2A297DCB003EB63C /* FormulaTests */,
 				4547A2B92A298FFF003EB63C /* ExpressionParserTests */,
 				45A83C952A398C4100D5128E /* OperationManagerTests */,
+				BA7E6B842A39984400BB833E /* OperandFormatterTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -252,6 +278,7 @@
 				4547A2AB2A297DCB003EB63C /* FormulaTests.xctest */,
 				4547A2B82A298FFF003EB63C /* ExpressionParserTests.xctest */,
 				45A83C942A398C4100D5128E /* OperationManagerTests.xctest */,
+				BA7E6B832A39984300BB833E /* OperandFormatterTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -363,6 +390,24 @@
 			productReference = 45CC295A2A28955900E28FFD /* OperatorTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		BA7E6B822A39984300BB833E /* OperandFormatterTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BA7E6B8B2A39984400BB833E /* Build configuration list for PBXNativeTarget "OperandFormatterTests" */;
+			buildPhases = (
+				BA7E6B7F2A39984300BB833E /* Sources */,
+				BA7E6B802A39984300BB833E /* Frameworks */,
+				BA7E6B812A39984300BB833E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BA7E6B882A39984400BB833E /* PBXTargetDependency */,
+			);
+			name = OperandFormatterTests;
+			productName = OperandFormatterTests;
+			productReference = BA7E6B832A39984300BB833E /* OperandFormatterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -409,6 +454,10 @@
 						CreatedOnToolsVersion = 14.2;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					BA7E6B822A39984300BB833E = {
+						CreatedOnToolsVersion = 14.2;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -433,6 +482,7 @@
 				4547A2AA2A297DCB003EB63C /* FormulaTests */,
 				4547A2B72A298FFF003EB63C /* ExpressionParserTests */,
 				45A83C932A398C4100D5128E /* OperationManagerTests */,
+				BA7E6B822A39984300BB833E /* OperandFormatterTests */,
 			);
 		};
 /* End PBXProject section */
@@ -467,6 +517,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		45CC29582A28955900E28FFD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BA7E6B812A39984300BB833E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -526,6 +583,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BA7E6B7F2A39984300BB833E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BA7E6B862A39984400BB833E /* OperandFormatterTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C713D93A2570E5EB001C3AFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -574,6 +639,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 45CC295E2A28955900E28FFD /* PBXContainerItemProxy */;
+		};
+		BA7E6B882A39984400BB833E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = BA7E6B872A39984400BB833E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -822,6 +892,53 @@
 			};
 			name = Release;
 		};
+		BA7E6B892A39984400BB833E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = L8JSH46K7X;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.minhyun219.OperandFormatterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Debug;
+		};
+		BA7E6B8A2A39984400BB833E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = L8JSH46K7X;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.minhyun219.OperandFormatterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Release;
+		};
 		C713D9502570E5ED001C3AFC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1029,6 +1146,15 @@
 			buildConfigurations = (
 				45CC29612A28955900E28FFD /* Debug */,
 				45CC29622A28955900E28FFD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BA7E6B8B2A39984400BB833E /* Build configuration list for PBXNativeTarget "OperandFormatterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BA7E6B892A39984400BB833E /* Debug */,
+				BA7E6B8A2A39984400BB833E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -95,6 +95,17 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA7E6B822A39984300BB833E"
+               BuildableName = "OperandFormatterTests.xctest"
+               BlueprintName = "OperandFormatterTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -84,6 +84,17 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "45A83C932A398C4100D5128E"
+               BuildableName = "OperationManagerTests.xctest"
+               BlueprintName = "OperationManagerTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -97,15 +97,21 @@ extension CalculatorViewController {
         }
         
         let operandsText = OperandFormatter.formatStringOperand(operands)
-        let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .title3)
-        label.textColor = .white
-        label.textAlignment = .right
-        label.text = "\(`operator`) \(operandsText)"
+        let label = setUpCalculationDetailsLabel(`operator`, operandsText)
         
         calculationDetailsStackView.addArrangedSubview(label)
         calculationDetailsScrollView.layoutIfNeeded()
         calculationDetailsScrollView.scrollToBottom(animated: false)
+    }
+    
+    private func setUpCalculationDetailsLabel(_ `operator`: String, _ operands: String) -> UILabel {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.textColor = .white
+        label.textAlignment = .right
+        label.text = "\(`operator`) \(operands)"
+        
+        return label
     }
     
     private func clearCalculationDetailsStackView() {

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -11,7 +11,7 @@ final class CalculatorViewController: UIViewController {
     
     private var operatorValue: String {
         get {
-            return operatorLabel.text ?? CalculatorNamespace.Empty
+            return operatorLabel.text ?? CalculatorNamespace.empty
         }
         set(newOperator) {
             operatorLabel.text = newOperator
@@ -20,7 +20,7 @@ final class CalculatorViewController: UIViewController {
     
     private var operandValue: String {
         get {
-            return OperandFormatter.removeComma(operandsLabel.text ?? CalculatorNamespace.Zero)
+            return OperandFormatter.removeComma(operandsLabel.text ?? CalculatorNamespace.zero)
         }
         set(newOperand) {
             operandsLabel.text = OperandFormatter.formatInput(newOperand)
@@ -35,32 +35,33 @@ final class CalculatorViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        operatorValue = CalculatorNamespace.Empty
-        operandValue = CalculatorNamespace.Zero
+        operatorValue = CalculatorNamespace.empty
+        operandValue = CalculatorNamespace.zero
         clearCalculationDetailsStackView()
     }
     
     @IBAction private func tapOperatorButton(_ sender: UIButton) {
         guard let inputOperator = sender.currentTitle,
-              operandValue != CalculatorNamespace.NaN else { return }
+              operandValue != CalculatorNamespace.nan else { return }
         
-        let result = operationManager.addFormula(operatorValue, operandValue)
+        let oldOperatorValue = operatorValue
         
+        operationManager.addFormula(operatorValue, operandValue)
         operatorValue = inputOperator
-        guard result.operandValue != CalculatorNamespace.Zero else { return }
         
-        addCalculationDetailsStackView(result.operatorValue, result.operandValue)
-        operandValue = CalculatorNamespace.Zero
+        guard operandValue != CalculatorNamespace.zero else { return }
+        
+        addCalculationDetailsStackView(oldOperatorValue, operandValue)
+        operandValue = CalculatorNamespace.zero
     }
     
     @IBAction private func tapEqualButton(_ sender: UIButton) {
-        guard operatorValue != CalculatorNamespace.Empty else { return }
+        guard operatorValue != CalculatorNamespace.empty else { return }
         
-        let result = operationManager.addFormula(operatorValue, operandValue)
-        
-        addCalculationDetailsStackView(result.operatorValue, result.operandValue)
+        operationManager.addFormula(operatorValue, operandValue)
+        addCalculationDetailsStackView(operatorValue, operandValue)
         operandValue = operationManager.calculateFormula()
-        operatorValue = CalculatorNamespace.Empty
+        operatorValue = CalculatorNamespace.empty
     }
     
     @IBAction private func tapNumberButton(_ sender: UIButton) {
@@ -74,14 +75,14 @@ final class CalculatorViewController: UIViewController {
         guard let buttonTitle = sender.currentTitle else { return }
         
         switch buttonTitle {
-        case CalculatorNamespace.AllClear:
-            operatorValue = CalculatorNamespace.Empty
-            operandValue = CalculatorNamespace.Zero
+        case CalculatorNamespace.allClear:
+            operatorValue = CalculatorNamespace.empty
+            operandValue = CalculatorNamespace.zero
             clearCalculationDetailsStackView()
             operationManager.clearFormula()
-        case CalculatorNamespace.ClearEntry:
-            operandValue = CalculatorNamespace.Zero
-        case CalculatorNamespace.SignToggle:
+        case CalculatorNamespace.clearEntry:
+            operandValue = CalculatorNamespace.zero
+        case CalculatorNamespace.signToggle:
             let result = operationManager.changeSign(operandValue)
             operandValue = result
         default:
@@ -92,7 +93,7 @@ final class CalculatorViewController: UIViewController {
 
 extension CalculatorViewController {
     private func addCalculationDetailsStackView(_ `operator`: String, _ operands: String) {
-        if `operator` == CalculatorNamespace.Empty && operands == CalculatorNamespace.Empty {
+        if `operator` == CalculatorNamespace.empty && operands == CalculatorNamespace.empty {
             return
         }
         

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -97,11 +97,12 @@ extension CalculatorViewController {
             return
         }
         
+        let operandsText = OperandFormatter.formatStringOperand(operands)
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .title3)
         label.textColor = .white
         label.textAlignment = .right
-        label.text = "\(`operator`) \(operands)"
+        label.text = "\(`operator`) \(operandsText)"
         
         calculationDetailsStackView.addArrangedSubview(label)
         calculationDetailsScrollView.layoutIfNeeded()

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -44,22 +44,21 @@ final class CalculatorViewController: UIViewController {
         guard let inputOperator = sender.currentTitle,
               operandValue != CalculatorNamespace.nan else { return }
         
-        let oldOperatorValue = operatorValue
-        
-        operationManager.addFormula(operatorValue, operandValue)
+        let result = operationManager.addFormula(operatorValue, operandValue)
         operatorValue = inputOperator
         
         guard operandValue != CalculatorNamespace.zero else { return }
         
-        addCalculationDetailsStackView(oldOperatorValue, operandValue)
+        addCalculationDetailsStackView(result.operatorValue, result.operandValue)
         operandValue = CalculatorNamespace.zero
     }
     
     @IBAction private func tapEqualButton(_ sender: UIButton) {
         guard operatorValue != CalculatorNamespace.empty else { return }
         
-        operationManager.addFormula(operatorValue, operandValue)
-        addCalculationDetailsStackView(operatorValue, operandValue)
+        let result = operationManager.addFormula(operatorValue, operandValue)
+        
+        addCalculationDetailsStackView(result.operatorValue, result.operandValue)
         operandValue = operationManager.calculateFormula()
         operatorValue = CalculatorNamespace.empty
     }

--- a/Calculator/Calculator/Controller/CalculatorViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorViewController.swift
@@ -66,11 +66,10 @@ final class CalculatorViewController: UIViewController {
     @IBAction private func tapNumberButton(_ sender: UIButton) {
         guard let inputNumber = sender.currentTitle else { return }
         
-        let result = operationManager.addOperandsLabel(operandValue, inputNumber)
-        operandValue = result
+        operandValue = operationManager.addOperandsLabel(operandValue, inputNumber)
     }
     
-    @IBAction private func tapFunctionButton(_ sender: UIButton) {
+    @IBAction private func tapClearButton(_ sender: UIButton) {
         guard let buttonTitle = sender.currentTitle else { return }
         
         switch buttonTitle {
@@ -81,12 +80,13 @@ final class CalculatorViewController: UIViewController {
             operationManager.clearFormula()
         case CalculatorNamespace.clearEntry:
             operandValue = CalculatorNamespace.zero
-        case CalculatorNamespace.signToggle:
-            let result = operationManager.changeSign(operandValue)
-            operandValue = result
         default:
             break
         }
+    }
+    
+    @IBAction private func tapSignToggleButton(_ sender: UIButton) {
+        operandValue = operationManager.changeSign(operandValue)
     }
 }
 

--- a/Calculator/Calculator/Model/CalculatorNamespace.swift
+++ b/Calculator/Calculator/Model/CalculatorNamespace.swift
@@ -6,15 +6,14 @@
 //  Last modify : idinaloq, Erick, Maxhyunm
 
 enum CalculatorNamespace {
-    static let Empty: String = ""
-    static let Zero: String = "0"
-    static let NaN: String = "NaN"
-    static let Negative: String = "-"
-    static let DoubleZero: String = "00"
-    static let Dot: String = "."
-    static let Equal: String = "="
-    static let AllClear: String = "AC"
-    static let ClearEntry: String = "CE"
-    static let SignToggle: String = "⁺⁄₋"
-    static let Comma: String = ","
+    static let empty: String = ""
+    static let zero: String = "0"
+    static let nan: String = "NaN"
+    static let negative: String = "-"
+    static let doubleZero: String = "00"
+    static let dot: String = "."
+    static let allClear: String = "AC"
+    static let clearEntry: String = "CE"
+    static let signToggle: String = "⁺⁄₋"
+    static let comma: String = ","
 }

--- a/Calculator/Calculator/Model/OperandFormatter.swift
+++ b/Calculator/Calculator/Model/OperandFormatter.swift
@@ -14,21 +14,12 @@ enum OperandFormatter {
     }
     
     static func formatInput(_ operand: String) -> String {
-        guard let firstDigit = operand.first,
-              !operand.contains(CalculatorNamespace.comma)
+        guard !operand.contains(CalculatorNamespace.comma)
         else {
             return operand
         }
         
         var newOperand: String = operand
-        var sign: String = CalculatorNamespace.empty
-        
-        if String(firstDigit) == CalculatorNamespace.negative {
-            newOperand = String(newOperand.dropFirst(1))
-            sign = CalculatorNamespace.negative
-        }
-        
-        newOperand = sign + newOperand
         let operandSplit = newOperand.components(separatedBy: CalculatorNamespace.dot)
         
         guard let operandInteger = operandSplit.first,

--- a/Calculator/Calculator/Model/OperandFormatter.swift
+++ b/Calculator/Calculator/Model/OperandFormatter.swift
@@ -15,20 +15,17 @@ enum OperandFormatter {
     
     static func formatInput(_ operand: String) -> String {
         guard let firstDigit = operand.first,
-              !operand.contains(",")
+              !operand.contains(CalculatorNamespace.comma)
         else {
             return operand
         }
+        
         var newOperand: String = operand
         var sign: String = CalculatorNamespace.empty
         
         if String(firstDigit) == CalculatorNamespace.negative {
             newOperand = String(newOperand.dropFirst(1))
             sign = CalculatorNamespace.negative
-        }
-
-        if newOperand.count > 20 {
-            newOperand = String(newOperand.prefix(20))
         }
         
         newOperand = sign + newOperand
@@ -65,6 +62,6 @@ enum OperandFormatter {
     }
     
     static func removeComma(_ operand: String) -> String {
-        return operand.replacingOccurrences(of: ",", with: "")
+        return operand.replacingOccurrences(of: CalculatorNamespace.comma, with: CalculatorNamespace.empty)
     }
 }

--- a/Calculator/Calculator/Model/OperandFormatter.swift
+++ b/Calculator/Calculator/Model/OperandFormatter.swift
@@ -16,12 +16,7 @@ enum OperandFormatter {
         numberFormatter.maximumIntegerDigits = 12
         numberFormatter.roundingMode = .halfUp
         
-        guard let numberFormatted = numberFormatter.string(for: operandNumber)
-        else {
-            return CalculatorNamespace.empty
-        }
-        
-        return numberFormatted
+        return numberFormatter.string(for: operandNumber) ?? CalculatorNamespace.empty
     }
     
     static func formatInput(_ operand: String) -> String {

--- a/Calculator/Calculator/Model/OperandFormatter.swift
+++ b/Calculator/Calculator/Model/OperandFormatter.swift
@@ -10,7 +10,20 @@ import Foundation
 enum OperandFormatter {
     static func formatStringOperand(_ operand: String) -> String {
         let operandNumber = NSDecimalNumber(string: operand)
-        return formatNumberToString(operandNumber)
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumFractionDigits = -2
+        numberFormatter.maximumIntegerDigits = 20
+        numberFormatter.maximumSignificantDigits = 20
+        numberFormatter.usesSignificantDigits = true
+        numberFormatter.roundingMode = .halfUp
+        
+        guard let numberFormatted = numberFormatter.string(for: operandNumber)
+        else {
+            return CalculatorNamespace.empty
+        }
+        
+        return numberFormatted
     }
     
     static func formatInput(_ operand: String) -> String {
@@ -22,34 +35,15 @@ enum OperandFormatter {
         var newOperand: String = operand
         let operandSplit = newOperand.components(separatedBy: CalculatorNamespace.dot)
         
-        guard let operandInteger = operandSplit.first,
-              let operandFraction = operandSplit.last
-        else {
-            return newOperand
+        for (index, item) in operandSplit.enumerated() {
+            if index == 0 {
+                newOperand = formatStringOperand(item)
+            } else {
+                newOperand += CalculatorNamespace.dot + item
+            }
         }
-        let operandDouble = NSDecimalNumber(string:operandInteger)
-        newOperand = formatNumberToString(operandDouble)
-        
-        if operandSplit.count == 2 {
-            newOperand += CalculatorNamespace.dot + operandFraction
-        }
+
         return newOperand
-    }
-    
-    private static func formatNumberToString(_ operand: NSDecimalNumber) -> String {
-        let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .decimal
-        numberFormatter.maximumFractionDigits = -2
-        numberFormatter.maximumIntegerDigits = 20
-        numberFormatter.maximumSignificantDigits = 20
-        numberFormatter.usesSignificantDigits = true
-        numberFormatter.roundingMode = .halfUp
-        
-        guard let numberFormatted = numberFormatter.string(for: operand)
-        else {
-            return CalculatorNamespace.empty
-        }
-        return numberFormatted
     }
     
     static func removeComma(_ operand: String) -> String {

--- a/Calculator/Calculator/Model/OperandFormatter.swift
+++ b/Calculator/Calculator/Model/OperandFormatter.swift
@@ -12,10 +12,8 @@ enum OperandFormatter {
         let operandNumber = NSDecimalNumber(string: operand)
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
-        numberFormatter.maximumFractionDigits = -2
-        numberFormatter.maximumIntegerDigits = 20
-        numberFormatter.maximumSignificantDigits = 20
-        numberFormatter.usesSignificantDigits = true
+        numberFormatter.maximumFractionDigits = 11
+        numberFormatter.maximumIntegerDigits = 12
         numberFormatter.roundingMode = .halfUp
         
         guard let numberFormatted = numberFormatter.string(for: operandNumber)

--- a/Calculator/Calculator/Model/OperandFormatter.swift
+++ b/Calculator/Calculator/Model/OperandFormatter.swift
@@ -20,11 +20,11 @@ enum OperandFormatter {
             return operand
         }
         var newOperand: String = operand
-        var sign: String = CalculatorNamespace.Empty
+        var sign: String = CalculatorNamespace.empty
         
-        if String(firstDigit) == CalculatorNamespace.Negative {
+        if String(firstDigit) == CalculatorNamespace.negative {
             newOperand = String(newOperand.dropFirst(1))
-            sign = CalculatorNamespace.Negative
+            sign = CalculatorNamespace.negative
         }
 
         if newOperand.count > 20 {
@@ -32,7 +32,7 @@ enum OperandFormatter {
         }
         
         newOperand = sign + newOperand
-        let operandSplit = newOperand.components(separatedBy: CalculatorNamespace.Dot)
+        let operandSplit = newOperand.components(separatedBy: CalculatorNamespace.dot)
         
         guard let operandInteger = operandSplit.first,
               let operandFraction = operandSplit.last
@@ -43,7 +43,7 @@ enum OperandFormatter {
         newOperand = formatNumberToString(operandDouble)
         
         if operandSplit.count == 2 {
-            newOperand += CalculatorNamespace.Dot + operandFraction
+            newOperand += CalculatorNamespace.dot + operandFraction
         }
         return newOperand
     }
@@ -59,7 +59,7 @@ enum OperandFormatter {
         
         guard let numberFormatted = numberFormatter.string(for: operand)
         else {
-            return CalculatorNamespace.Empty
+            return CalculatorNamespace.empty
         }
         return numberFormatted
     }

--- a/Calculator/Calculator/Model/OperationManager.swift
+++ b/Calculator/Calculator/Model/OperationManager.swift
@@ -15,11 +15,10 @@ struct OperationManager {
     
     mutating func calculateFormula() -> String {
         var parsedFormula = ExpressionParser.parse(from: formula)
-        let result = OperandFormatter.formatStringOperand(String(parsedFormula.result()))
         isCalculate = true
         clearFormula()
         
-        return result
+        return OperandFormatter.formatStringOperand(String(parsedFormula.result()))
     }
 
     @discardableResult

--- a/Calculator/Calculator/Model/OperationManager.swift
+++ b/Calculator/Calculator/Model/OperationManager.swift
@@ -23,8 +23,6 @@ struct OperationManager {
     }
 
     mutating func addFormula(_ operators: String, _ operands: String)  {
-        let operands = OperandFormatter.formatStringOperand(operands)
-        
         if formula.isEmpty && operands != CalculatorNamespace.zero  {
             formula += "\(operands)"
         } else if operands != CalculatorNamespace.zero {
@@ -38,12 +36,8 @@ struct OperationManager {
     
     mutating func addOperandsLabel(_ currentOperands: String, _ inputOperands: String) -> String {
         let numberOperands = isCalculate ? CalculatorNamespace.zero : currentOperands
-        let operands = OperandFormatter.formatStringOperand(numberOperands + inputOperands)
+        let operands = numberOperands + inputOperands
         isCalculate = false
-        
-        if operands.filter({ $0 == "," }).count == 4 || numberOperands.count >= 13 {
-            return currentOperands
-        }
         
         if numberOperands.contains(CalculatorNamespace.dot) &&
             (inputOperands == CalculatorNamespace.zero || inputOperands == CalculatorNamespace.doubleZero) {
@@ -60,7 +54,7 @@ struct OperationManager {
     
     func changeSign(_ operands: String) -> String {
         var operands = operands
-        guard operands != CalculatorNamespace.zero else { return CalculatorNamespace.zero }
+        guard operands != CalculatorNamespace.zero else { return operands }
         
         if operands.contains(CalculatorNamespace.negative) {
             operands.removeFirst()

--- a/Calculator/Calculator/Model/OperationManager.swift
+++ b/Calculator/Calculator/Model/OperationManager.swift
@@ -40,7 +40,6 @@ struct OperationManager {
     
     mutating func addOperandsLabel(_ currentOperands: String, _ inputOperands: String) -> String {
         let numberOperands = isCalculate ? CalculatorNamespace.zero : currentOperands
-        let operands = numberOperands + inputOperands
         isCalculate = false
         
         if numberOperands
@@ -54,7 +53,7 @@ struct OperationManager {
             return numberOperands
         }
 
-        return operands
+        return numberOperands + inputOperands
     }
     
     func changeSign(_ operands: String) -> String {

--- a/Calculator/Calculator/Model/OperationManager.swift
+++ b/Calculator/Calculator/Model/OperationManager.swift
@@ -22,6 +22,7 @@ struct OperationManager {
         return result
     }
 
+    @discardableResult
     mutating func addFormula(_ operators: String, _ operands: String) -> LabelValues {
         if formula.isEmpty {
             if operands == CalculatorNamespace.zero {
@@ -42,8 +43,9 @@ struct OperationManager {
         let operands = numberOperands + inputOperands
         isCalculate = false
         
-        if operands.filter({ String($0) == CalculatorNamespace.comma }).count == 4 ||
-            numberOperands.count >= 13 {
+        if numberOperands
+            .replacingOccurrences(of: CalculatorNamespace.negative, with: CalculatorNamespace.empty)
+            .count >= 12 {
             return numberOperands
         }
         

--- a/Calculator/Calculator/Model/OperationManager.swift
+++ b/Calculator/Calculator/Model/OperationManager.swift
@@ -39,14 +39,14 @@ struct OperationManager {
         let operands = numberOperands + inputOperands
         isCalculate = false
         
+        if operands.filter({ String($0) == CalculatorNamespace.comma }).count == 4 ||
+            numberOperands.count >= 13 {
+            return numberOperands
+        }
+        
         if numberOperands.contains(CalculatorNamespace.dot) &&
-            (inputOperands == CalculatorNamespace.zero || inputOperands == CalculatorNamespace.doubleZero) {
-            let result = numberOperands + inputOperands
-            return result
-        } else if !numberOperands.contains(CalculatorNamespace.dot) &&
-                    inputOperands == CalculatorNamespace.dot {
-            let result = operands + inputOperands
-            return result
+            inputOperands == CalculatorNamespace.dot {
+            return numberOperands
         }
 
         return operands

--- a/Calculator/Calculator/Model/OperationManager.swift
+++ b/Calculator/Calculator/Model/OperationManager.swift
@@ -10,7 +10,7 @@ import Foundation
 typealias LabelValues = (operandValue: String, operatorValue: String)
 
 struct OperationManager {
-    private var formula: String = CalculatorNamespace.Empty
+    private var formula: String = CalculatorNamespace.empty
     private var isCalculate: Bool = false
     
     mutating func calculateFormula() -> String {
@@ -22,28 +22,22 @@ struct OperationManager {
         return result
     }
 
-    mutating func addFormula(_ operators: String, _ operands: String) -> LabelValues {
-        let `operator` = operators
+    mutating func addFormula(_ operators: String, _ operands: String)  {
         let operands = OperandFormatter.formatStringOperand(operands)
         
-        if formula.isEmpty && operands != CalculatorNamespace.Zero  {
+        if formula.isEmpty && operands != CalculatorNamespace.zero  {
             formula += "\(operands)"
-            return (CalculatorNamespace.Empty, operands)
-        } else if operands != CalculatorNamespace.Zero {
-            formula += "\(`operator`)\(operands)"
-            return (operandValue: operands, operatorValue: `operator`)
+        } else if operands != CalculatorNamespace.zero {
+            formula += "\(operators)\(operands)"
         }
         
-        if operands == CalculatorNamespace.Zero {
-            formula += "\(`operator`)\(operands)"
-            return (operandValue: operands, operatorValue: `operator`)
+        if operands == CalculatorNamespace.zero {
+            formula += "\(operators)\(operands)"
         }
-        
-        return (operandValue: CalculatorNamespace.Empty, operatorValue: CalculatorNamespace.Empty)
     }
     
     mutating func addOperandsLabel(_ currentOperands: String, _ inputOperands: String) -> String {
-        let numberOperands = isCalculate ? CalculatorNamespace.Zero : currentOperands
+        let numberOperands = isCalculate ? CalculatorNamespace.zero : currentOperands
         let operands = OperandFormatter.formatStringOperand(numberOperands + inputOperands)
         isCalculate = false
         
@@ -51,12 +45,12 @@ struct OperationManager {
             return currentOperands
         }
         
-        if numberOperands.contains(CalculatorNamespace.Dot) &&
-            (inputOperands == CalculatorNamespace.Zero || inputOperands == CalculatorNamespace.DoubleZero) {
+        if numberOperands.contains(CalculatorNamespace.dot) &&
+            (inputOperands == CalculatorNamespace.zero || inputOperands == CalculatorNamespace.doubleZero) {
             let result = numberOperands + inputOperands
             return result
-        } else if !numberOperands.contains(CalculatorNamespace.Dot) &&
-                    inputOperands == CalculatorNamespace.Dot {
+        } else if !numberOperands.contains(CalculatorNamespace.dot) &&
+                    inputOperands == CalculatorNamespace.dot {
             let result = operands + inputOperands
             return result
         }
@@ -66,18 +60,18 @@ struct OperationManager {
     
     func changeSign(_ operands: String) -> String {
         var operands = operands
-        guard operands != CalculatorNamespace.Zero else { return CalculatorNamespace.Zero }
+        guard operands != CalculatorNamespace.zero else { return CalculatorNamespace.zero }
         
-        if operands.contains(CalculatorNamespace.Negative) {
+        if operands.contains(CalculatorNamespace.negative) {
             operands.removeFirst()
         } else {
-            operands.insert(Character(CalculatorNamespace.Negative), at: operands.startIndex)
+            operands.insert(Character(CalculatorNamespace.negative), at: operands.startIndex)
         }
         
         return operands
     }
     
     mutating func clearFormula() {
-        formula = CalculatorNamespace.Empty
+        formula = CalculatorNamespace.empty
     }
 }

--- a/Calculator/Calculator/Model/OperationManager.swift
+++ b/Calculator/Calculator/Model/OperationManager.swift
@@ -22,16 +22,19 @@ struct OperationManager {
         return result
     }
 
-    mutating func addFormula(_ operators: String, _ operands: String)  {
-        if formula.isEmpty && operands != CalculatorNamespace.zero  {
-            formula += "\(operands)"
-        } else if operands != CalculatorNamespace.zero {
-            formula += "\(operators)\(operands)"
+    mutating func addFormula(_ operators: String, _ operands: String) -> LabelValues {
+        if formula.isEmpty {
+            if operands == CalculatorNamespace.zero {
+                return (operandValue: CalculatorNamespace.empty,
+                        operatorValue: CalculatorNamespace.empty)
+            } else {
+                formula += "\(operands)"
+                return (operandValue: operands,
+                        operatorValue: CalculatorNamespace.empty)
+            }
         }
-        
-        if operands == CalculatorNamespace.zero {
-            formula += "\(operators)\(operands)"
-        }
+        formula += "\(operators)\(operands)"
+        return (operandValue: operands, operatorValue: operators)
     }
     
     mutating func addOperandsLabel(_ currentOperands: String, _ inputOperands: String) -> String {

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -86,7 +86,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="tapFunctionButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2Gc-6V-uYB"/>
+                                                    <action selector="tapClearButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mq9-eO-NJr"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
@@ -97,7 +97,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="tapFunctionButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="z5P-5p-o6U"/>
+                                                    <action selector="tapClearButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fDe-7P-x64"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
@@ -108,7 +108,7 @@
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="tapFunctionButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aid-YS-1fj"/>
+                                                    <action selector="tapSignToggleButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CQE-ac-qZa"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">

--- a/Calculator/ExpressionParserTests/ExpressionParserTests.swift
+++ b/Calculator/ExpressionParserTests/ExpressionParserTests.swift
@@ -15,7 +15,7 @@ final class ExpressionParserTests: XCTestCase {
     override func tearDownWithError() throws { }
     
     func test_공식을_parse에_넣으면_Formula가_반환되어_result를_호출하면_답이_반환됩니다() {
-        let input = "1 + 3"
+        let input = "1+3"
         var formula = ExpressionParser.parse(from: input)
         let expectation: Double = 4
         
@@ -25,7 +25,7 @@ final class ExpressionParserTests: XCTestCase {
     }
     
     func test_nan이_반환되는_공식을_parse에_넣으면_result도_nan을_반환합니다() {
-        let input = "1 + 3 ÷ 0 × 10"
+        let input = "1+3÷0×10"
         var formula = ExpressionParser.parse(from: input)
         
         let result = formula.result().isNaN
@@ -34,7 +34,7 @@ final class ExpressionParserTests: XCTestCase {
     }
     
     func test_부호가_다른_숫자를_포함한_공식을_parse에_넣으면_result도_그에_맞는_답을_반환합니다() {
-        let input = "1 + 3 − −3"
+        let input = "1+3−-3"
         var formula = ExpressionParser.parse(from: input)
         let expectation: Double = 7
         

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -9,26 +9,24 @@ import XCTest
 @testable import Calculator
 
 final class FormulaTests: XCTestCase {
-    var sut: Formula!
     
-    override func setUpWithError() throws {
-        sut = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
-    }
+    override func setUpWithError() throws { }
 
-    override func tearDownWithError() throws {
-        sut = nil
-    }
+    override func tearDownWithError() throws { }
     
     func test_피연산자에_2_3을_넣고_연산자에_add를_넣으면_result가_5를_반환합니다() {
         let input: Double = 2
         let input2: Double = 3
-        sut.operands.enqueue(input)
-        sut.operands.enqueue(input2)
+        var inputOpernds = CalculatorItemQueue<Double>()
+        inputOpernds.enqueue(input)
+        inputOpernds.enqueue(input2)
         let inputOperator: Operator = .add
-        sut.operators.enqueue(inputOperator)
+        var inputOperators = CalculatorItemQueue<Operator>()
+        inputOperators.enqueue(inputOperator)
         let expectation: Double = 5
         
-        let result = sut.result()
+        var formula = Formula(operands: inputOpernds, operators: inputOperators)
+        let result = formula.result()
         
         XCTAssertEqual(result, expectation)
     }
@@ -36,29 +34,38 @@ final class FormulaTests: XCTestCase {
     func test_피연산자가_없을때_result가_0을_반환합니다() {
         let expectation: Double = 0
         
-        let result = sut.result()
+        var formula = Formula(operands: CalculatorItemQueue<Double>(),
+                              operators: CalculatorItemQueue<Operator>())
+        let result = formula.result()
         
         XCTAssertEqual(result, expectation)
     }
     
     func test_연산자가_없을때_result가_피연산자를_반환합니다() {
         let input: Double = 5
-        sut.operands.enqueue(input)
+        var inputOpernds = CalculatorItemQueue<Double>()
+        inputOpernds.enqueue(input)
         let expectation: Double = 5
         
-        let result = sut.result()
+        var formula = Formula(operands: inputOpernds,
+                              operators: CalculatorItemQueue<Operator>())
+        let result = formula.result()
         
         XCTAssertEqual(result, expectation)
     }
     
     func test_두번째_피연산자가_없을때_result가_첫번째_피연산자를_반환합니다() {
         let input: Double = 5
-        sut.operands.enqueue(input)
+        var inputOpernds = CalculatorItemQueue<Double>()
+        inputOpernds.enqueue(input)
         let inputOperator: Operator = .add
-        sut.operators.enqueue(inputOperator)
+        var inputOperators = CalculatorItemQueue<Operator>()
+        inputOperators.enqueue(inputOperator)
         let expectation: Double = 5
         
-        let result = sut.result()
+        var formula = Formula(operands: inputOpernds,
+                              operators: inputOperators)
+        let result = formula.result()
         
         XCTAssertEqual(result, expectation)
     }
@@ -66,12 +73,16 @@ final class FormulaTests: XCTestCase {
     func test_0으로_나누면_result가_nan을_반환합니다() {
         let input: Double = 4
         let input2: Double = 0
-        sut.operands.enqueue(input)
-        sut.operands.enqueue(input2)
+        var inputOpernds = CalculatorItemQueue<Double>()
+        inputOpernds.enqueue(input)
+        inputOpernds.enqueue(input2)
         let inputOperator: Operator = .divide
-        sut.operators.enqueue(inputOperator)
+        var inputOperators = CalculatorItemQueue<Operator>()
+        inputOperators.enqueue(inputOperator)
                 
-        let result = sut.result().isNaN
+        var formula = Formula(operands: inputOpernds,
+                              operators: inputOperators)
+        let result = formula.result().isNaN
         
         XCTAssertTrue(result)
     }

--- a/Calculator/OperandFormatterTests/OperandFormatterTests.swift
+++ b/Calculator/OperandFormatterTests/OperandFormatterTests.swift
@@ -1,0 +1,51 @@
+//
+//  OperandFormatterTests.swift
+//  OperandFormatterTests
+//
+//  Created by Min Hyun on 2023/06/14.
+//
+
+import XCTest
+@testable import Calculator
+
+final class OperandFormatterTests: XCTestCase {
+    func test_formatStringOperand로_문자열_형태의_소수를_보내면_올바른_형태로_변환합니다() {
+        let inputString = "1234.56"
+        let inputDouble = 1234.56
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumFractionDigits = -2
+        numberFormatter.maximumIntegerDigits = 20
+        numberFormatter.maximumSignificantDigits = 20
+        numberFormatter.usesSignificantDigits = true
+        numberFormatter.roundingMode = .halfUp
+        
+        let expectation = numberFormatter.string(for: inputDouble)!
+        let result = OperandFormatter.formatStringOperand(inputString)
+        
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_formatInput로_쉼표가_포함된_문자열을_보내면_변환을_진행하지_않습니다() {
+        let input = "1,234.56"
+        let result = OperandFormatter.formatInput(input)
+
+        XCTAssertEqual(result, input)
+    }
+    
+    func test_formatInput로_문자열_형태의_소수를_보내면_올바른_형태로_변환합니다() {
+        let input = "1234.56"
+        let expectation = "1,234.56"
+        let result = OperandFormatter.formatInput(input)
+
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_removeComma로_쉼표가_포함된_문자열을_보내면_쉼표를_제거합니다() {
+        let input = "1,234.56"
+        let result = OperandFormatter.removeComma(input)
+        let expectation = "1234.56"
+        
+        XCTAssertEqual(result, expectation)
+    }
+}

--- a/Calculator/OperationManagerTests/OperationManagerTests.swift
+++ b/Calculator/OperationManagerTests/OperationManagerTests.swift
@@ -1,0 +1,112 @@
+//
+//  OperationManagerTests.swift
+//  OperationManagerTests
+//
+//  Created by 표현수 on 2023/06/14.
+//
+
+import XCTest
+@testable import Calculator
+
+final class OperationManagerTests: XCTestCase {
+    var sut: OperationManager!
+    
+    override func setUpWithError() throws {
+        sut = OperationManager()
+    }
+    
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+    
+    func test_formula가_비어있는_상태로_calculateFormula를_호출하면_문자_0이_반환됩니다() {
+        let expectation = CalculatorNamespace.zero
+        
+        let result = sut.calculateFormula()
+        
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_formula에_수식을_넣고_calculateFormula를_호출하면_그에_맞는_값을_반환합니다() {
+        sut.addFormula("", "1")
+        sut.addFormula("+", "2")
+        sut.addFormula("+", "3")
+        sut.addFormula("+", "4")
+        sut.addFormula("+", "5")
+        let expectation = "15"
+        
+        let result = sut.calculateFormula()
+        
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_formula가_비어있을때_addFormula에_연산자와_피연산자를_입력하지_않는다면_빈문자열을_반환합니다() {
+        let expectation = (operandValue: CalculatorNamespace.empty,
+                           operatorValue:  CalculatorNamespace.empty)
+        
+        let result = sut.addFormula("", "0")
+        
+        XCTAssertEqual(result.operandValue, expectation.operandValue)
+        XCTAssertEqual(result.operatorValue, expectation.operatorValue)
+    }
+    
+    func test_calculateFormula로_계산을_한_이후에는_addOperandsLabel로_숫자_두개를_입력하면_첫번쨰_인자를_0으로_변환합니다() {
+        sut.addFormula("", "1")
+        sut.addFormula("+", "2")
+        sut.addFormula("+", "3")
+        sut.addFormula("+", "4")
+        sut.addFormula("+", "5")
+        let formulaResult = sut.calculateFormula()
+        let input = "9"
+        let expectation = "09"
+        
+        let result = sut.addOperandsLabel(formulaResult, input)
+        
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_addOperandsLabel로_문자열이_입력되었을때_12자리를_초과하는_내용은_더_이상_입력되지_않습니다() {
+        let input = "999999999999"
+        let expectation = input
+        
+        let result = sut.addOperandsLabel(input, "9")
+        
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_소수점이_포함된_숫자와_소수점을_addOperandsLabel로_전달하면_두번째_소수점이_무시됩니다() {
+        let input = "0."
+        let expectation = input
+        
+        let result = sut.addOperandsLabel(input, CalculatorNamespace.dot)
+        
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_0일때_changeSign을_호출하면_부호가_붙지_않습니다() {
+        let input = "0"
+        let expectation = input
+        
+        let result = sut.changeSign(input)
+        
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_양수일때_changeSign을_호출하면_음수로_변환됩니다() {
+        let input = "1"
+        let expectation = "-1"
+        
+        let result = sut.changeSign(input)
+        
+        XCTAssertEqual(result, expectation)
+    }
+    
+    func test_음수일때_changeSign을_호출하면_양수로_변환됩니다() {
+        let input = "-1"
+        let expectation = "1"
+        
+        let result = sut.changeSign(input)
+        
+        XCTAssertEqual(result, expectation)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,153 +1,69 @@
-# 계산기
+# 🧮 계산기 II
 
 > +, -, ×, ÷ 연산이 가능한 계산기 앱
 
 </br>
 
-## 목차
-
-1. [팀원](#1.)
-2. [시각화된 프로젝트 구조](#2.)
-3. [타임라인](#3.)
-4. [실행 화면(기능 설명)](#4.)
-5. [트러블 슈팅](#5.)
-6. [참고 링크](#6.)
-7. [프로젝트 회고](#7.)
-
----
+## 목차📌</br>
+[1. 팀원소개](##팀원소개🧑‍💻)</br>
+[2. 타임라인](##타임라인📅)</br>
+[3. UML](##UML📊)</br>
+[4. 실행화면](##실행화면📱)</br>
+[5. 트러블슈팅](##트러블슈팅🚨)</br>
+[6. 참고자료](##참고자료📘)</br>
+[7. 회고](##회고📝)</br>
 
 </br>
 
-<a id="1."></a>
-
-## 1. 팀원
-
-| [Erick](https://github.com/h-suo) |
-| :---: |
-| <img src="https://user-images.githubusercontent.com/109963294/235300758-fe15d3c5-e312-41dd-a9dd-d61e0ab354cf.png" height="150"/> | 
-
----
-
-<a id="2."></a>
+## 팀원소개🧑‍💻
+|<img src="https://user-images.githubusercontent.com/109963294/235300758-fe15d3c5-e312-41dd-a9dd-d61e0ab354cf.png" width="200"/>|<img src="https://user-images.githubusercontent.com/109963294/235301015-b81055d2-8618-433c-b680-58b6a38047d9.png" width="200"/>|<img src="https://hackmd.io/_uploads/r1rWKewLn.png" width="200"/>|
+| :-: | :-: | :-: |
+|[**Erick**](https://github.com/h-suo)|[**idinaloq**](https://github.com/idinaloq)|[**maxhyunm**](https://github.com/maxhyunm)<br/>|
 
 </br>
 
-## 2. 시각화된 프로젝트 구조
-
-### UML
-<img src="https://github.com/h-suo/ios-calculator-app/assets/109963294/0b590bd2-f904-45b6-b017-21e26654cb49" height="1000"/>
-
-### 폴더 구조
-
-```
-Calculator
-├── Extension
-│   ├── Double+Extension
-│   ├── String+Extension
-│   └── UIScrollView+Extension
-├── Model
-│   ├── ExpressionParser
-│   ├── Formula
-│   ├── CalculatorItemQueue
-│   ├── CalculateItem
-│   ├── Operator
-│   └── CalculatorTerms
-├── View
-│   └── Main
-└──  Controller
-    ├── AppDelegate
-    ├── SceneDelegate
-    └── CalculatorViewController
+## 타임라인📅
+<details><summary>타임라인 테이블</summary>
+    <div markdown="1">
+        <table>
+            <tr>
+                <td><b>날짜</b></td>
+                <td><b>작업내용</b></td>
+            </tr>
+            <tr>
+                <td>6/12(월)</td>
+                <td>ExpressionParser, Operator 타입 병합 및 리팩토링<br/></td>
+            </tr>
+            <tr>
+                <td>6/13(화)</td>
+                <td>CalculatorNamespace, OperandFormatter 병합 및 리팩토링<br/>나누기 연산문제 수정<br/></td>
+            </tr>
+            <tr>
+                <td>6/14(수)</td>
+                <td>병합된 코드 기반으로 정상작동할 수 있도록 OperationManager, CalculatorViewController 리팩토링<br/>OperationManager, OperandFormatter 유닛테스트 작성<br/></td>
+            </tr>
+            <tr>
+                <td>6/15(목)</td>
+                <td>OperandFormatter 리팩토링 - 부동소수점 표기 문제 수정 및 불필요한 메서드 삭제<br/>CalculatorViewController 리팩토링 - tapFunctionButton 메서드 분할<br/></td>
+            </tr>
+            <tr>
+                <td>6/16(금)</td>
+                <td>setUpCalculationDetailsLabel() 메서드 생성<br/>README 작성</td>
+            </tr>
+        </table>
+    </div>
+</details>
     
-Test
-├── CalculatorItemQueueTests
-├── OperatorTests
-├── FormulaTests
-└── ExpressionParserTests
-```
-
 </br>
 
----
-
-<a id="3."></a>
-
-## 3. 타임라인
-
-### ***STEP2***
-
-### **2023.06.01.(목)**
-**Queue 수정**
-- 연결리스트로 구현했던 `CalculatorItemQueue`를 더블 스택 큐로 수정
-
-**Operator**
-- `Operator` 타입에 연산 메서드 `calculate` 추가
-- 테스트를 위한 `OperatorTests` 생성
-
-**String+**
-- `split` 메서드 추가
-
-### **2023.06.02.(금)**
-**UML**
-- 제공받은 UML에 맞게 로직 구현
-- **Formula**
-    - 피연산자를 가져와 연산자로 계산하는 로직 구현
-    - 테스트를 위한 `FormulaTests` 생성
-- **ExpressionParser**
-    - 받아온 문자열을 피연산자와 연산자로 나누어 Formula를 반환하는 로직 구현
-    - 테스트를 위한 `ExpressionParserTests` 생성
-
-### 2023.06.05.(월)
-**리펙토링**
-- 축약어를 사용하지 않도록 리네임
-- 잘못된 띄어쓰기 및 대소문자 수정
-
+## UML📊
+<details><summary>UML 이미지</summary>
+    <div markdown="1">
+        <img src="https://github.com/idinaloq/testRep/assets/124647187/4de1076f-d5c6-4441-bfbd-b096615d6ec9" width="700">
+    </div></details>
 </br>
 
-### ***STEP3***
-
-### **2023.06.06.(화)**
-**뷰객체와 컨트롤러 연결**
-- `@IBOutlet`으로 `operatorLabel`, `operandsLabel`을 생성하여 연산자를 표시하는 레이블과 피연산자를 표시하는 레이블에 연결
-- `@IBAction`으로 버튼 액션과 관련된 함수를 생성하여 숫자 버튼, 옵션 버튼, 연산자 버튼으로 동작을 나누어 연결
-
-### **2023.06.07.(수)**
-**버튼 액션 분리**
-- `TapNumberButton`에서 `TapDecimalPointButton`을 분리
-- `TapOperatorButton`에서 `TapEqualButton` 분리
-- `TapOptionButton`을 `AC`, `CE`, `ChangeSign`에 따라 분리
-
-**버튼 액션 구현**
-- 버튼을 눌렀을 때 그에 맞게 숫자가 입력되고 연산자가 입력되는 로직 구현
-- `TapEqualButton`을 눌렀을 때 `formula`에 맞는 결과를 보여주도록 구현
-- `TapChangeSignButton`을 눌렀을 때 부호를 변경하는 로직 구현
-
-**연산 내역 추가**
-- 연산을 추가할 때마다 스택뷰에 연산 내역이 쌓이도록 구현
-- 연산이 많아져도 가장 최근 연산을 보여줄 수 있도록 `UIScrollView`를 확장하여 `scrollToBottom` 메서드 생성
-
-### **2023.06.08.(목)**
-**코드의 분리**
-- `@IBAction` 내부에서 바로 처리하던 로직들을 함수로 분리
-
-**계산기 용어 정리**
-- 컨트롤러에서 반복적으로 사용되는 "0", "." 과 같은 문자들을 `CalculatorTerms`을 생성하여 정리
-
-### **2023.06.09.(금)**
-**README 작성**
-
-**계산기 로직 수정**
-- 연산 내역에는 정상적인 숫자가 추가되도록 수정
-- 계산 후 숫자가 입력되면 결과에서 숫자가 추가되는 것이 아닌 새로운 숫자만 추가되도록 수정
-- 입력 받는 자릿수 그리고 결과의 자릿수를 12자리로 수정
-
----
-
-</br>
-
-<a id="4."></a>
-
-## 4. 실행 화면(기능 설명)
+## 실행화면📱
 
 | **계산 수행** | **0으로 나누었을 때 NaN** |
 |:----:|:----:|
@@ -159,219 +75,108 @@ Test
 
 </br>
 
----
+## 트러블슈팅🚨
 
-<a id="5."></a>
-
-## 5. 트러블 슈팅
-
-### NaN
-
-**🔥문제점**
-
-- `Operator`의 `divide` 연산을 수행할 때 0으로 나누어도 NaN을 반환하지 않았습니다.
-
+### 부동소수점
+🔒 **[ 문제사항 ]** 
+소수점 자리수가 늘어나거나 일반 연산과 합쳐지면 실제 값이 아닌 근사값을 표기하며 오류가 발생하였습니다.
 <details>
-<summary>본문 코드 내용</summary>
+    <summary>참고 이미지</summary>
+    <div markdown="1">
+        <img src="https://hackmd.io/_uploads/BJyExtuvn.png">
+    </div>
+</details>
+<br>
 
+🔑 **[ 해결1 ]** 
+연산하기 전과 포매터에 넘기기 전 타입을 `Decimal`과 `NSDecimalNumber`로 변경하여 오차 폭을 줄였습니다.
 ```swift
-func divide(lhs: Double, rhs: Double) -> Double {        
-    return lhs / rhs
+private func add(lhs: Double, rhs: Double) -> Double {
+    let result = NSDecimalNumber(decimal: Decimal(lhs) + Decimal(rhs))
+    return result.doubleValue
+}
+
+static func formatStringOperand(_ operand: String) -> String {
+        let operandNumber = NSDecimalNumber(string: operand)
+    ...
 }
 ```
-    
-</details>
-
-</br>
-
-**🧯해결방안**
-
-- `divide`의 결과값이 `Double.infinity`라면 `Double.nan`을 던져주도록 구현하였습니다.
-
-<details>
-<summary>본문 코드 내용</summary>
-
+🔑 **[ 해결2 ]** 
+`NSDecimalNumber`로 설정했음에도 오류가 발생하는 상황에 대해서는 `NumberFormatter`에서 소수점 자릿수 한정을 두어 반올림 표현되도록 해결하였습니다.
 ```swift
-func divide(lhs: Double, rhs: Double) -> Double {
-    let result = lhs / rhs
-        
-    return result.isInfinite ? Double.nan : result
+static func formatStringOperand(_ operand: String) -> String {
+    ...
+    numberFormatter.maximumFractionDigits = 11
+    numberFormatter.maximumIntegerDigits = 12
+    ...
 }
 ```
-    
-</details>
 
-</br>
-
-### 고차함수
-
-**🔥문제점**
-
-- `ExpressionParser`의 `parse` 내부 로직에 고차함수와 `if`문이 섞여있어 가독성이 떨어지는 문제가 있었습니다.
-
-<details>
-<summary>본문 코드 내용</summary>
-
+### 테스트를 통과하지 않는 코드
+🔒 **[ 문제사항 ]** 
+옵셔널 바인딩을 위해 작성한 `guard`문 같은 경우 `else`문을 통과할 경우의 수가 존재하지 않아 실질적으로 테스트를 100% 진행하지 못하는 경우가 발생하였습니다. 
 ```swift
-static func parse(from input: String) -> Formula {
-    var formula = Formula()
-    let calculateItemList = componentsByOperators(from: input)
-        
-    calculateItemList.forEach { item in
-        if let oper: Double = Double(item) {
-            formula.operands.enqueue(oper)
-        } else if let oper: Operator = Operator(rawValue: item) {
-            formula.operators.enqueue(oper)
-        }
+guard let operandInteger = operandSplit.first,
+    let operandFraction = operandSplit.last
+else {
+ return newOperand
+}
+```
+🔑 **[ 해결 ]** 
+이런 경우를 최소화하기 위해 옵셔널처리가 필요한 `.first`와 `.last` 대신 `for`문과 `enumerate()` 메서드를 활용하여 불필요한 else문을 제거하였습니다.
+```swift
+for (index, item) in operandSplit.enumerated() {
+    if index == 0 {
+        newOperand = formatStringOperand(item)
+    } else {
+        newOperand += CalculatorNamespace.dot + item
     }
-    
-    return formula
 }
 ```
-    
-</details>
 
-</br>
-
-**🧯해결방안**
-
-- if문과 고차함수를 같이 사용하는 것이 아닌 고차함수로만 로직을 구현하여 가독성을 높였습니다.
-
-<details>
-<summary>본문 코드 내용</summary>
-
+### 모호한 메서드명
+🔒 **[ 문제사항 ]** 
+`AC`, `CE`, `+/-` 버튼을 눌렀을 때 동작하는 `IBAction` 메서드의 명칭이 정확히 어떤 행동을 나타내는 것인지 파악하기가 어려웠습니다.
 ```swift
-static func parse(from input: String) -> Formula {
-    var operands = CalculatorItemQueue<Double>()
-    var operators = CalculatorItemQueue<Operator>()
-    let components = componentsByOperators(from: input)
-        
-    components
-        .compactMap { Double($0) }
-        .forEach { operands.enqueue($0) }
-        
-    components
-        .filter { $0.count == 1 }
-        .compactMap { Operator(rawValue: Character($0))}
-        .forEach { operators.enqueue($0)}
-        
-    return Formula(operands: operands, operators: operators)
+@IBAction private func tapFunctionButton(_ sender: UIButton) {
+    ...
 }
 ```
-    
-</details>
-
-</br>
-
-### arrangedSubviews
-
-**🔥문제점**
-
-- 연산 내역을 `stackView`에 추가할 때 뷰를 추가하는 것과 삭제하는 것의 번거로움이 있었습니다.
-
-</br>
-
-**🧯해결방안**
-
-- `arrangedSubviews`를 이용하여 스택뷰로만 이루어진 하위뷰에 쉽게 접근할 수 있었습니다.
-- 이를 이용하여 `arrangedSubviews`에 새로운 레이블을 추가하거나, `arrangedSubviews`로 접근하여 상위 뷰와의 연결을 끊어 쉽게 뷰를 삭제할 수 있었습니다.
-
-<details>
-<summary>본문 코드 내용</summary>
-
+🔑 **[ 해결 ]** 
+내용을 삭제하는 기능을 가진 `AC`와 `CE`를 묶고, 별도의 기능을 가진 `+/-`를 분리하여 메서드명을 정리하였습니다.
 ```swift
-final class CalculatorViewController: UIViewController {
-    
-    // ...
-    private func addCalculationDetailsStackView(_ `operator`: String, _ operands: String) {
-        let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .title3)
-        label.textColor = .white
-        label.textAlignment = .right
-        label.text = "\(`operator`) \(operands)"
-        
-        calculationDetailsStackView.addArrangedSubview(label)
-        // ...
-    }
-    
-    // ...
-    private func clearCalculationDetailsStackView() {
-        calculationDetailsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-    }
-    
-    // ...
+@IBAction private func tapClearButton(_ sender: UIButton) {
+    ...
+}
+
+@IBAction private func tapSignToggleButton(_ sender: UIButton) {
+    ...
 }
 ```
-    
-</details>
+
+
+### 코드병합
+🔒 **[ 문제사항 ]** 
+각자 작업했던 코드를 하나로 합치는 과정에서 불필요한 변수나 상수, 메서드가 다수 발생했고 분기처리에 오류가 발생하는 등 많은 리팩토링이 필요했습니다.
+
+🔑 **[ 해결 ]** 
+사용하지 않는 변수와 메서드를 구분하여 삭제처리하고, 병합할 수 있는 내용을 병합하였습니다. 로직 분기점 또한 효율적으로 진행할 수 있는 부분을 찾아 다시 배치하였습니다. 결과적으로 코드가 더욱 깔끔해져 가독성이 올라갔고, 기능에 따라 분리가 이루어져 효율성이 크게 올라갔습니다.
 
 </br>
 
-### 오토레이아웃
-
-**🔥문제점**
-
-- 스택뷰에 새로운 뷰가 업데이트 되는 것보다 `scrollToBottom`이 먼저 호출되어 연산 내역에 화면 넘어까지 연산이 추가되어도 입력값이 보이지 않는 문제가 있었습니다.
-
-<details>
-<summary>문제 실행 화면</summary>
-    
-<img src="https://github.com/h-suo/ios-calculator-app/assets/109963294/5ba2414f-ea61-49c6-afb0-0fed3e7d05b1" width="300"/>
-
-</details>
-    
-</br>
-
-**🧯해결방안**
-
-- iOS는 내부적으로 메인 스레드에서 `main run loop`를 실행하고 이후에 `Update Cycle`을 실행하기 때문에 레이아웃 업데이트를 즉시 실행해주는 `layoutIfNeeded()`를 호출하도록 하였습니다.
-
-<details>
-<summary>본문 코드 내용</summary>
-
-```swift
-final class CalculatorViewController: UIViewController {
-    
-    // ...
-    private func addCalculationDetailsStackView(_ `operator`: String, _ operands: String) {
-        
-        // ...
-        calculationDetailsScrollView.layoutIfNeeded()
-        calculationDetailsScrollView.scrollToBottom(animated: false)
-    }
-    
-    // ...
-}
-```
-    
-</details>
-
----
+## 참고자료📘
+[Apple Developer Documentation - Double](https://developer.apple.com/documentation/swift/double)</br>
+[Apple Developer Documentation - Decimal](https://developer.apple.com/documentation/foundation/decimal)</br>
+[Apple Developer Documentation - NSDecimalNumber](https://developer.apple.com/documentation/foundation/nsdecimalnumber)</br>
+[Apple Developer Documentation - NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)</br>
 
 </br>
 
-<a id="6."></a>
+## 회고📝
+### 우리 팀이 잘한 점👍
+- 개인적인 일이 있어서 참여를 못해도 시간 배분을 잘했기 때문에 수월하게 프로젝트를 진행할 수 있었습니다.</br>
+- 각자의 의견을 모두 취합하여 코드를 작성하였습니다.</br>
+- 문제가 발생했을 때 효율적인 해결법이 무엇인지에 대해 함께 고민하고, 의견을 모아 진행한 덕분에 리팩토링이 깔끔하게 진행되었습니다.</br>
 
-## 6. 참고 링크
-
-- [🍎 Apple-NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)
-- [🍎 Apple-arrangedSubviews](https://developer.apple.com/documentation/uikit/uistackview/1616232-arrangedsubviews)
-- [😺 Z1napp/ScrollView scroll to bottom extension.swift](https://gist.github.com/Z1napp/e7f921e16315d5b484e5d9a9c34a0b46)
-- [🗒️ UIView에서 Subview 지우기](https://gyuha.tistory.com/419)
-- [🗒️ layoutIfNeeded() 이해하고 사용하기 ](https://ios-development.tistory.com/986)
-
----
-
-</br>
-
-<a id="7."></a>
-
-## 7. 프로젝트 회고
-
-### 👏🏻 잘한 점
-
-- 기능 구현을 하기 위해 여러 방법들을 찾아보고 공부한 것이 잘한 점이라고 생각합니다.
-
-### 👊🏻 개선할 점
-
-- 다양한 방향으로 생각하는 것이 부족한 것 같습니다.
+### 우리 팀이 아쉬웠던 점👎
+- 코드를 합치는 과정에서 세 명이 작업한 코드를 적용해야 하다보니 내비게이터와 드라이버의 구분이 종종 모호해지는 경우가 있었습니다.</br>

--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@
 </br>
 
 ## 목차📌</br>
-[1. 팀원소개](##팀원소개🧑‍💻)</br>
-[2. 타임라인](##타임라인📅)</br>
-[3. UML](##UML📊)</br>
-[4. 실행화면](##실행화면📱)</br>
-[5. 트러블슈팅](##트러블슈팅🚨)</br>
-[6. 참고자료](##참고자료📘)</br>
-[7. 회고](##회고📝)</br>
+1. [팀원소개](#1.)
+2. [타임라인](#2.)
+3. [UML](#3.)
+4. [실행화면](#4.)
+5. [트러블슈팅](#5.)
+6. [참고자료](#6.)
+7. [회고](#7.)
 
 </br>
+
+<a id="1."></a>
 
 ## 팀원소개🧑‍💻
 |<img src="https://user-images.githubusercontent.com/109963294/235300758-fe15d3c5-e312-41dd-a9dd-d61e0ab354cf.png" width="200"/>|<img src="https://user-images.githubusercontent.com/109963294/235301015-b81055d2-8618-433c-b680-58b6a38047d9.png" width="200"/>|<img src="https://hackmd.io/_uploads/r1rWKewLn.png" width="200"/>|
@@ -21,6 +23,8 @@
 |[**Erick**](https://github.com/h-suo)|[**idinaloq**](https://github.com/idinaloq)|[**maxhyunm**](https://github.com/maxhyunm)<br/>|
 
 </br>
+
+<a id="2."></a>
 
 ## 타임라인📅
 <details><summary>타임라인 테이블</summary>
@@ -56,12 +60,16 @@
     
 </br>
 
+<a id="3."></a>
+
 ## UML📊
 <details><summary>UML 이미지</summary>
     <div markdown="1">
         <img src="https://github.com/idinaloq/testRep/assets/124647187/4de1076f-d5c6-4441-bfbd-b096615d6ec9" width="700">
     </div></details>
 </br>
+
+<a id="4."></a>
 
 ## 실행화면📱
 
@@ -74,6 +82,8 @@
 |<img src="https://github.com/h-suo/ios-calculator-app/assets/109963294/7ba36e98-093e-4e52-837c-93b7d61083a1" width="300"/>|<img src="https://github.com/h-suo/ios-calculator-app/assets/109963294/ba112176-a48a-40b7-ac6e-526fec84319d" width="300"/>|
 
 </br>
+
+<a id="5."></a>
 
 ## 트러블슈팅🚨
 
@@ -164,6 +174,8 @@ for (index, item) in operandSplit.enumerated() {
 
 </br>
 
+<a id="6."></a>
+
 ## 참고자료📘
 [Apple Developer Documentation - Double](https://developer.apple.com/documentation/swift/double)</br>
 [Apple Developer Documentation - Decimal](https://developer.apple.com/documentation/foundation/decimal)</br>
@@ -171,6 +183,8 @@ for (index, item) in operandSplit.enumerated() {
 [Apple Developer Documentation - NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)</br>
 
 </br>
+
+<a id="7."></a>
 
 ## 회고📝
 ### 우리 팀이 잘한 점👍


### PR DESCRIPTION
@jsa0224
솜!! 드디어 계산기 프로젝트 마지막 PR입니다!
이번에도 좋은 리뷰 부탁드립니다! 🙇‍♂️

### 고민한 점
- 반복적인 코드를 제거하고 불필요한 조건문을 삭제하는 것을 가장 큰 목표로 진행하였습니다. 또한 매직리터럴과 매직넘버를 없애기 위해 Namespace를 적극 활용하였습니다.
- 수정 과정에서 로직이 정상적으로 작동하지 않아, 여러 차례 테스트를 거치며 분기점 수정을 진행하였습니다.
- 가장 큰 고민을 하였던 두 가지 문제는 아래 문의사항으로 남겨두었습니다.

### 조언을 얻고 싶은 점
- 소수점 문제
    - `Decimal`과 `NSDecimalNumber`를 활용하여 단순 숫자표현과 간단한 소수 계산`예: 0.1+0.3`의 정확도를 올렸지만, 아직도 소수 자리가 길어지거나`0.0000005 + 0.0000001`와 같은 다른 연산과 소수가 섞이게 되면 오차가 포함된 결과를 반환합니다. 
저희가 생각하기에 `Queue`에 숫자를 넣을 때나 `Operator`를 거칠 때 `Double` 형태로 주고받게 되는 지점 때문인 것 같습니다.
`UML`에 정해져 있는 `Double` 타입 제약을 지키면서 이 부분을 해결할 수 있는 방법을 찾지 못하여, 겉으로 보여지는 값만이라도 정상적으로 보일 수 있게끔 `NumberFormatter`의 설정을 조절하여 작업하였습니다.

<br>

- 항상 조건을 만족하는 `guard-let`구문 테스트
    - 예)
        `NSDecimalNumber`가 `NumberFormatter`를 통과하는 과정에서 발생하는 `guard let` 문입니다.
여기서 `string()` 메서드의 반환값이 옵셔널이기 때문에 바인딩을 위해 필수적으로 `else`문이 들어가야 하지만, `NSDecimalNumber`에서 숫자가 아닌 값은 모두 `NSDecimalNumber` 타입의 `NaN`으로 반환하기 때문에 어떤 경우에도 `NumberFormatter`를 정상적으로 통과합니다. 결국 이 `else`문은 실질적으로 어떤 경우에도 호출되지 않습니다.
이럴 경우에는 `else`문에 대한 테스트를 반드시 진행해야 할까요?
        
```swift
enum OperandFormatter {
    let operandNumber = NSDecimalNumber(string: operand)
    
    // ...
    guard let numberFormatted = numberFormatter.string(for: operandNumber)
    else {
        return CalculatorNamespace.empty
    }
    
    // ...
}
```