### PR TITLE
계산기 [STEP2] 찰스

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		DCF286082ACE8E1C0065C4FA /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286072ACE8E1C0065C4FA /* CalculatorItemQueue.swift */; };
 		DCF2860A2ACE8F240065C4FA /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286092ACE8F240065C4FA /* CalculateItem.swift */; };
 		DCF286122ACE8F890065C4FA /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286112ACE8F890065C4FA /* CalculatorTests.swift */; };
+		DCF8B0752AD2CA9D00868334 /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8B0742AD2CA9D00868334 /* Formula.swift */; };
+		DCF8B0772AD2CB6B00868334 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8B0762AD2CB6B00868334 /* ExpressionParser.swift */; };
+		DCF8B0792AD2CBFC00868334 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8B0782AD2CBFC00868334 /* Operator.swift */; };
+		DCF8B07B2AD2CCF800868334 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8B07A2AD2CCF800868334 /* StringExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,6 +46,10 @@
 		DCF286092ACE8F240065C4FA /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		DCF2860F2ACE8F890065C4FA /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCF286112ACE8F890065C4FA /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
+		DCF8B0742AD2CA9D00868334 /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		DCF8B0762AD2CB6B00868334 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		DCF8B0782AD2CBFC00868334 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		DCF8B07A2AD2CCF800868334 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +105,10 @@
 			children = (
 				DCF286072ACE8E1C0065C4FA /* CalculatorItemQueue.swift */,
 				DCF286092ACE8F240065C4FA /* CalculateItem.swift */,
+				DCF8B0742AD2CA9D00868334 /* Formula.swift */,
+				DCF8B0762AD2CB6B00868334 /* ExpressionParser.swift */,
+				DCF8B0782AD2CBFC00868334 /* Operator.swift */,
+				DCF8B07A2AD2CCF800868334 /* StringExtension.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -232,8 +244,12 @@
 			files = (
 				DCF2860A2ACE8F240065C4FA /* CalculateItem.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				DCF8B0752AD2CA9D00868334 /* Formula.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				DCF286082ACE8E1C0065C4FA /* CalculatorItemQueue.swift in Sources */,
+				DCF8B07B2AD2CCF800868334 /* StringExtension.swift in Sources */,
+				DCF8B0792AD2CBFC00868334 /* Operator.swift in Sources */,
+				DCF8B0772AD2CB6B00868334 /* ExpressionParser.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
+		DC32530B2AD51B8A00200EF6 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC32530A2AD51B8A00200EF6 /* FormulaTests.swift */; };
 		DCF286082ACE8E1C0065C4FA /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286072ACE8E1C0065C4FA /* CalculatorItemQueue.swift */; };
 		DCF2860A2ACE8F240065C4FA /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286092ACE8F240065C4FA /* CalculateItem.swift */; };
 		DCF286122ACE8F890065C4FA /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286112ACE8F890065C4FA /* CalculatorTests.swift */; };
@@ -24,6 +25,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		DC32530C2AD51B8A00200EF6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 		DCF286132ACE8F890065C4FA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
@@ -43,6 +51,9 @@
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC1BFFDC2AD00740001AB01D /* Calculator.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Calculator.xctestplan; sourceTree = "<group>"; };
+		DC3253082AD51B8A00200EF6 /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC32530A2AD51B8A00200EF6 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
+		DC3253112AD51E8500200EF6 /* FormulaTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FormulaTests.xctestplan; sourceTree = "<group>"; };
 		DCF286072ACE8E1C0065C4FA /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		DCF286092ACE8F240065C4FA /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		DCF2860F2ACE8F890065C4FA /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -62,6 +73,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DC3253052AD51B8A00200EF6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DCF2860C2ACE8F890065C4FA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -75,9 +93,11 @@
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
+				DC3253112AD51E8500200EF6 /* FormulaTests.xctestplan */,
 				DC1BFFDC2AD00740001AB01D /* Calculator.xctestplan */,
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				DCF286102ACE8F890065C4FA /* CalculatorTests */,
+				DC3253092AD51B8A00200EF6 /* FormulaTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -87,6 +107,7 @@
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				DCF2860F2ACE8F890065C4FA /* CalculatorTests.xctest */,
+				DC3253082AD51B8A00200EF6 /* FormulaTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -100,6 +121,14 @@
 				C713D94F2570E5ED001C3AFC /* Info.plist */,
 			);
 			path = Calculator;
+			sourceTree = "<group>";
+		};
+		DC3253092AD51B8A00200EF6 /* FormulaTests */ = {
+			isa = PBXGroup;
+			children = (
+				DC32530A2AD51B8A00200EF6 /* FormulaTests.swift */,
+			);
+			path = FormulaTests;
 			sourceTree = "<group>";
 		};
 		DCF286032ACE8CE00065C4FA /* Models */ = {
@@ -164,6 +193,24 @@
 			productReference = C713D93E2570E5EB001C3AFC /* Calculator.app */;
 			productType = "com.apple.product-type.application";
 		};
+		DC3253072AD51B8A00200EF6 /* FormulaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DC32530E2AD51B8A00200EF6 /* Build configuration list for PBXNativeTarget "FormulaTests" */;
+			buildPhases = (
+				DC3253042AD51B8A00200EF6 /* Sources */,
+				DC3253052AD51B8A00200EF6 /* Frameworks */,
+				DC3253062AD51B8A00200EF6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DC32530D2AD51B8A00200EF6 /* PBXTargetDependency */,
+			);
+			name = FormulaTests;
+			productName = FormulaTests;
+			productReference = DC3253082AD51B8A00200EF6 /* FormulaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		DCF2860E2ACE8F890065C4FA /* CalculatorTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DCF286152ACE8F890065C4FA /* Build configuration list for PBXNativeTarget "CalculatorTests" */;
@@ -195,6 +242,10 @@
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
+					DC3253072AD51B8A00200EF6 = {
+						CreatedOnToolsVersion = 14.3.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					DCF2860E2ACE8F890065C4FA = {
 						CreatedOnToolsVersion = 14.3.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
@@ -216,6 +267,7 @@
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				DCF2860E2ACE8F890065C4FA /* CalculatorTests */,
+				DC3253072AD51B8A00200EF6 /* FormulaTests */,
 			);
 		};
 /* End PBXProject section */
@@ -228,6 +280,13 @@
 				C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */,
 				C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */,
 				C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DC3253062AD51B8A00200EF6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -258,6 +317,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DC3253042AD51B8A00200EF6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC32530B2AD51B8A00200EF6 /* FormulaTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DCF2860B2ACE8F890065C4FA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -269,6 +336,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		DC32530D2AD51B8A00200EF6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = DC32530C2AD51B8A00200EF6 /* PBXContainerItemProxy */;
+		};
 		DCF286142ACE8F890065C4FA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
@@ -455,6 +527,50 @@
 			};
 			name = Release;
 		};
