### PR TITLE
계산기 II [STEP1] 우에무, 찰스

### DIFF
--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -11,7 +11,7 @@ struct Formula {
     
     mutating func result() throws -> Double {
         guard var accumulatingValue = operands.dequeue() else {
-            throw OperateError.emptyQueueError
+            throw OperateError.emptyQueue
         }
         
         while let `operator` = operators.dequeue(), let rhs = operands.dequeue() {

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -10,10 +10,8 @@ struct Formula {
     var operators = CalculatorItemQueue<Operator>()
     
     mutating func result() throws -> Double {
-        var accumulatingValue: Double = .zero
-        
-        if let initialValue = operands.dequeue() {
-            accumulatingValue = initialValue
+        guard var accumulatingValue = operands.dequeue() else {
+            throw OperateError.emptyQueueError
         }
         
         while let `operator` = operators.dequeue(), let rhs = operands.dequeue() {

--- a/Calculator/Calculator/Models/Formula.swift
+++ b/Calculator/Calculator/Models/Formula.swift
@@ -16,7 +16,7 @@ struct Formula {
             accumulatingValue = initialValue
         }
         
-        while !operators.isEmpty, let `operator` = operators.dequeue(), let rhs = operands.dequeue() {
+        while let `operator` = operators.dequeue(), let rhs = operands.dequeue() {
             accumulatingValue = try `operator`.calculate(lhs: accumulatingValue, rhs: rhs)
         }
         

--- a/Calculator/Calculator/Models/OperateError.swift
+++ b/Calculator/Calculator/Models/OperateError.swift
@@ -7,5 +7,5 @@
 
 enum OperateError: Error {
     case dividingZero
-    case emptyQueueError
+    case emptyQueue
 }

--- a/Calculator/Calculator/Models/OperateError.swift
+++ b/Calculator/Calculator/Models/OperateError.swift
@@ -7,4 +7,5 @@
 
 enum OperateError: Error {
     case dividingZero
+    case emptyQueueError
 }


### PR DESCRIPTION
@juun97 

안녕하세요! 릴라!
스텝1 PR 보냅니다.

## 고민했던 점

> Linked List vs Double Stack
- 링크드 리스트 기반의 구현
   - 연결 리스트는 꼬리 노드의 이전 참조와 다음 참조를 새로운 노드에게 업데이트합니다. 시간복잡도는 O(1)입니다.
   - Dequeue 구현
      - 리스트가 비어있지 않고 큐의 첫 번째 요소가 존재하는지 확인합니다. 존재하지 않을 경우 nil을 반환하고 그렇지 않으면 큐의 앞에 있는 요소를 제거한 후 반환합니다.
      - 리스트의 앞 쪽에서 제거하는 것은 배열 구현과 비교하면 요소를 하나씩 이동할 필요가 없기에 시간복잡도는 O(1)입니다.
   - Enqueue 구현
      - 연결 리스트는 꼬리 노드의 이전 참조와 다음 참조를 새로운 노드에 업데이트합니다. 시간복잡도는 O(1)입니다.
   - 장점
      - 큐 배열의 주요 문제 중 하나는 항목을 큐에서 제거하는데 선형적인 시간이 걸린다는 것입니다. 이를 링크드 리스트로 구현을하면 이를 O(1)로 줄일 수 있습니다.
   - 단점
      - O(1) 성능에도 불구하고 오버헤드가 높습니다.
         - 여기서 오버헤드란 프로그램의 실행흐름에서 나타나는 현상중 하나로 예를 들어 , 프로그램의 실행흐름 도중에 동떨어진 위치의 코드를 실행시켜야 할 때 , 추가적으로 시간, 메모리자원이 사용되는 현상입니다.

- 더블스택으로 구현
   - 두 개의 스택을 사용하는 방식인데 요소를 큐에 넣을 때마다 오른쪽 스택에 넣고 요소를 대기열에서 해제해야 할 때는 오른쪽 스택을 뒤집어 왼쪽 스택에 할당하여 FIFO 순서인 것처럼 검색하는 방법입니다.
   - 배열과 같이 isEmpty와 peek의 시간복잡도는 O(1)입니다.
   - Enqueue 구현
      - 배열에 추가하여 스택에 push하기만 하면 되므로 시간복잡도는 O(1)입니다.
   - Dequeue 구현(4단계로 구현)
      1. 왼쪽 스택이 비었는지 확인
      2. 비었다면 오른쪽 스택을 뒤집어서 왼쪽 스택에 할당
      3. 오른쪽 스택의 모든 요소 제거
      4. 왼쪽 스택의 마지막 요소를 꺼내어 반환
      - 시간복잡도는 O(1)
   - 장점
      - 두 개의 스택을 활용하기 때문에 dequeue()의 시간복잡도를 배열 기반과는 다르게 O(1)연산이 가능합니다.
    
> 참고 서적
[스위프트 자료구조와 알고리즘](https://www.kodeco.com/books/data-structures-algorithms-in-swift)

> `Formula`의 `result`메서드
- 저는 처음에 비어있는 큐에 접근했을 때에 대해서는 아무런 처리가 되어있지 않은 상태였습니다. 하지만 우에무 코드에서는 처음 비어있는 큐에 접근했을 때 오류처리를 하도록 되어있어 안정성이 더 높다 판단되어 오류 처리를 해주었습니다.

> `String` 확장의 `split`메서드
- 저 같은 경우는 `components`메서드를 사용하였고 우에무는 `split`메서드를 사용하였습니다.
   - 우선 `components`메서드는 `[String]`을 반환을 하고 `split`메서드는 `[Self.SubSequence]`를 반환하기 때문에 따로 매핑을 해줘야 하기에 전자를 선택하였습니다.

> `componentsByOperator` 메서드에서의 `reduce`와 `forEach`
- 이 두 개의 고차함수 둘 다 각 요소에 접근을 한다는 점은 동일하여 어느 코드가 더 낫다라는 판단이 서지 않아서 기존대로 두었습니다.

