### PR TITLE
계산기 II [STEP 2] 비모, redmango

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		5D9A07842A2F658800F6E112 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07832A2F658700F6E112 /* ExpressionParser.swift */; };
 		5D9A07862A2F65B600F6E112 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07852A2F65B600F6E112 /* Formula.swift */; };
 		5D9A078A2A2F98D400F6E112 /* ExpressionParserTeste.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A07892A2F98D400F6E112 /* ExpressionParserTeste.swift */; };
-		5DA805942A30903C0081E2E0 /* CalculatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA805932A30903C0081E2E0 /* CalculatorError.swift */; };
 		5DCA9B0E2A27A13B00ACBFF6 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA9B0D2A27A13B00ACBFF6 /* Node.swift */; };
 		5DCA9B122A27A21000ACBFF6 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCA9B112A27A21000ACBFF6 /* LinkedList.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -60,7 +59,6 @@
 		5D9A07832A2F658700F6E112 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		5D9A07852A2F65B600F6E112 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		5D9A07892A2F98D400F6E112 /* ExpressionParserTeste.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExpressionParserTeste.swift; path = LinkedListTests/ExpressionParserTeste.swift; sourceTree = SOURCE_ROOT; };
-		5DA805932A30903C0081E2E0 /* CalculatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorError.swift; sourceTree = "<group>"; };
 		5DCA9B0D2A27A13B00ACBFF6 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		5DCA9B112A27A21000ACBFF6 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -167,15 +165,6 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
-		5DA805922A308EC60081E2E0 /* Error */ = {
-			isa = PBXGroup;
-			children = (
-				5DA805932A30903C0081E2E0 /* CalculatorError.swift */,
-			);
-			name = Error;
-			path = Protocol;
-			sourceTree = "<group>";
-		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
@@ -199,7 +188,6 @@
 		C713D9402570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
-				5DA805922A308EC60081E2E0 /* Error */,
 				5D9A077E2A2F650D00F6E112 /* Extension */,
 				5D7AC4932A25E88700AFE620 /* Protocol */,
 				5D7AC4922A25E88500AFE620 /* Model */,
@@ -361,7 +349,6 @@
 				5D7AC4972A25E8EE00AFE620 /* CalculateItem.swift in Sources */,
 				5D9A07802A2F652800F6E112 /* Double+.swift in Sources */,
 				5D9A07862A2F65B600F6E112 /* Formula.swift in Sources */,
-				5DA805942A30903C0081E2E0 /* CalculatorError.swift in Sources */,
 				5D9A07822A2F653600F6E112 /* String+.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* CalculatorMainViewController.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,

--- a/Calculator/Calculator/Controller/CalculatorMainViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorMainViewController.swift
@@ -54,9 +54,9 @@ final class CalculatorMainViewController: UIViewController {
     @IBAction private func touchUpNumberButton(_ sender: UIButton) {
         if isFormulaEnd {
             appendCalculateItem()
-            clearEntry()
             operatorsAndOperandsInput = ""
             isFormulaEnd = false
+            clearEntry()
         }
         
         guard
@@ -75,9 +75,9 @@ final class CalculatorMainViewController: UIViewController {
     @IBAction private func touchUpZeroButton(_ sender: UIButton) {
         if isFormulaEnd {
             appendCalculateItem()
-            clearEntry()
             operatorsAndOperandsInput = ""
             isFormulaEnd = false
+            clearEntry()
         }
         
         guard
@@ -116,6 +116,12 @@ final class CalculatorMainViewController: UIViewController {
     }
     
     @IBAction private func touchUpClearEntryButton(_ sender: UIButton) {
+        if isFormulaEnd {
+            appendCalculateItem()
+            operatorsAndOperandsInput = ""
+            isFormulaEnd = false
+        }
+        
         clearEntry()
     }
     
@@ -177,12 +183,6 @@ final class CalculatorMainViewController: UIViewController {
     }
     
     private func clearEntry() {
-        if isFormulaEnd {
-            appendCalculateItem()
-            operatorsAndOperandsInput = ""
-            isFormulaEnd = false
-        }
-        
         operandLabel.text = "0"
     }
     

--- a/Calculator/Calculator/Controller/CalculatorMainViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorMainViewController.swift
@@ -92,6 +92,10 @@ final class CalculatorMainViewController: UIViewController {
         }
         
         operandLabel.text?.append(zeroText)
+        
+        if !operandLabelText.contains(".") {
+            operandLabel.text = formatNumber(of: operandLabelNumber)
+        }
     }
     
     @IBAction private func touchUpPointButton(_ sender: UIButton) {

--- a/Calculator/Calculator/Controller/CalculatorMainViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorMainViewController.swift
@@ -145,18 +145,16 @@ final class CalculatorMainViewController: UIViewController {
         guard !operatorsAndOperandsInput.isEmpty else {
             return
         }
+     
+        appendCalculateItem()
+        let result = calculate()
         
-        do {
-            appendCalculateItem()
-            operandLabel.text = formatNumber(of: try calculate())
-        } catch let error as CalculatorError {
-            switch error {
-            case .divideError:
-                operandLabel.text = "NaN"
-            }
-        } catch {
-            print("알 수 없는 에러 발생")
+        if result.isNaN || result.isInfinite {
+            operandLabel.text = "NaN"
+        } else {
+            operandLabel.text = formatNumber(of: result)
         }
+        
     }
     
     @IBAction private func touchUpChangeSignButton(_ sender: UIButton) {
@@ -263,14 +261,14 @@ final class CalculatorMainViewController: UIViewController {
         return stackView
     }
     
-    private func calculate() throws -> Double {
+    private func calculate() -> Double {
         var formula = ExpressionParser.parse(from: operatorsAndOperandsInput)
         
         clearOperator()
         clearInput()
         finishFormulaProcess()
         
-        return try formula.result()
+        return formula.result()
     }
     
     private func scrollToBottom() {

--- a/Calculator/Calculator/Controller/CalculatorMainViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorMainViewController.swift
@@ -125,18 +125,26 @@ class CalculatorMainViewController: UIViewController {
         } catch {
             print("알 수 없는 에러 발생")
         }
+        
+        
     }
     
     @IBAction func touchUpChangeSignButton(_ sender: UIButton) {
-        var currentOperandText = operandLabel.text ?? "0"
-        let isCurrentSign = currentOperandText.contains("-")
-        
-        if isCurrentSign == true {
-            currentOperandText.removeFirst()
-            operandLabel.text = currentOperandText
-        } else {
-            operandLabel.text = "-" + currentOperandText
+        guard
+            var operandLabelText = removeComma(of: operandLabel.text),
+            let number = Decimal(string: operandLabelText),
+            !number.isZero
+        else {
+            return
         }
+        
+        if operandLabelText.contains("-") {
+            operandLabelText.removeFirst()
+        } else {
+            operandLabelText = "-\(operandLabelText)"
+        }
+        
+        operandLabel.text = operandLabelText
     }
     
     // MARK: - Method

--- a/Calculator/Calculator/Controller/CalculatorMainViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorMainViewController.swift
@@ -36,6 +36,10 @@ final class CalculatorMainViewController: UIViewController {
         return Decimal(string: operandLabelText)
     }
     
+    private var isOperandInputPossible: Bool {
+        return operandLabelText.count < 20
+    }
+    
     // MARK: - View State Method
     
     override func viewDidLoad() {
@@ -54,7 +58,7 @@ final class CalculatorMainViewController: UIViewController {
         }
         
         guard
-            operandLabelText.count < 20,
+            isOperandInputPossible,
             let numberText = sender.titleLabel?.text
         else {
             return
@@ -75,7 +79,7 @@ final class CalculatorMainViewController: UIViewController {
         guard
             operandLabelText.isNotNaN,
             operandLabelText != "0" || operandLabelText.contains("."),
-            operandLabelText.count < 20,
+            isOperandInputPossible,
             let zeroText = sender.titleLabel?.text
         else {
             return

--- a/Calculator/Calculator/Controller/CalculatorMainViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorMainViewController.swift
@@ -29,13 +29,7 @@ final class CalculatorMainViewController: UIViewController {
     }()
     
     private var operandLabelText: String {
-        get {
-            return removeComma(of: operandLabel.text)
-        }
-        
-        set(text) {
-            operandLabel.text = text
-        }
+        return removeComma(of: operandLabel.text)
     }
     
     private var operandLabelNumber: Decimal {
@@ -70,7 +64,7 @@ final class CalculatorMainViewController: UIViewController {
             return
         }
 
-        operandLabelText.append(numberText)
+        operandLabel.text?.append(numberText)
         operandLabel.text = formatNumber(of: operandLabelNumber)
     }
     
@@ -157,7 +151,7 @@ final class CalculatorMainViewController: UIViewController {
         } catch let error as CalculatorError {
             switch error {
             case .divideError:
-                operandLabelText = "NaN"
+                operandLabel.text = "NaN"
             }
         } catch {
             print("알 수 없는 에러 발생")
@@ -170,9 +164,9 @@ final class CalculatorMainViewController: UIViewController {
         }
         
         if operandLabelText.contains("-") {
-            operandLabelText.removeFirst()
+            operandLabel.text?.removeFirst()
         } else {
-            operandLabelText = "-\(operandLabelText)"
+            operandLabel.text = "-\(operandLabelText)"
         }
     }
     
@@ -194,7 +188,7 @@ final class CalculatorMainViewController: UIViewController {
     }
     
     private func clearEntry() {
-        operandLabelText = "0"
+        operandLabel.text? = "0"
     }
     
     private func clearOperator() {
@@ -243,7 +237,7 @@ final class CalculatorMainViewController: UIViewController {
         let operandLabel = createUILabel(text: formattedNumber)
         
         if operandLabelText.last == "." {
-            operandLabelText.removeLast()
+            operandLabel.text?.removeLast()
         }
         
         let calculateItemStackView = createCalculateItemStackView(operatorLabel, operandLabel)

--- a/Calculator/Calculator/Controller/CalculatorMainViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorMainViewController.swift
@@ -17,7 +17,7 @@ final class CalculatorMainViewController: UIViewController {
     // MARK: - Property
     
     private var operatorsAndOperandsInput: String = ""
-    private var isFormulainProcess: Bool = true
+    private var isFormulaInProcess: Bool = true
     
     private let numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
@@ -50,7 +50,7 @@ final class CalculatorMainViewController: UIViewController {
     // MARK: - IBAction
     
     @IBAction private func touchUpNumberButton(_ sender: UIButton) {
-        if !isFormulainProcess {
+        if !isFormulaInProcess {
             appendCalculateItem()
             clearInput()
             continueFormulaProcess()
@@ -69,7 +69,7 @@ final class CalculatorMainViewController: UIViewController {
     }
     
     @IBAction private func touchUpZeroButton(_ sender: UIButton) {
-        if !isFormulainProcess {
+        if !isFormulaInProcess {
             appendCalculateItem()
             clearInput()
             continueFormulaProcess()
@@ -94,7 +94,7 @@ final class CalculatorMainViewController: UIViewController {
     
     @IBAction private func touchUpPointButton(_ sender: UIButton) {
         guard
-            isFormulainProcess,
+            isFormulaInProcess,
             let pointText = sender.titleLabel?.text,
             !operandLabelText.contains(pointText)
         else {
@@ -128,7 +128,7 @@ final class CalculatorMainViewController: UIViewController {
     }
     
     @IBAction private func touchUpClearEntryButton(_ sender: UIButton) {
-        if !isFormulainProcess {
+        if !isFormulaInProcess {
             appendCalculateItem()
             clearInput()
             continueFormulaProcess()
@@ -204,11 +204,11 @@ final class CalculatorMainViewController: UIViewController {
     }
     
     func continueFormulaProcess() {
-        isFormulainProcess = true
+        isFormulaInProcess = true
     }
     
     func finishFormulaProcess() {
-        isFormulainProcess = false
+        isFormulaInProcess = false
     }
     
     private func removeComma(of text: String?) -> String {

--- a/Calculator/Calculator/Controller/CalculatorMainViewController.swift
+++ b/Calculator/Calculator/Controller/CalculatorMainViewController.swift
@@ -32,12 +32,8 @@ final class CalculatorMainViewController: UIViewController {
         return removeComma(of: operandLabel.text)
     }
     
-    private var operandLabelNumber: Decimal {
-        guard let number = Decimal(string: operandLabelText) else {
-            return 0
-        }
-        
-        return number
+    private var operandLabelNumber: Decimal? {
+        return Decimal(string: operandLabelText)
     }
     
     // MARK: - View State Method
@@ -107,6 +103,7 @@ final class CalculatorMainViewController: UIViewController {
     @IBAction private func touchUpOperatorButton(_ sender: UIButton) {
         guard
             operandLabelText.isNotNaN,
+            let operandLabelNumber,
             !operatorsAndOperandsInput.isEmpty || !operandLabelNumber.isZero,
             let operatorText = sender.titleLabel?.text
         else {
@@ -159,7 +156,10 @@ final class CalculatorMainViewController: UIViewController {
     }
     
     @IBAction private func touchUpChangeSignButton(_ sender: UIButton) {
-        guard !operandLabelNumber.isZero else {
+        guard
+            let operandLabelNumber,
+            !operandLabelNumber.isZero
+        else {
             return
         }
         

--- a/Calculator/Calculator/Formula.swift
+++ b/Calculator/Calculator/Formula.swift
@@ -9,7 +9,7 @@ struct Formula {
     var operands: CalculatorItemQueue<Double> = CalculatorItemQueue()
     var operators: CalculatorItemQueue<Operator> = CalculatorItemQueue()
     
-    mutating func result() throws -> Double {
+    mutating func result() -> Double {
         guard var firstOperand = operands.dequeue() else {
             return 0
         }
@@ -18,7 +18,7 @@ struct Formula {
             let currentOperator = operators.dequeue(),
             let secondOperand = operands.dequeue()
         {
-            firstOperand = try currentOperator.calculate(lhs: firstOperand, rhs: secondOperand)
+            firstOperand = currentOperator.calculate(lhs: firstOperand, rhs: secondOperand)
         }
         
         return firstOperand.isZero ? 0 : firstOperand

--- a/Calculator/Calculator/Operator.swift
+++ b/Calculator/Calculator/Operator.swift
@@ -11,14 +11,14 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "÷"
     case multiply = "×"
     
-    func calculate(lhs: Double, rhs:Double) throws -> Double {
+    func calculate(lhs: Double, rhs:Double) -> Double {
         switch self {
         case .add:
             return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            return try divide(lhs: lhs, rhs: rhs)
+            return divide(lhs: lhs, rhs: rhs)
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
         }
@@ -32,11 +32,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
         return lhs - rhs
     }
     
-    private func divide(lhs: Double, rhs:Double) throws -> Double {
-        guard !rhs.isZero else {
-            throw CalculatorError.divideError
-        }
-        
+    private func divide(lhs: Double, rhs:Double) -> Double {
         return lhs / rhs
     }
     

--- a/Calculator/Calculator/Protocol/String+.swift
+++ b/Calculator/Calculator/Protocol/String+.swift
@@ -6,6 +6,14 @@
 //
 
 extension String {
+    var isNaN: Bool {
+        return self == "NaN"
+    }
+    
+    var isNotNaN: Bool {
+        return self != "NaN"
+    }
+    
     func split(with target: Character) -> [String] {
         return self.components(separatedBy: String(target))
     }

--- a/Calculator/CalculatorItemQueueTests/FormulaTests.swift
+++ b/Calculator/CalculatorItemQueueTests/FormulaTests.swift
@@ -26,7 +26,7 @@ final class FormulaTests: XCTestCase {
         sut = ExpressionParser.parse(from: input)
         
         // when
-        let result = try! sut.result()
+        let result = sut.result()
         let expectedValue: Double = 11
         
         // then
@@ -39,7 +39,7 @@ final class FormulaTests: XCTestCase {
         sut = ExpressionParser.parse(from: input)
         
         // when
-        let result = try! sut.result()
+        let result = sut.result()
         let expectedValue: Double = -9
         
         // then
@@ -52,7 +52,7 @@ final class FormulaTests: XCTestCase {
         sut = ExpressionParser.parse(from: input)
         
         // when
-        let result = try! sut.result()
+        let result = sut.result()
         let expectedValue: Double = -9
         
         // then
@@ -65,7 +65,7 @@ final class FormulaTests: XCTestCase {
         sut = ExpressionParser.parse(from: input)
         
         // when
-        let result = try! sut.result()
+        let result = sut.result()
         let expectedValue: Double = 0.5
         
         // then
@@ -78,7 +78,7 @@ final class FormulaTests: XCTestCase {
         sut = ExpressionParser.parse(from: input)
         
         // when
-        let result = try! sut.result()
+        let result = sut.result()
         let expectedValue: Double = 20
         
         // then
@@ -91,28 +91,11 @@ final class FormulaTests: XCTestCase {
         sut = ExpressionParser.parse(from: input)
         
         // when
-        let result = try! sut.result()
+        let result = sut.result()
         let expectedValue: Double = 6
         
         // then
         XCTAssertEqual(result, expectedValue)
-    }
-    
-    func test_result_2을_0으로_나누면_divideError에러에_걸린다() {
-        // given
-        let input = "2÷0"
-        sut = ExpressionParser.parse(from: input)
-        
-        let errorMassage: CalculatorError = CalculatorError.divideError
-        var error: CalculatorError?
-        
-        // when
-        XCTAssertThrowsError(try sut.result()){ result in
-            error = result as? CalculatorError
-        }
-
-        // then
-        XCTAssertEqual(error, errorMassage)
     }
     
     func test_result_0을_2로_나누면_예상값은_0이다() {
@@ -121,7 +104,7 @@ final class FormulaTests: XCTestCase {
         sut = ExpressionParser.parse(from: input)
         
         // when
-        let result = try! sut.result()
+        let result = sut.result()
         let expectedValue: Double = 0
         
         // then

--- a/Calculator/CalculatorItemQueueTests/FormulaTests.swift
+++ b/Calculator/CalculatorItemQueueTests/FormulaTests.swift
@@ -127,21 +127,4 @@ final class FormulaTests: XCTestCase {
         // then
         XCTAssertEqual(result, expectedValue)
     }
-    
-    func test_result_2_나누기만_입력하면_divideError에러에_걸린다() {
-        // given
-        let input = "2÷"
-        sut = ExpressionParser.parse(from: input)
-        
-        let errorMassage: CalculatorError = CalculatorError.incompleteFormula
-        var error: CalculatorError?
-        
-        // when
-        XCTAssertThrowsError(try sut.result()){ result in
-            error = result as? CalculatorError
-        }
-
-        // then
-        XCTAssertEqual(error, errorMassage)
-    }
 }


### PR DESCRIPTION
@wonbi92 
안녕하세요 Wonbi🌙
레드망고 & 비모입니다!
계산기 II Step2 PR 보냅니다.
방학 전 마지막 PR이네요!
잘 부탁드립니다

---

## 고민했던점 

### 1️⃣ 반복되는 옵셔널 바인딩
`operandLabel.text`와 `Decimal`, `removeComma` 메소드의 사용이 적지 않은데 매번 사용하는 메소드들에서 중복되는 코드와 `guard_let`바인딩이 불필요하다고 느껴졌습니다. 그에 처음엔 `removeComma`메소드를 수정하고 아래와 같은 연산 프로퍼티를 만들어보았습니다.
```swift
private var operandLabelText: String {
    get {
        return removeComma(of: operandLabel.text)
    }

    set(text) {
        operandLabel.text = text
    }
}
    
private var operandLabelNumber: Decimal {
    guard let number = Decimal(string: operandLabelText) else {
        return 0
    }
        
    return number
}
```
이것으로 중복되는 코드와 옵셔널 바인딩을 조금 줄일 수 있게 되었지만 기존에 `operandLabel.text`를 사용하는 부분을 `operandLabelText`로 전부 수정하려하니 `formatNumber`를 사용하는 부분 등 다시 바인딩을 해야하는 부분도 있고 `removeComma`메소드를 사용하지 않는 부분은 여전히 `operandLabel.text`를 사용해야 했습니다.
```swift
private var operandLabelText: String {
    return removeComma(of: operandLabel.text)
}
    
private var operandLabelNumber: Decimal? {
    return Decimal(string: operandLabelText)
}
```
저희는 이와 같은 원인을 set 속성때문이라고 생각하고 set을 제거하고 읽기 전용 연산프로퍼티로 수정했습니다. 이후 `operandLabel`을 설정할땐 `operandLabel.text`를, 사용할땐 `operandLabelText`를 사용하는 등 분리를 시도했습니다. `operandLabelNumber` 프로퍼티의 경우 기존엔 Decimal로 타입 변경을 하지 못하는 경우 `0`을 리턴해줬는데 이와 같은 방법은 에러의 소지가 있다고 판단되어 타입을 옵셔널로 변경하고 `guard`문을 제거했습니다.


## 조언을 구하는 점

### 1️⃣ !isNaN
가독성과 매직 리터럴을 줄여보기 위해 `String+`에 `isNaN`이라는 읽기전용 연산 프로퍼티를 만들었습니다. 해당 프로퍼티를 이용하여 리팩토링 하던 중 `!isNaN`인 경우를 사용하게 되었는데, `guard`문 안에 해당 문법을 사용하게 되니 가독성이 굉장히 안좋게 느껴졌습니다.

> `NaN`인 경우
> -> 그런데 접두어가 `!`
> -> `NaN`이 아닌 경우
> -> 그런데 `guard`문
> 🤯

이렇게 작업하던 중 저희는 `isNaN == false` 이렇게 작성하는 것이 `!isNaN`보다 낫다고 생각했습니다. 체이닝이 길어지는 경우 접두어 `!` 판단이 어렵기 때문입니다.
하지만 프로퍼티 명에 `!`이나 `false`를 붙이는 것보다 `isNotNaN`를 추가하는 것이 낫다고 판단했습니다.
결과가 같더라도, 코드를 작성하는 입장에서는 접두어 확인과 비교연산자의 우항 비교를 하지 않아도 돼서 더 가독성이 좋다고 생각했습니다.
이렇게 `Bool`타입의 프로퍼티가 제공되는 경우, 어떻게 사용하는 것이 좀 더 좋을지 조언을 얻고자 합니다.