+		DC32530F2AD51B8A00200EF6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hyungchul.FormulaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Debug;
+		};
+		DC3253102AD51B8A00200EF6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hyungchul.FormulaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Release;
+		};
 		DCF286162ACE8F890065C4FA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -519,6 +635,15 @@
 			buildConfigurations = (
 				C713D9532570E5ED001C3AFC /* Debug */,
 				C713D9542570E5ED001C3AFC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DC32530E2AD51B8A00200EF6 /* Build configuration list for PBXNativeTarget "FormulaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DC32530F2AD51B8A00200EF6 /* Debug */,
+				DC3253102AD51B8A00200EF6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
 		DC32530B2AD51B8A00200EF6 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC32530A2AD51B8A00200EF6 /* FormulaTests.swift */; };
+		DC3253192AD68B0F00200EF6 /* ExpressionPaserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3253182AD68B0F00200EF6 /* ExpressionPaserTests.swift */; };
 		DCF286082ACE8E1C0065C4FA /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286072ACE8E1C0065C4FA /* CalculatorItemQueue.swift */; };
 		DCF2860A2ACE8F240065C4FA /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286092ACE8F240065C4FA /* CalculateItem.swift */; };
 		DCF286122ACE8F890065C4FA /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286112ACE8F890065C4FA /* CalculatorTests.swift */; };
@@ -26,6 +27,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		DC32530C2AD51B8A00200EF6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
+		DC32531A2AD68B0F00200EF6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
 			proxyType = 1;
@@ -54,6 +62,9 @@
 		DC3253082AD51B8A00200EF6 /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC32530A2AD51B8A00200EF6 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		DC3253112AD51E8500200EF6 /* FormulaTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FormulaTests.xctestplan; sourceTree = "<group>"; };
+		DC3253162AD68B0F00200EF6 /* ExpressionPaserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionPaserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC3253182AD68B0F00200EF6 /* ExpressionPaserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionPaserTests.swift; sourceTree = "<group>"; };
+		DC32531F2AD68DAD00200EF6 /* ExpressionParser.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ExpressionParser.xctestplan; sourceTree = "<group>"; };
 		DCF286072ACE8E1C0065C4FA /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		DCF286092ACE8F240065C4FA /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		DCF2860F2ACE8F890065C4FA /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -80,6 +91,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DC3253132AD68B0F00200EF6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DCF2860C2ACE8F890065C4FA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -93,11 +111,13 @@
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
+				DC32531F2AD68DAD00200EF6 /* ExpressionParser.xctestplan */,
 				DC3253112AD51E8500200EF6 /* FormulaTests.xctestplan */,
 				DC1BFFDC2AD00740001AB01D /* Calculator.xctestplan */,
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				DCF286102ACE8F890065C4FA /* CalculatorTests */,
 				DC3253092AD51B8A00200EF6 /* FormulaTests */,
+				DC3253172AD68B0F00200EF6 /* ExpressionPaserTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -108,6 +128,7 @@
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				DCF2860F2ACE8F890065C4FA /* CalculatorTests.xctest */,
 				DC3253082AD51B8A00200EF6 /* FormulaTests.xctest */,
+				DC3253162AD68B0F00200EF6 /* ExpressionPaserTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -129,6 +150,14 @@
 				DC32530A2AD51B8A00200EF6 /* FormulaTests.swift */,
 			);
 			path = FormulaTests;
+			sourceTree = "<group>";
+		};
+		DC3253172AD68B0F00200EF6 /* ExpressionPaserTests */ = {
+			isa = PBXGroup;
+			children = (
+				DC3253182AD68B0F00200EF6 /* ExpressionPaserTests.swift */,
+			);
+			path = ExpressionPaserTests;
 			sourceTree = "<group>";
 		};
 		DCF286032ACE8CE00065C4FA /* Models */ = {
@@ -211,6 +240,24 @@
 			productReference = DC3253082AD51B8A00200EF6 /* FormulaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		DC3253152AD68B0F00200EF6 /* ExpressionPaserTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DC32531C2AD68B0F00200EF6 /* Build configuration list for PBXNativeTarget "ExpressionPaserTests" */;
+			buildPhases = (
+				DC3253122AD68B0F00200EF6 /* Sources */,
+				DC3253132AD68B0F00200EF6 /* Frameworks */,
+				DC3253142AD68B0F00200EF6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DC32531B2AD68B0F00200EF6 /* PBXTargetDependency */,
+			);
+			name = ExpressionPaserTests;
+			productName = ExpressionPaserTests;
+			productReference = DC3253162AD68B0F00200EF6 /* ExpressionPaserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		DCF2860E2ACE8F890065C4FA /* CalculatorTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DCF286152ACE8F890065C4FA /* Build configuration list for PBXNativeTarget "CalculatorTests" */;
@@ -246,6 +293,10 @@
 						CreatedOnToolsVersion = 14.3.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					DC3253152AD68B0F00200EF6 = {
+						CreatedOnToolsVersion = 14.3.1;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					DCF2860E2ACE8F890065C4FA = {
 						CreatedOnToolsVersion = 14.3.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
@@ -268,6 +319,7 @@
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				DCF2860E2ACE8F890065C4FA /* CalculatorTests */,
 				DC3253072AD51B8A00200EF6 /* FormulaTests */,
+				DC3253152AD68B0F00200EF6 /* ExpressionPaserTests */,
 			);
 		};
 /* End PBXProject section */
@@ -284,6 +336,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		DC3253062AD51B8A00200EF6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DC3253142AD68B0F00200EF6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -325,6 +384,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DC3253122AD68B0F00200EF6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC3253192AD68B0F00200EF6 /* ExpressionPaserTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DCF2860B2ACE8F890065C4FA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -340,6 +407,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = DC32530C2AD51B8A00200EF6 /* PBXContainerItemProxy */;
+		};
+		DC32531B2AD68B0F00200EF6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = DC32531A2AD68B0F00200EF6 /* PBXContainerItemProxy */;
 		};
 		DCF286142ACE8F890065C4FA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -571,6 +643,50 @@
 			};
 			name = Release;
 		};
+		DC32531D2AD68B0F00200EF6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hyungchul.ExpressionPaserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Debug;
+		};
+		DC32531E2AD68B0F00200EF6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hyungchul.ExpressionPaserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Release;
+		};
 		DCF286162ACE8F890065C4FA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -644,6 +760,15 @@
 			buildConfigurations = (
 				DC32530F2AD51B8A00200EF6 /* Debug */,
 				DC3253102AD51B8A00200EF6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DC32531C2AD68B0F00200EF6 /* Build configuration list for PBXNativeTarget "ExpressionPaserTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DC32531D2AD68B0F00200EF6 /* Debug */,
+				DC32531E2AD68B0F00200EF6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
 		C713D94B2570E5ED001C3AFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C713D94A2570E5ED001C3AFC /* Assets.xcassets */; };
 		C713D94E2570E5ED001C3AFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D94C2570E5ED001C3AFC /* LaunchScreen.storyboard */; };
-		DC32530B2AD51B8A00200EF6 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC32530A2AD51B8A00200EF6 /* FormulaTests.swift */; };
 		DC3253192AD68B0F00200EF6 /* ExpressionPaserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3253182AD68B0F00200EF6 /* ExpressionPaserTests.swift */; };
+		DC8C11B82ADA608A007AF3EF /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8C11B72ADA608A007AF3EF /* FormulaTests.swift */; };
 		DCF286082ACE8E1C0065C4FA /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286072ACE8E1C0065C4FA /* CalculatorItemQueue.swift */; };
 		DCF2860A2ACE8F240065C4FA /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286092ACE8F240065C4FA /* CalculateItem.swift */; };
 		DCF286122ACE8F890065C4FA /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF286112ACE8F890065C4FA /* CalculatorTests.swift */; };
@@ -26,14 +26,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		DC32530C2AD51B8A00200EF6 /* PBXContainerItemProxy */ = {
+		DC32531A2AD68B0F00200EF6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
-		DC32531A2AD68B0F00200EF6 /* PBXContainerItemProxy */ = {
+		DC8C11B92ADA608A007AF3EF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
 			proxyType = 1;
@@ -59,12 +59,13 @@
 		C713D94D2570E5ED001C3AFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C713D94F2570E5ED001C3AFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC1BFFDC2AD00740001AB01D /* Calculator.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Calculator.xctestplan; sourceTree = "<group>"; };
-		DC3253082AD51B8A00200EF6 /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC32530A2AD51B8A00200EF6 /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
-		DC3253112AD51E8500200EF6 /* FormulaTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FormulaTests.xctestplan; sourceTree = "<group>"; };
 		DC3253162AD68B0F00200EF6 /* ExpressionPaserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpressionPaserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC3253182AD68B0F00200EF6 /* ExpressionPaserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionPaserTests.swift; sourceTree = "<group>"; };
-		DC32531F2AD68DAD00200EF6 /* ExpressionParser.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ExpressionParser.xctestplan; sourceTree = "<group>"; };
+		DC8C11B52ADA6089007AF3EF /* FormulaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormulaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC8C11B72ADA608A007AF3EF /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
+		DC8C11BE2ADA60DB007AF3EF /* FormulaTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FormulaTests.xctestplan; sourceTree = "<group>"; };
+		DCC0DADD2ADA5EF500DCC580 /* ExpressionPaserTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ExpressionPaserTests.xctestplan; sourceTree = "<group>"; };
 		DCF286072ACE8E1C0065C4FA /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		DCF286092ACE8F240065C4FA /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		DCF2860F2ACE8F890065C4FA /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -84,14 +85,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DC3253052AD51B8A00200EF6 /* Frameworks */ = {
+		DC3253132AD68B0F00200EF6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DC3253132AD68B0F00200EF6 /* Frameworks */ = {
+		DC8C11B22ADA6089007AF3EF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -111,13 +112,14 @@
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
-				DC32531F2AD68DAD00200EF6 /* ExpressionParser.xctestplan */,
-				DC3253112AD51E8500200EF6 /* FormulaTests.xctestplan */,
+				DC8C11BE2ADA60DB007AF3EF /* FormulaTests.xctestplan */,
+				DCC0DADD2ADA5EF500DCC580 /* ExpressionPaserTests.xctestplan */,
 				DC1BFFDC2AD00740001AB01D /* Calculator.xctestplan */,
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				DCF286102ACE8F890065C4FA /* CalculatorTests */,
 				DC3253092AD51B8A00200EF6 /* FormulaTests */,
 				DC3253172AD68B0F00200EF6 /* ExpressionPaserTests */,
+				DC8C11B62ADA608A007AF3EF /* FormulaTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -127,8 +129,8 @@
 			children = (
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				DCF2860F2ACE8F890065C4FA /* CalculatorTests.xctest */,
-				DC3253082AD51B8A00200EF6 /* FormulaTests.xctest */,
 				DC3253162AD68B0F00200EF6 /* ExpressionPaserTests.xctest */,
+				DC8C11B52ADA6089007AF3EF /* FormulaTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -158,6 +160,14 @@
 				DC3253182AD68B0F00200EF6 /* ExpressionPaserTests.swift */,
 			);
 			path = ExpressionPaserTests;
+			sourceTree = "<group>";
+		};
+		DC8C11B62ADA608A007AF3EF /* FormulaTests */ = {
+			isa = PBXGroup;
+			children = (
+				DC8C11B72ADA608A007AF3EF /* FormulaTests.swift */,
+			);
+			path = FormulaTests;
 			sourceTree = "<group>";
 		};
 		DCF286032ACE8CE00065C4FA /* Models */ = {
@@ -222,24 +232,6 @@
 			productReference = C713D93E2570E5EB001C3AFC /* Calculator.app */;
 			productType = "com.apple.product-type.application";
 		};
-		DC3253072AD51B8A00200EF6 /* FormulaTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DC32530E2AD51B8A00200EF6 /* Build configuration list for PBXNativeTarget "FormulaTests" */;
-			buildPhases = (
-				DC3253042AD51B8A00200EF6 /* Sources */,
-				DC3253052AD51B8A00200EF6 /* Frameworks */,
-				DC3253062AD51B8A00200EF6 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				DC32530D2AD51B8A00200EF6 /* PBXTargetDependency */,
-			);
-			name = FormulaTests;
-			productName = FormulaTests;
-			productReference = DC3253082AD51B8A00200EF6 /* FormulaTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		DC3253152AD68B0F00200EF6 /* ExpressionPaserTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DC32531C2AD68B0F00200EF6 /* Build configuration list for PBXNativeTarget "ExpressionPaserTests" */;
@@ -256,6 +248,24 @@
 			name = ExpressionPaserTests;
 			productName = ExpressionPaserTests;
 			productReference = DC3253162AD68B0F00200EF6 /* ExpressionPaserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DC8C11B42ADA6089007AF3EF /* FormulaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DC8C11BB2ADA608A007AF3EF /* Build configuration list for PBXNativeTarget "FormulaTests" */;
+			buildPhases = (
+				DC8C11B12ADA6089007AF3EF /* Sources */,
+				DC8C11B22ADA6089007AF3EF /* Frameworks */,
+				DC8C11B32ADA6089007AF3EF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DC8C11BA2ADA608A007AF3EF /* PBXTargetDependency */,
+			);
+			name = FormulaTests;
+			productName = FormulaTests;
+			productReference = DC8C11B52ADA6089007AF3EF /* FormulaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		DCF2860E2ACE8F890065C4FA /* CalculatorTests */ = {
@@ -289,11 +299,11 @@
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
-					DC3253072AD51B8A00200EF6 = {
+					DC3253152AD68B0F00200EF6 = {
 						CreatedOnToolsVersion = 14.3.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
-					DC3253152AD68B0F00200EF6 = {
+					DC8C11B42ADA6089007AF3EF = {
 						CreatedOnToolsVersion = 14.3.1;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
@@ -318,8 +328,8 @@
 			targets = (
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				DCF2860E2ACE8F890065C4FA /* CalculatorTests */,
-				DC3253072AD51B8A00200EF6 /* FormulaTests */,
 				DC3253152AD68B0F00200EF6 /* ExpressionPaserTests */,
+				DC8C11B42ADA6089007AF3EF /* FormulaTests */,
 			);
 		};
 /* End PBXProject section */
@@ -335,14 +345,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DC3253062AD51B8A00200EF6 /* Resources */ = {
+		DC3253142AD68B0F00200EF6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DC3253142AD68B0F00200EF6 /* Resources */ = {
+		DC8C11B32ADA6089007AF3EF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -376,19 +386,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DC3253042AD51B8A00200EF6 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DC32530B2AD51B8A00200EF6 /* FormulaTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		DC3253122AD68B0F00200EF6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				DC3253192AD68B0F00200EF6 /* ExpressionPaserTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DC8C11B12ADA6089007AF3EF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC8C11B82ADA608A007AF3EF /* FormulaTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -403,15 +413,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		DC32530D2AD51B8A00200EF6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C713D93D2570E5EB001C3AFC /* Calculator */;
-			targetProxy = DC32530C2AD51B8A00200EF6 /* PBXContainerItemProxy */;
-		};
 		DC32531B2AD68B0F00200EF6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = DC32531A2AD68B0F00200EF6 /* PBXContainerItemProxy */;
+		};
+		DC8C11BA2ADA608A007AF3EF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = DC8C11B92ADA608A007AF3EF /* PBXContainerItemProxy */;
 		};
 		DCF286142ACE8F890065C4FA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -599,50 +609,6 @@
 			};
 			name = Release;
 		};
-		DC32530F2AD51B8A00200EF6 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hyungchul.FormulaTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
-			};
-			name = Debug;
-		};
-		DC3253102AD51B8A00200EF6 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.hyungchul.FormulaTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
-			};
-			name = Release;
-		};
 		DC32531D2AD68B0F00200EF6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -677,6 +643,50 @@
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyungchul.ExpressionPaserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Release;
+		};
+		DC8C11BC2ADA608A007AF3EF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hyungchul.FormulaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Calculator";
+			};
+			name = Debug;
+		};
+		DC8C11BD2ADA608A007AF3EF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hyungchul.FormulaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -755,20 +765,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DC32530E2AD51B8A00200EF6 /* Build configuration list for PBXNativeTarget "FormulaTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DC32530F2AD51B8A00200EF6 /* Debug */,
-				DC3253102AD51B8A00200EF6 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		DC32531C2AD68B0F00200EF6 /* Build configuration list for PBXNativeTarget "ExpressionPaserTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DC32531D2AD68B0F00200EF6 /* Debug */,
 				DC32531E2AD68B0F00200EF6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DC8C11BB2ADA608A007AF3EF /* Build configuration list for PBXNativeTarget "FormulaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DC8C11BC2ADA608A007AF3EF /* Debug */,
+				DC8C11BD2ADA608A007AF3EF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		DCF8B0772AD2CB6B00868334 /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8B0762AD2CB6B00868334 /* ExpressionParser.swift */; };
 		DCF8B0792AD2CBFC00868334 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8B0782AD2CBFC00868334 /* Operator.swift */; };
 		DCF8B07B2AD2CCF800868334 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8B07A2AD2CCF800868334 /* StringExtension.swift */; };
+		DCF8B07D2AD3E39900868334 /* OperateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8B07C2AD3E39900868334 /* OperateError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +51,7 @@
 		DCF8B0762AD2CB6B00868334 /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		DCF8B0782AD2CBFC00868334 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		DCF8B07A2AD2CCF800868334 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
+		DCF8B07C2AD3E39900868334 /* OperateError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperateError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 				DCF8B0762AD2CB6B00868334 /* ExpressionParser.swift */,
 				DCF8B0782AD2CBFC00868334 /* Operator.swift */,
 				DCF8B07A2AD2CCF800868334 /* StringExtension.swift */,
+				DCF8B07C2AD3E39900868334 /* OperateError.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -249,6 +252,7 @@
 				DCF286082ACE8E1C0065C4FA /* CalculatorItemQueue.swift in Sources */,
 				DCF8B07B2AD2CCF800868334 /* StringExtension.swift in Sources */,
 				DCF8B0792AD2CBFC00868334 /* Operator.swift in Sources */,
+				DCF8B07D2AD3E39900868334 /* OperateError.swift in Sources */,
 				DCF8B0772AD2CB6B00868334 /* ExpressionParser.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -26,105 +26,16 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <TestPlans>
-         <TestPlanReference
-            reference = "container:Calculator.xctestplan"
-            default = "YES">
-         </TestPlanReference>
-      </TestPlans>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DCF2860E2ACE8F890065C4FA"
-               BuildableName = "CalculatorTests.xctest"
-               BlueprintName = "CalculatorTests"
-               ReferencedContainer = "container:Calculator.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DCF8B0812AD42D6B00868334"
-               BuildableName = "FormulsTests.xctest"
-               BlueprintName = "FormulsTests"
-               ReferencedContainer = "container:Calculator.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DCF8B0812AD42D6B00868334"
-               BuildableName = "FormulsTests.xctest"
-               BlueprintName = "FormulsTests"
-               ReferencedContainer = "container:Calculator.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DCF8B0812AD42D6B00868334"
-               BuildableName = "FormulsTests.xctest"
-               BlueprintName = "FormulsTests"
-               ReferencedContainer = "container:Calculator.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DCF8B0812AD42D6B00868334"
-               BuildableName = "FormulsTests.xctest"
-               BlueprintName = "FormulsTests"
-               ReferencedContainer = "container:Calculator.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DC3253072AD51B8A00200EF6"
+               BlueprintIdentifier = "DC8C11B42ADA6089007AF3EF"
                BuildableName = "FormulaTests.xctest"
                BlueprintName = "FormulaTests"
-               ReferencedContainer = "container:Calculator.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DC3253072AD51B8A00200EF6"
-               BuildableName = "FormulaTests.xctest"
-               BlueprintName = "FormulaTests"
-               ReferencedContainer = "container:Calculator.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DC3253152AD68B0F00200EF6"
-               BuildableName = "ExpressionPaserTests.xctest"
-               BlueprintName = "ExpressionPaserTests"
-               ReferencedContainer = "container:Calculator.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DC3253152AD68B0F00200EF6"
-               BuildableName = "ExpressionPaserTests.xctest"
-               BlueprintName = "ExpressionPaserTests"
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -45,6 +45,47 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF8B0812AD42D6B00868334"
+               BuildableName = "FormulsTests.xctest"
+               BlueprintName = "FormulsTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF8B0812AD42D6B00868334"
+               BuildableName = "FormulsTests.xctest"
+               BlueprintName = "FormulsTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF8B0812AD42D6B00868334"
+               BuildableName = "FormulsTests.xctest"
+               BlueprintName = "FormulsTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF8B0812AD42D6B00868334"
+               BuildableName = "FormulsTests.xctest"
+               BlueprintName = "FormulsTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -107,6 +107,27 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC3253152AD68B0F00200EF6"
+               BuildableName = "ExpressionPaserTests.xctest"
+               BlueprintName = "ExpressionPaserTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC3253152AD68B0F00200EF6"
+               BuildableName = "ExpressionPaserTests.xctest"
+               BlueprintName = "ExpressionPaserTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -86,6 +86,27 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC3253072AD51B8A00200EF6"
+               BuildableName = "FormulaTests.xctest"
+               BlueprintName = "FormulaTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC3253072AD51B8A00200EF6"
+               BuildableName = "FormulaTests.xctest"
+               BlueprintName = "FormulaTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/ExpressionPaserTests.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/ExpressionPaserTests.xcscheme
@@ -10,8 +10,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:ExpressionPaserTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/ExpressionPaserTests.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/ExpressionPaserTests.xcscheme
@@ -10,22 +10,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <TestPlans>
-         <TestPlanReference
-            reference = "container:ExpressionParser.xctestplan"
-            default = "YES">
-         </TestPlanReference>
-      </TestPlans>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
             skipped = "NO"
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DC3253072AD51B8A00200EF6"
-               BuildableName = "FormulaTests.xctest"
-               BlueprintName = "FormulaTests"
+               BlueprintIdentifier = "DC3253152AD68B0F00200EF6"
+               BuildableName = "ExpressionPaserTests.xctest"
+               BlueprintName = "ExpressionPaserTests"
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/FormulaTests.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/FormulaTests.xcscheme
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:FormulaTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC3253072AD51B8A00200EF6"
+               BuildableName = "FormulaTests.xctest"
+               BlueprintName = "FormulaTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/FormulaTests.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/FormulaTests.xcscheme
@@ -13,7 +13,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:ExpressionParser.xctestplan"
+            reference = "container:FormulaTests.xctestplan"
             default = "YES">
          </TestPlanReference>
       </TestPlans>
@@ -23,7 +23,7 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DC3253072AD51B8A00200EF6"
+               BlueprintIdentifier = "DC8C11B42ADA6089007AF3EF"
                BuildableName = "FormulaTests.xctest"
                BlueprintName = "FormulaTests"
                ReferencedContainer = "container:Calculator.xcodeproj">

--- a/Calculator/Calculator/Models/CalculateItem.swift
+++ b/Calculator/Calculator/Models/CalculateItem.swift
@@ -9,6 +9,6 @@ protocol CalculateItem {
     
 }
 
-extension Int: CalculateItem {
+extension Double: CalculateItem {
     
 }

--- a/Calculator/Calculator/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Models/ExpressionParser.swift
@@ -11,7 +11,15 @@ enum ExpressionParser {
     }
     
     static private func componentsByOperators(from input: String) -> [String] {
-        return []
+        var result = ""
+        
+        for char in input {
+            if char != " " {
+                result += String(char) + " "
+            }
+        }
+        
+        return result.split(with: " ").filter{ $0 != "" }
     }
 }
 

--- a/Calculator/Calculator/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Models/ExpressionParser.swift
@@ -7,7 +7,7 @@
 
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        var formula = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
+        var formula = Formula()
         let componentsArray = componentsByOperators(from: input)
         
         componentsArray.forEach{ component in

--- a/Calculator/Calculator/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Models/ExpressionParser.swift
@@ -1,0 +1,18 @@
+//
+//  ExpressionParser.swift
+//  Calculator
+//
+//  Created by Charles on 2023/10/08.
+//
+
+enum ExpressionParser {
+    func parse(from input: String) -> Formula? {
+        return nil
+    }
+    
+    private func componentsByOperators(from input: String) -> [String] {
+        return []
+    }
+}
+
+

--- a/Calculator/Calculator/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Models/ExpressionParser.swift
@@ -6,11 +6,11 @@
 //
 
 enum ExpressionParser {
-    func parse(from input: String) -> Formula? {
+    static func parse(from input: String) -> Formula? {
         return nil
     }
     
-    private func componentsByOperators(from input: String) -> [String] {
+    static private func componentsByOperators(from input: String) -> [String] {
         return []
     }
 }

--- a/Calculator/Calculator/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Models/ExpressionParser.swift
@@ -6,8 +6,19 @@
 //
 
 enum ExpressionParser {
-    static func parse(from input: String) -> Formula? {
-        return nil
+    static func parse(from input: String) -> Formula {
+        var formula = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
+        let componentsArray = componentsByOperators(from: input)
+        
+        componentsArray.forEach{ component in
+            if let operand = Double(component) {
+                formula.operands.enqueue(operand)
+            } else if let operatorSymbol = Operator(rawValue: Character(component)) {
+                formula.operators.enqueue(operatorSymbol)
+            }
+        }
+        
+        return formula
     }
     
     static private func componentsByOperators(from input: String) -> [String] {

--- a/Calculator/Calculator/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Models/ExpressionParser.swift
@@ -10,7 +10,7 @@ enum ExpressionParser {
         var formula = Formula()
         let componentsArray = componentsByOperators(from: input)
         
-        componentsArray.forEach{ component in
+        componentsArray.forEach { component in
             if let operand = Double(component) {
                 formula.operands.enqueue(operand)
             } else if let operatorSymbol = Operator(rawValue: Character(component)) {
@@ -30,7 +30,7 @@ enum ExpressionParser {
             }
         }
         
-        return result.split(with: " ").filter{ $0 != "" }
+        return result.split(with: " ").filter { $0 != "" }
     }
 }
 

--- a/Calculator/Calculator/Models/ExpressionParser.swift
+++ b/Calculator/Calculator/Models/ExpressionParser.swift
@@ -7,30 +7,31 @@
 
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        var formula = Formula()
-        let componentsArray = componentsByOperators(from: input)
+        var operatorsQueue = CalculatorItemQueue<Operator>()
+        var operandsQueue = CalculatorItemQueue<Double>()
+        let operandsArray = componentsByOperators(from: input)
         
-        componentsArray.forEach { component in
-            if let operand = Double(component) {
-                formula.operands.enqueue(operand)
-            } else if let operatorSymbol = Operator(rawValue: Character(component)) {
-                formula.operators.enqueue(operatorSymbol)
-            }
+        operandsArray.compactMap { Double($0) }.forEach { component in
+            operandsQueue.enqueue(component)
         }
         
-        return formula
+        input.compactMap { Operator(rawValue: $0) }.forEach { component in
+            operatorsQueue.enqueue(component)
+        }
+        
+        return Formula(operands: operandsQueue, operators: operatorsQueue)
     }
     
     static private func componentsByOperators(from input: String) -> [String] {
-        var result = ""
+        var result = [input]
         
-        for char in input {
-            if char != " " {
-                result += String(char) + " "
+        Operator.allCases.forEach { `operator` in
+            result = result.flatMap { component in
+                component.split(with: `operator`.rawValue)
             }
         }
         
-        return result.split(with: " ").filter { $0 != "" }
+        return result.filter { $0 != "" }
     }
 }
 

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -9,7 +9,7 @@ struct Formula {
     var operands = CalculatorItemQueue<Double>()
     var operators = CalculatorItemQueue<Operator>()
     
-    mutating func result() -> Double {
+    mutating func result() throws -> Double {
         var accumulatingValue: Double = .zero
         
         if let initialValue = operands.dequeue() {
@@ -17,7 +17,7 @@ struct Formula {
         }
         
         while !operators.isEmpty, let `operator` = operators.dequeue(), let rhs = operands.dequeue() {
-            accumulatingValue = `operator`.calculate(lhs: accumulatingValue, rhs: rhs)
+            accumulatingValue = try `operator`.calculate(lhs: accumulatingValue, rhs: rhs)
         }
         
         return accumulatingValue

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -6,8 +6,8 @@
 //
 
 struct Formula {
-    var operands: CalculatorItemQueue<Double>()
-    var operators: CalculatorItemQueue<Operator>()
+    var operands = CalculatorItemQueue<Double>()
+    var operators = CalculatorItemQueue<Operator>()
     
     mutating func result() -> Double {
         var accumulatingValue: Double = 0

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -10,6 +10,20 @@ struct Formula {
     var operators: CalculatorItemQueue<Operator>
     
     mutating func result() -> Double {
-        return 0
+        var accumulatingValue: Double = 0
+        
+        if let initialValue = operands.dequeue() {
+            accumulatingValue = initialValue
+        }
+        
+        while !operators.isEmpty {
+            guard let op = operators.dequeue() else { break }
+            
+            guard let rhs = operands.dequeue() else { break }
+            accumulatingValue = op.calculate(lhs: accumulatingValue, rhs: rhs)
+
+        }
+        
+        return accumulatingValue
     }
 }

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -6,8 +6,8 @@
 //
 
 struct Formula {
-    var operands: CalculatorItemQueue<Double>
-    var operators: CalculatorItemQueue<Operator>
+    var operands: CalculatorItemQueue<Double>()
+    var operators: CalculatorItemQueue<Operator>()
     
     mutating func result() -> Double {
         var accumulatingValue: Double = 0

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -16,12 +16,8 @@ struct Formula {
             accumulatingValue = initialValue
         }
         
-        while !operators.isEmpty {
-            guard let `operator` = operators.dequeue() else { break }
-            
-            guard let rhs = operands.dequeue() else { break }
+        while !operators.isEmpty, let `operator` = operators.dequeue(), let rhs = operands.dequeue() {
             accumulatingValue = `operator`.calculate(lhs: accumulatingValue, rhs: rhs)
-
         }
         
         return accumulatingValue

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -1,0 +1,15 @@
+//
+//  Formula.swift
+//  Calculator
+//
+//  Created by Charles on 2023/10/08.
+//
+
+struct Formula {
+    var operands: CalculatorItemQueue<Double>
+    var operators: CalculatorItemQueue<Operator>
+    
+    mutating func result() -> Double {
+        return 0
+    }
+}

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -17,10 +17,10 @@ struct Formula {
         }
         
         while !operators.isEmpty {
-            guard let op = operators.dequeue() else { break }
+            guard let operatingSymbol = operators.dequeue() else { break }
             
             guard let rhs = operands.dequeue() else { break }
-            accumulatingValue = op.calculate(lhs: accumulatingValue, rhs: rhs)
+            accumulatingValue = operatingSymbol.calculate(lhs: accumulatingValue, rhs: rhs)
 
         }
         

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -10,17 +10,17 @@ struct Formula {
     var operators = CalculatorItemQueue<Operator>()
     
     mutating func result() -> Double {
-        var accumulatingValue: Double = 0
+        var accumulatingValue: Double = .zero
         
         if let initialValue = operands.dequeue() {
             accumulatingValue = initialValue
         }
         
         while !operators.isEmpty {
-            guard let operatingSymbol = operators.dequeue() else { break }
+            guard let `operator` = operators.dequeue() else { break }
             
             guard let rhs = operands.dequeue() else { break }
-            accumulatingValue = operatingSymbol.calculate(lhs: accumulatingValue, rhs: rhs)
+            accumulatingValue = `operator`.calculate(lhs: accumulatingValue, rhs: rhs)
 
         }
         

--- a/Calculator/Calculator/Models/OperateError.swift
+++ b/Calculator/Calculator/Models/OperateError.swift
@@ -1,0 +1,10 @@
+//
+//  OperateError.swift
+//  Calculator
+//
+//  Created by Charles on 2023/10/09.
+//
+
+enum OperateError {
+    case dividingZero
+}

--- a/Calculator/Calculator/Models/OperateError.swift
+++ b/Calculator/Calculator/Models/OperateError.swift
@@ -5,6 +5,6 @@
 //  Created by Charles on 2023/10/09.
 //
 
-enum OperateError {
+enum OperateError: Error {
     case dividingZero
 }

--- a/Calculator/Calculator/Models/Operator.swift
+++ b/Calculator/Calculator/Models/Operator.swift
@@ -7,9 +7,9 @@
 
 enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
-    case subtract = "-"
-    case divide = "/"
-    case multiply = "x"
+    case subtract = "−"
+    case divide = "÷"
+    case multiply = "×"
     
     func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {

--- a/Calculator/Calculator/Models/Operator.swift
+++ b/Calculator/Calculator/Models/Operator.swift
@@ -12,22 +12,31 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case multiply = "*"
     
     func calculate(lhs: Double, rhs: Double) -> Double {
-        return 0
+        switch self {
+        case .add:
+            return add(lhs: lhs, rhs: rhs)
+        case .subtract:
+            return subtract(lhs: lhs, rhs: rhs)
+        case .divide:
+            return divide(lhs: lhs, rhs: rhs)
+        case .multiply:
+            return multiply(lhs: lhs, rhs: rhs)
+        }
     }
     
     private func add(lhs: Double, rhs: Double) -> Double {
-        return 0
+        return lhs + rhs
     }
     
     private func subtract(lhs: Double, rhs: Double) -> Double {
-        return 0
+        return lhs - rhs
     }
     
     private func divide(lhs: Double, rhs: Double) -> Double {
-        return 0
+        return lhs / rhs
     }
     
     private func multiply(lhs: Double, rhs: Double) -> Double {
-        return 0
+        return lhs * rhs
     }
 }

--- a/Calculator/Calculator/Models/Operator.swift
+++ b/Calculator/Calculator/Models/Operator.swift
@@ -1,0 +1,33 @@
+//
+//  Operator.swift
+//  Calculator
+//
+//  Created by Charles on 2023/10/08.
+//
+
+enum Operator: Character, CaseIterable, CalculateItem {
+    case add = "+"
+    case subtract = "-"
+    case divide = "/"
+    case multiply = "*"
+    
+    func calculate(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+    
+    private func add(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+    
+    private func subtract(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+    
+    private func divide(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+    
+    private func multiply(lhs: Double, rhs: Double) -> Double {
+        return 0
+    }
+}

--- a/Calculator/Calculator/Models/Operator.swift
+++ b/Calculator/Calculator/Models/Operator.swift
@@ -11,14 +11,14 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "/"
     case multiply = "x"
     
-    func calculate(lhs: Double, rhs: Double) -> Double {
+    func calculate(lhs: Double, rhs: Double) throws -> Double {
         switch self {
         case .add:
             return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            return divide(lhs: lhs, rhs: rhs)
+            return try divide(lhs: lhs, rhs: rhs)
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
         }
@@ -32,7 +32,9 @@ enum Operator: Character, CaseIterable, CalculateItem {
         return lhs - rhs
     }
     
-    private func divide(lhs: Double, rhs: Double) -> Double {
+    private func divide(lhs: Double, rhs: Double) throws -> Double {
+        guard rhs != 0 else { throw OperateError.dividingZero }
+        
         return lhs / rhs
     }
     

--- a/Calculator/Calculator/Models/Operator.swift
+++ b/Calculator/Calculator/Models/Operator.swift
@@ -9,7 +9,7 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case add = "+"
     case subtract = "-"
     case divide = "/"
-    case multiply = "*"
+    case multiply = "x"
     
     func calculate(lhs: Double, rhs: Double) -> Double {
         switch self {

--- a/Calculator/Calculator/Models/StringExtension.swift
+++ b/Calculator/Calculator/Models/StringExtension.swift
@@ -1,0 +1,12 @@
+//
+//  StringExtension.swift
+//  Calculator
+//
+//  Created by Charles on 2023/10/08.
+//
+
+extension String {
+    func split(with target: Character) -> [String] {
+        return []
+    }
+}

--- a/Calculator/Calculator/Models/StringExtension.swift
+++ b/Calculator/Calculator/Models/StringExtension.swift
@@ -4,9 +4,10 @@
 //
 //  Created by Charles on 2023/10/08.
 //
+import Foundation
 
 extension String {
     func split(with target: Character) -> [String] {
-        return []
+        return components(separatedBy: String(target))
     }
 }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import Calculator
 
 final class CalculatorTests: XCTestCase {
-    var sut: CalculatorItemQueue<Int>!
+    var sut: CalculatorItemQueue<Double>!
     
     override func setUpWithError() throws {
         sut = CalculatorItemQueue()

--- a/Calculator/ExpressionParser.xctestplan
+++ b/Calculator/ExpressionParser.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "BCD60EB5-BED6-4306-8918-1CE3C65EF1C7",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Calculator.xcodeproj",
+        "identifier" : "DC3253072AD51B8A00200EF6",
+        "name" : "FormulaTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Calculator/ExpressionPaserTests.xctestplan
+++ b/Calculator/ExpressionPaserTests.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "BCD60EB5-BED6-4306-8918-1CE3C65EF1C7",
+      "id" : "E3790E58-2DF5-4CE4-938C-597959A4B1B9",
       "name" : "Test Scheme Action",
       "options" : {
 
@@ -16,8 +16,8 @@
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Calculator.xcodeproj",
-        "identifier" : "DC3253072AD51B8A00200EF6",
-        "name" : "FormulaTests"
+        "identifier" : "DC3253152AD68B0F00200EF6",
+        "name" : "ExpressionPaserTests"
       }
     }
   ],

--- a/Calculator/ExpressionPaserTests/ExpressionPaserTests.swift
+++ b/Calculator/ExpressionPaserTests/ExpressionPaserTests.swift
@@ -9,49 +9,32 @@ import XCTest
 @testable import Calculator
 
 final class ExpressionPaserTests: XCTestCase {
-    var sut: Formula!
-    override func setUpWithError() throws {
-        sut = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
-    }
-
-    override func tearDownWithError() throws {
-        sut = nil
-    }
-
-    func test_띄워쓰기없이_요소들이_주어졌을때_결과값은_5이다() {
+    
+    func test_input과_각expactation이_주어지고_parse가호출시_각컨테이너에_들어간결과는_각expactation값과_같다() {
         // given
-        sut = ExpressionParser.parse(from: "3x2-1")
-        let expactation: Double = 5
+        let input = "3×2−1"
+        let operandsExpactation = [3.0, 2.0, 1.0]
+        let operatorsExpactation = [Operator(rawValue: "×")!, Operator(rawValue: "−")!]
         
         // when
-        let result = sut.result()
+        let result = ExpressionParser.parse(from: input)
         
         // then
-        XCTAssertEqual(result, expactation)
+        XCTAssertEqual(result.operands.enqueueContainer, operandsExpactation)
+        XCTAssertEqual(result.operators.enqueueContainer, operatorsExpactation)
     }
     
-    func test_양쪽끝에공백이있는_요소들이_주어졌을때_결과값은_5이다() {
+    func test_input과_각expactation이_주어지고_parse가호출시_각컨테이너에_들어간결과는_각expactation값과_같다_() {
         // given
-        sut = ExpressionParser.parse(from: " 3x2-1 ")
-        let expactation: Double = 5
+        let input = "5×2÷-1"
+        let operandsExpactation = [5.0, 2.0, -1.0]
+        let operatorsExpactation = [Operator(rawValue: "×")!, Operator(rawValue: "÷")!]
         
         // when
-        let result = sut.result()
+        let result = ExpressionParser.parse(from: input)
         
         // then
-        XCTAssertEqual(result, expactation)
+        XCTAssertEqual(result.operands.enqueueContainer, operandsExpactation)
+        XCTAssertEqual(result.operators.enqueueContainer, operatorsExpactation)
     }
-    
-    func test_사이사이공백이존재하는_요소들이_주어졌을때_결과값은_5이다() {
-        // given
-        sut = ExpressionParser.parse(from: " 3  x 2 -1 ")
-        let expactation: Double = 5
-        
-        // when
-        let result = sut.result()
-        
-        // then
-        XCTAssertEqual(result, expactation)
-    }
-
 }

--- a/Calculator/ExpressionPaserTests/ExpressionPaserTests.swift
+++ b/Calculator/ExpressionPaserTests/ExpressionPaserTests.swift
@@ -1,0 +1,57 @@
+//
+//  ExpressionPaserTests.swift
+//  ExpressionPaserTests
+//
+//  Created by Charles on 2023/10/11.
+//
+
+import XCTest
+@testable import Calculator
+
+final class ExpressionPaserTests: XCTestCase {
+    var sut: Formula!
+    override func setUpWithError() throws {
+        sut = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+
+    func test_띄워쓰기없이_요소들이_주어졌을때_결과값은_5이다() {
+        // given
+        sut = ExpressionParser.parse(from: "3x2-1")
+        let expactation: Double = 5
+        
+        // when
+        let result = sut.result()
+        
+        // then
+        XCTAssertEqual(result, expactation)
+    }
+    
+    func test_양쪽끝에공백이있는_요소들이_주어졌을때_결과값은_5이다() {
+        // given
+        sut = ExpressionParser.parse(from: " 3x2-1 ")
+        let expactation: Double = 5
+        
+        // when
+        let result = sut.result()
+        
+        // then
+        XCTAssertEqual(result, expactation)
+    }
+    
+    func test_사이사이공백이존재하는_요소들이_주어졌을때_결과값은_5이다() {
+        // given
+        sut = ExpressionParser.parse(from: " 3  x 2 -1 ")
+        let expactation: Double = 5
+        
+        // when
+        let result = sut.result()
+        
+        // then
+        XCTAssertEqual(result, expactation)
+    }
+
+}

--- a/Calculator/FormulaTests.xctestplan
+++ b/Calculator/FormulaTests.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "BCD60EB5-BED6-4306-8918-1CE3C65EF1C7",
+      "id" : "FC4D90D5-ABE1-4BE6-B2EF-48B91A2DBB8E",
       "name" : "Test Scheme Action",
       "options" : {
 
@@ -16,7 +16,7 @@
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Calculator.xcodeproj",
-        "identifier" : "DC3253072AD51B8A00200EF6",
+        "identifier" : "DC8C11B42ADA6089007AF3EF",
         "name" : "FormulaTests"
       }
     }

--- a/Calculator/FormulaTests.xctestplan
+++ b/Calculator/FormulaTests.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "BCD60EB5-BED6-4306-8918-1CE3C65EF1C7",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Calculator.xcodeproj",
+        "identifier" : "DC3253072AD51B8A00200EF6",
+        "name" : "FormulaTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -2,7 +2,7 @@
 //  FormulaTests.swift
 //  FormulaTests
 //
-//  Created by Charles on 2023/10/10.
+//  Created by Charles on 2023/10/14.
 //
 
 import XCTest
@@ -57,5 +57,4 @@ final class FormulaTests: XCTestCase {
             XCTAssertEqual(error as? OperateError, OperateError.dividingZero)
         }
     }
-
 }

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -1,0 +1,40 @@
+//
+//  FormulaTests.swift
+//  FormulaTests
+//
+//  Created by Charles on 2023/10/10.
+//
+
+import XCTest
+@testable import Calculator
+
+final class FormulaTests: XCTestCase {
+    var sut: Formula!
+    
+    override func setUpWithError() throws {
+        sut = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+
+    func test_피연산자2331_연산자AddMultiplySubtract가_큐에존재할때_모두를연산한결과는_14와같다() {
+        // given
+        sut = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
+        sut.operands.enqueue(2)
+        sut.operands.enqueue(3)
+        sut.operands.enqueue(3)
+        sut.operands.enqueue(1)
+        sut.operators.enqueue(.add)
+        sut.operators.enqueue(.multiply)
+        sut.operators.enqueue(.subtract)
+        
+        // when
+        let result = sut.result()
+        
+        // then
+        XCTAssertEqual(result, 14)
+    }
+
+}

--- a/Calculator/FormulaTests/FormulaTests.swift
+++ b/Calculator/FormulaTests/FormulaTests.swift
@@ -19,9 +19,9 @@ final class FormulaTests: XCTestCase {
         sut = nil
     }
 
-    func test_피연산자2331_연산자AddMultiplySubtract가_큐에존재할때_모두를연산한결과는_14와같다() {
+    func test_피연산자들과_연산자들이_주어지고_result호출시_결과값은_14와같다() {
         // given
-        sut = Formula(operands: CalculatorItemQueue<Double>(), operators: CalculatorItemQueue<Operator>())
+        sut = Formula()
         sut.operands.enqueue(2)
         sut.operands.enqueue(3)
         sut.operands.enqueue(3)
@@ -31,10 +31,31 @@ final class FormulaTests: XCTestCase {
         sut.operators.enqueue(.subtract)
         
         // when
-        let result = sut.result()
+        let result = try! sut.result()
         
         // then
         XCTAssertEqual(result, 14)
+    }
+    
+    func test_피연산자에_0과_연산자에_나누기가_주어지고_result를호출했을때의_에러는_dividingZero와같다() {
+        // given
+        sut = Formula()
+        sut.operands.enqueue(3)
+        sut.operands.enqueue(0)
+        sut.operators.enqueue(.divide)
+        
+        // when
+        let result = Result {
+            try sut.result()
+        }
+        
+        // then
+        switch result {
+        case .success(_):
+            break
+        case .failure(let error):
+            XCTAssertEqual(error as? OperateError, OperateError.dividingZero)
+        }
     }
 
 }


### PR DESCRIPTION
@Tediousday93 
안녕하세요 로웬! STEP2 제출합니다.

## 고민했던점
- 확장을 통한 `split`메서드 구현
   - `components`와 `split` 중에 고민을 했었습니다.  `components`같은 경우는 `[String]`을 반환하고 `split`은 `[Self.SubSquence]`를 반환하여  `map`고차함수를 사용하여 매핑을 할까 고민을 했지만 `components`를 사용하기로 하였습니다.
  
- `ExpressionParser`의 `componentsByOperators` 구현
   - 우선 `components` 메서드 경우 구분 기호 문자열이 인접하여 발생하면 빈 문자열이 생성되고, 문자열이 구분기호로 시작하거나 끝나면 각각 첫 번째 또는 마지막 하위 문자열이 빈문자열로 생성되기에 이를 반환할 때 `filter`를 사용하여 걸러주었습니다.
> split만 했을 경우
```swift
let a = " 1 + 2 * 3 - 1 "

extension String {
    func split(with target: Character) -> [String] {
        return components(separatedBy: String(target))
    }
}

let b = a.split(with: " ")
print(b)

// Prints :  ["", "1", "+", "2", "*", "3", "-", "1", ""]
```

> filter까지 했을 경우
```swift
let a = " 1 + 2 * 3 - 1 "

extension String {
    func split(with target: Character) -> [String] {
        return components(separatedBy: String(target))
    }
}

let b = a.split(with: " ").filter { $0 != "" }
print(b)

// Prints : ["1", "+", "2", "*", "3", "-", "1"]
```
   - 이 후, 문자열이 띄워쓰기 없이 매개변수로 전달될 경우를 생각하여 전달받은 문자열을  `for문`을 통하여 글자 하나씩 살펴 공백이 아닌 경우 공백을 추가하여 새로운 문자열을 만들어 이를 이용하여 반환을 하도록 구현하였습니다.
 > 띄워쓰기 없이 문자열을 전달했을 경우
```swift
let a = "1+2*3-1"

extension String {
    func split(with target: Character) -> [String] {
        return components(separatedBy: String(target))
    }
}

func componentsByOperators(from input: String) -> [String] {
    var input2 = ""
    for char in input {
        if char != " " {
            input2 += String(char) + " "
        }
    }
    return input2.split(with: " ").filter{ $0 != "" }
}

var c = componentsByOperators(from: a)
print(c)

// Prints : ["1", "+", "2", "*", "3", "-", "1"]
```

- `componentsByOperators`를 통해 전달받은 배열을 어떻게 나누어 각각에 큐에 넣어줄까
   - 이는 `forEach`를 이용하여 각각에 요소에 접근하면 그 요소를 `Double`로 바뀌는지 아니면 `Operator`로 바뀌는 지 확인하여 각각에 맞는 타입의 큐로 넣어주었습니다.

- `Formula`의 `result`메서드 구현
   - 처음에는 `reduce`를 이용하여 누적된 값으로 연산하는 방식으로 구현을 하려고 했으나, 이를 이용하기 위해 `reversed`메서드를 사용해 먼저 큐를 뒤집어야 해서 이는 더블 스택의 본질을 흐린다 판단하여 누적값을 담는 변수를 선언하여 이를 토대로 연산자와 매칭하여 연산을 하도록 구현하였습니다. 

---

## 조언을 얻고싶은 점
- MVC로 파일들을 분리하였는데, 이번 프로젝트와 같이 String 확장 같은 경우는 어떻게 관리를 해야하는 지에 대한 조언을 얻고 싶습니다.
- `ExpressionParser` 같은 경우 `enum` 타입으로 구현하라 UML에 명시되어 있는데 `case`로 나누지 않는데 구조체를 사용해도 될 걸 굳이 왜 열거형으로 정의를 하라고 했을까에 대한 의문을 가졌지만 이에 대한 해결이 되지 않아 조언을 얻고 싶습니다.